### PR TITLE
feat(core): add streamable-http transport mode (SAF-28480)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ SAFEBREACH_MCP_BASE_URL="/api/mcp" uv run start_all_servers.py
 # Combined configuration with external access and custom base URL
 SAFEBREACH_MCP_AUTH_TOKEN="your-token" SAFEBREACH_MCP_BASE_URL="/api/mcp" uv run start_all_servers.py --external
 
+# Streamable HTTP transport (default is SSE)
+SAFEBREACH_MCP_TRANSPORT=streamable-http uv run start_all_servers.py
+
+# Streamable HTTP with custom base URL (endpoint becomes /api/mcp instead of /mcp)
+SAFEBREACH_MCP_TRANSPORT=streamable-http SAFEBREACH_MCP_BASE_URL="/api/mcp" uv run start_all_servers.py
+
 # Single-tenant deployment (SafeBreach internal use)
 export DATA_URL="http://localhost:3400"
 export CONFIG_URL="http://localhost:3401" 
@@ -381,6 +387,10 @@ export SAFEBREACH_MCP_BIND_HOST=0.0.0.0
 
 # Per-agent concurrency limit (default: 2)
 export SAFEBREACH_MCP_CONCURRENCY_LIMIT=3
+
+# Transport mode (default: sse)
+export SAFEBREACH_MCP_TRANSPORT=sse            # Server-Sent Events (default) — endpoints: /sse + /messages/
+export SAFEBREACH_MCP_TRANSPORT=streamable-http # Streamable HTTP — single endpoint: /mcp (or $SAFEBREACH_MCP_BASE_URL)
 ```
 
 **Command-Line Arguments:**

--- a/prds/SAF-28480/prd.md
+++ b/prds/SAF-28480/prd.md
@@ -1,0 +1,91 @@
+# SAF-28480: Add HTTP Streamable Transport Mode
+
+## Overview
+
+- **Task Type**: Enhancement
+- **Purpose**: Allow the SafeBreach MCP servers to run in `streamable-http` transport mode in addition to the existing SSE transport
+- **Target Consumer**: Any MCP client that prefers the streamable-http protocol (e.g., newer versions of Claude Desktop, mcp-remote, programmatic clients)
+- **Originating Request**: SAF-28480 — requested to support clients that use HTTP Streamable MCP transport
+
+## Problem
+
+All five SafeBreach MCP servers (config, data, utilities, playbook, studio) use SSE transport exclusively via `FastMCP.sse_app()`. This requires clients to maintain a long-lived SSE connection (`/sse`) for receiving events, plus separate HTTP POST requests to `/messages/?session_id=...` for sending.
+
+The MCP SDK (v1.12.1) provides a second transport, `streamable-http`, which uses a single `/mcp` HTTP endpoint for both sending and receiving. This is simpler for clients that prefer standard request/response semantics with optional streaming.
+
+There was no way to configure the transport without code changes.
+
+## Solution
+
+Read the transport from a new environment variable `SAFEBREACH_MCP_TRANSPORT` in `run_server()` and select the appropriate FastMCP app:
+
+| Value | FastMCP method | Endpoint |
+|---|---|---|
+| `sse` (default) | `FastMCP.sse_app()` | `/sse` + `/messages/` |
+| `streamable-http` | `FastMCP.streamable_http_app()` | `/mcp` (or `$BASE_URL`) |
+
+### Changes to `safebreach_mcp_core/safebreach_base.py`
+
+**1. `run_server()` — resolve transport and select app:**
+
+```python
+transport = os.environ.get('SAFEBREACH_MCP_TRANSPORT', 'sse').strip().lower()
+if transport not in ('sse', 'streamable-http'):
+    logger.warning(f"Unknown SAFEBREACH_MCP_TRANSPORT value '{transport}', falling back to 'sse'")
+    transport = 'sse'
+
+if transport == 'streamable-http':
+    endpoint_path = self.base_url if self.base_url != '/' else '/mcp'
+    self.mcp.settings.streamable_http_path = endpoint_path
+    mcp_app = self.mcp.streamable_http_app()
+    app = mcp_app
+    ...
+else:
+    # existing SSE code — unchanged
+```
+
+`self.mcp.settings.streamable_http_path` is mutated before calling `streamable_http_app()` so that `SAFEBREACH_MCP_BASE_URL` is honoured: when `base_url=/api/mcp`, the streamable-http endpoint becomes `/api/mcp` (not `/api/mcp/mcp`).
+
+**2. `_create_concurrency_limited_app()` — add streamable-http session tracking:**
+
+The method signature gains `transport` and `endpoint_path` parameters. A new branch handles streamable-http sessions, which are identified by the `Mcp-Session-Id` request header (versus SSE sessions which use the `session_id` query-string parameter):
+
+```python
+if transport == 'streamable-http' and path == endpoint_path:
+    session_id = headers.get(b"mcp-session-id", b"").decode(...)
+    if not session_id:
+        return await original_app(scope, receive, send)  # initialize — pass through
+    # lazy semaphore creation + rate limiting (identical logic to SSE branch)
+```
+
+The existing SSE paths (`/sse` and `/messages/`) are **unchanged**.
+
+## New Environment Variable
+
+| Variable | Values | Default |
+|---|---|---|
+| `SAFEBREACH_MCP_TRANSPORT` | `sse`, `streamable-http` | `sse` |
+
+## Backward Compatibility
+
+- Default value is `sse` — all existing deployments are unaffected
+- Unknown values log a warning and fall back to `sse`
+- No changes to `start_all_servers.py` or any individual server file
+
+## Testing
+
+```bash
+# Verify SSE mode still works (regression)
+uv run start_all_servers.py
+
+# Verify streamable-http mode
+SAFEBREACH_MCP_TRANSPORT=streamable-http uv run start_all_servers.py
+# Endpoint: http://127.0.0.1:8001/mcp
+
+# Verify with custom base URL
+SAFEBREACH_MCP_TRANSPORT=streamable-http SAFEBREACH_MCP_BASE_URL=/api/mcp uv run start_all_servers.py
+# Endpoint: http://127.0.0.1:8001/api/mcp
+
+# Run unit tests
+uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m "not e2e"
+```

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -125,37 +125,56 @@ class SafeBreachMCPBase:
     async def run_server(self, port: int = 8000, host: str = "127.0.0.1", allow_external: bool = False) -> None:
         """
         Run the MCP server.
-        
+
         Args:
             port: Port number to run the server on
             host: Host to bind to (default: 127.0.0.1)
             allow_external: Whether to allow external connections (default: False)
+
+        Transport is selected via the SAFEBREACH_MCP_TRANSPORT environment variable:
+            "sse" (default) — SSE transport, endpoints /sse and /messages/
+            "streamable-http"  — Streamable HTTP transport, single /mcp endpoint
         """
         import uvicorn
         apply_patch()  # Apply MCP initialization patch
-        
+
+        # Resolve transport from env var
+        transport = os.environ.get('SAFEBREACH_MCP_TRANSPORT', 'sse').strip().lower()
+        if transport not in ('sse', 'streamable-http'):
+            logger.warning(f"Unknown SAFEBREACH_MCP_TRANSPORT value '{transport}', falling back to 'sse'")
+            transport = 'sse'
+
         # Determine bind address based on configuration
         bind_host = self._determine_bind_host(host, allow_external)
-        
-        # Get the Starlette app from FastMCP
-        mcp_app = self.mcp.sse_app()
-        
-        # Create the main app and mount the MCP app at the base URL
-        if self.base_url != '/':
-            from starlette.applications import Starlette
-            from starlette.responses import JSONResponse
-            from starlette.routing import Mount
-            
-            app = Starlette()
-            app.mount(self.base_url, mcp_app)
-            
-            logger.info(f"🔗 MCP server mounted at base URL: {self.base_url}")
-            logger.info(f"📡 SSE endpoint will be available at: {self.base_url}/sse")
-        else:
+
+        if transport == 'streamable-http':
+            # For streamable-http, set the endpoint path to base_url (or /mcp when root)
+            # so the single /mcp endpoint respects SAFEBREACH_MCP_BASE_URL cleanly.
+            endpoint_path = self.base_url if self.base_url != '/' else '/mcp'
+            self.mcp.settings.streamable_http_path = endpoint_path
+            mcp_app = self.mcp.streamable_http_app()
             app = mcp_app
-            logger.info("🔗 MCP server running at root URL: /")
-            logger.info("📡 SSE endpoint available at: /sse")
-        
+            logger.info("🔗 MCP server running with streamable-http transport")
+            logger.info(f"📡 Streamable HTTP endpoint available at: {endpoint_path}")
+        else:
+            # SSE transport — existing logic unchanged
+            mcp_app = self.mcp.sse_app()
+            if self.base_url != '/':
+                from starlette.applications import Starlette
+                from starlette.responses import JSONResponse
+                from starlette.routing import Mount
+
+                app = Starlette()
+                app.mount(self.base_url, mcp_app)
+
+                logger.info(f"🔗 MCP server mounted at base URL: {self.base_url}")
+                logger.info(f"📡 SSE endpoint will be available at: {self.base_url}/sse")
+            else:
+                app = mcp_app
+                logger.info("🔗 MCP server running at root URL: /")
+                logger.info("📡 SSE endpoint available at: /sse")
+            endpoint_path = '/sse'
+
         # Wrap with authentication for external connections
         if allow_external:
             logger.info("Adding ASGI authentication wrapper for external connections")
@@ -165,7 +184,7 @@ class SafeBreachMCPBase:
             logger.info("🏠 Local-only server - no authentication wrapper applied")
 
         # Wrap with concurrency limiter (applies to all servers)
-        app = self._create_concurrency_limited_app(app)
+        app = self._create_concurrency_limited_app(app, transport=transport, endpoint_path=endpoint_path)
         logger.info(f"🔒 Concurrency limiter enabled: max {_concurrency_limit} concurrent requests per session")
 
         # Start background tasks
@@ -482,8 +501,8 @@ class SafeBreachMCPBase:
         logger.warning("🔒 HTTP Authorization required for external connections")
         logger.warning("🔑 Set SAFEBREACH_MCP_AUTH_TOKEN environment variable for authentication")
 
-    def _create_concurrency_limited_app(self, original_app):
-        """Create an ASGI wrapper that limits concurrent requests per SSE session."""
+    def _create_concurrency_limited_app(self, original_app, transport: str = "sse", endpoint_path: str = "/sse"):
+        """Create an ASGI wrapper that limits concurrent requests per MCP session."""
 
         async def concurrency_limited_app(scope, receive, send):
             if scope["type"] != "http":
@@ -603,6 +622,48 @@ class SafeBreachMCPBase:
                 # No session tracking — pass through
                 logger.debug(f"⏩ No session_id found — pass through (path={path})")
                 return await original_app(scope, receive, send)
+
+            # Streamable HTTP — single endpoint, session identified by Mcp-Session-Id header
+            if transport == 'streamable-http' and path == endpoint_path:
+                headers_dict = dict(scope.get("headers", []))
+                session_id = headers_dict.get(b"mcp-session-id", b"").decode("utf-8", errors="replace")
+
+                if not session_id:
+                    # Initialize request — no session yet, pass through
+                    return await original_app(scope, receive, send)
+
+                # Lazy semaphore creation per session
+                if session_id not in _session_semaphores:
+                    _session_semaphores[session_id] = (asyncio.Semaphore(_concurrency_limit), time.time())
+                    logger.info(
+                        f"🆔 New streamable-http session: {session_id[:8]}... "
+                        f"(limit={_concurrency_limit}, active_sessions={len(_session_semaphores)})"
+                    )
+
+                sem, _ = _session_semaphores[session_id]
+                if sem.locked():
+                    logger.warning(
+                        f"⚠️ Rate limited session {session_id[:8]}... (limit={_concurrency_limit})"
+                    )
+                    response_body = json.dumps({
+                        "error": "Too Many Requests",
+                        "message": f"Concurrency limit of {_concurrency_limit} exceeded. Please retry.",
+                        "retry_after": 5
+                    }).encode()
+                    await send({
+                        "type": "http.response.start",
+                        "status": 429,
+                        "headers": [
+                            [b"content-type", b"application/json"],
+                            [b"content-length", str(len(response_body)).encode()],
+                            [b"retry-after", b"5"],
+                        ],
+                    })
+                    await send({"type": "http.response.body", "body": response_body})
+                    return
+
+                async with sem:
+                    return await original_app(scope, receive, send)
 
             # All other paths — pass through without limiting
             return await original_app(scope, receive, send)


### PR DESCRIPTION
Introduce SAFEBREACH_MCP_TRANSPORT env var (values: "sse" | "streamable-http",
default: "sse") to allow all MCP servers to run in HTTP Streamable mode.

- run_server() resolves transport from env var and selects FastMCP.sse_app() or FastMCP.streamable_http_app() accordingly
- For streamable-http, mutates mcp.settings.streamable_http_path to respect SAFEBREACH_MCP_BASE_URL cleanly (endpoint at base_url, not base_url/mcp)
- _create_concurrency_limited_app() gains transport/endpoint_path params and a new streamable-http branch that identifies sessions via Mcp-Session-Id header instead of SSE query-string session_id
- All existing SSE code paths are unchanged; default behaviour is preserved