### PR TITLE
SAF-29642: Add attacker/target platform filtering to playbook attacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,13 +361,16 @@ All filters work in combination and include pagination support. The response inc
   Supports comma-separated multi-value with OR logic (e.g., "LINUX,WINDOWS").
   Case-insensitive partial match (e.g., "win" matches "WINDOWS").
 - **Target Platform**: Filter by target OS via `target_platform_filter`. Same syntax as attacker filter.
-- **Valid Platform Values**: AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS
-- **Always-On Fields**: `attacker_platform` and `target_platform` are always present in results (None when unavailable).
-- **None Pass-Through**: Attacks without platform data are **included** when platform filters are active.
-  This avoids hiding attacks that lack OS constraints (~67.7% of attacks).
+- **Valid Platform Values**: ANY, AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS
+- **Always-On Fields**: `attacker_platform` and `target_platform` are always present in results.
+  Values are a specific OS (e.g., "WINDOWS"), "ANY" (runs on any platform), or None (no node data).
+- **Strict Filtering**: By default, platform filters only return attacks that explicitly match the
+  specified platform. "ANY" and None platform attacks are excluded.
+- **Including ANY**: Add `ANY` to the filter to also include platform-agnostic attacks
+  (e.g., `target_platform_filter="WINDOWS,ANY"` returns WINDOWS + any-platform attacks).
 - **Platform Source**: Extracted from `content.nodes.{node}.constraints.os` with role mapping via
   `isSource` (attacker) and `isDestination` (target) flags.
-- **Coverage**: ~32.3% of playbook attacks have OS constraints (93.8% of host attacks, 3.7% of network attacks).
+- **Coverage**: ~32.3% of playbook attacks have specific OS constraints; the remainder are "ANY".
 
 ## Drift Analysis
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ All filters work in combination and include pagination support. The response inc
   Supports comma-separated multi-value with OR logic (e.g., "LINUX,WINDOWS").
   Case-insensitive partial match (e.g., "win" matches "WINDOWS").
 - **Target Platform**: Filter by target OS via `target_platform_filter`. Same syntax as attacker filter.
-- **Valid Platform Values**: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+- **Valid Platform Values**: AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS
 - **Always-On Fields**: `attacker_platform` and `target_platform` are always present in results (None when unavailable).
 - **None Pass-Through**: Attacks without platform data are **included** when platform filters are active.
   This avoids hiding attacks that lack OS constraints (~67.7% of attacks).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,9 +291,13 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 
 **Playbook Server (Port 8003):**
 15. `get_playbook_attacks` ✨ **Enhanced** - Filtered and paginated playbook attacks with comprehensive filtering
-  (name, description, ID range, date ranges, MITRE ATT&CK techniques/tactics) and pagination.
+  (name, description, ID range, date ranges, MITRE ATT&CK techniques/tactics, attacker/target platform) and pagination.
   Supports `include_mitre_techniques`, `mitre_technique_filter` (comma-separated, OR logic),
-  and `mitre_tactic_filter` (comma-separated, OR logic)
+  `mitre_tactic_filter` (comma-separated, OR logic),
+  `attacker_platform_filter` (comma-separated, OR logic, case-insensitive partial match),
+  and `target_platform_filter` (comma-separated, OR logic, case-insensitive partial match).
+  Each attack always includes `attacker_platform` and `target_platform` fields.
+  Attacks without platform data are included when platform filters are active (None pass-through)
 16. `get_playbook_attack_details` ✨ **Enhanced** - Detailed attack information with verbosity options
   (fix suggestions, tags, parameters, MITRE ATT&CK data with URLs) for specific attack techniques
 
@@ -351,6 +355,19 @@ All filters work in combination and include pagination support. The response inc
   techniques, and sub-techniques with ATT&CK URLs in responses.
   Auto-enabled when MITRE filters are active.
 - **Coverage**: ~42.6% of playbook attacks have MITRE technique/tactic mappings.
+
+**Platform Filtering (`get_playbook_attacks`):**
+- **Attacker Platform**: Filter by attacker OS via `attacker_platform_filter` (e.g., "LINUX" or "WINDOWS").
+  Supports comma-separated multi-value with OR logic (e.g., "LINUX,WINDOWS").
+  Case-insensitive partial match (e.g., "win" matches "WINDOWS").
+- **Target Platform**: Filter by target OS via `target_platform_filter`. Same syntax as attacker filter.
+- **Valid Platform Values**: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+- **Always-On Fields**: `attacker_platform` and `target_platform` are always present in results (None when unavailable).
+- **None Pass-Through**: Attacks without platform data are **included** when platform filters are active.
+  This avoids hiding attacks that lack OS constraints (~67.7% of attacks).
+- **Platform Source**: Extracted from `content.nodes.{node}.constraints.os` with role mapping via
+  `isSource` (attacker) and `isDestination` (target) flags.
+- **Coverage**: ~32.3% of playbook attacks have OS constraints (93.8% of host attacks, 3.7% of network attacks).
 
 ## Drift Analysis
 

--- a/prds/SAF-29642-add-playbook-filtering-options/context.md
+++ b/prds/SAF-29642-add-playbook-filtering-options/context.md
@@ -1,0 +1,106 @@
+# Ticket Context: SAF-29642
+
+## Status
+Phase 4: Investigation Complete
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: [safebreach-mcp] Allow filtering the playbook attacks by the attacker platform and target platform attributes of the attacks
+- **Description**: Currently the playbook MCP tool for fetching attacks supports filtering by various options like name filter, description filter, id ranges, published date etc. We want to add the ability to filter the attacks by two additional attributes: attacker platform, target platform. The optional values for attacker platform and target platform should be automatically researched from the live console pentest01.
+- **Acceptance Criteria**: None defined yet
+- **Status**: To Do
+
+## Task Scope
+Full ticket preparation - investigate the playbook server codebase to understand current filtering, the attack data model (attacker/target platform fields), and how to add new platform-based filtering options.
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+
+## Investigation Findings
+
+### Playbook Server Architecture
+- **playbook_types.py**: Data transformations, filtering logic, pagination
+- **playbook_functions.py**: Business logic, cache management, API calls
+- **playbook_server.py**: MCP tool definitions and response formatting
+
+### Current Filtering Capabilities
+The `get_playbook_attacks` tool supports:
+- `name_filter` — case-insensitive partial match on attack name
+- `description_filter` — case-insensitive partial match on description
+- `id_min` / `id_max` — integer ID range (inclusive)
+- `modified_date_start` / `modified_date_end` — ISO date range
+- `published_date_start` / `published_date_end` — ISO date range
+- `mitre_technique_filter` — comma-separated technique IDs/names (OR logic)
+- `mitre_tactic_filter` — comma-separated tactic names/IDs (OR logic)
+
+### Data Flow
+1. `_get_all_attacks_from_cache_or_api()` fetches from `/api/kb/vLatest/moves?details=true`
+2. `transform_reduced_playbook_attack()` extracts: name, id, description, modifiedDate, publishedDate (+ MITRE if requested)
+3. `filter_attacks_by_criteria()` applies all active filters
+4. `paginate_attacks()` handles 10-per-page pagination
+
+### MITRE Filtering (Reference Pattern)
+Recently added via SAF-28305. Pattern:
+- Fields extracted from `tags` array in raw API data via `_extract_mitre_data()`
+- Filter uses comma-separated OR logic with `_attack_matches_mitre_technique()` helper
+- Auto-enables MITRE data extraction when MITRE filters are active
+- Applied filters tracked in response metadata
+
+### Critical Unknown: Platform Field Names
+The raw API response from `/api/kb/vLatest/moves?details=true` has NOT been documented in the codebase for platform-related fields. Test mocks don't include platform data. The ticket explicitly requires discovering the field names and valid values from the live pentest01 console.
+
+Likely field locations (to be confirmed):
+- Top-level: `attack['attackerPlatform']`, `attack['targetPlatform']`
+- Content nested: `attack['content']['attackerPlatform']`
+- Tags-based: similar to MITRE data in the `tags` array
+
+### Test Infrastructure
+- **test_playbook_functions.py**: Unit tests with mock data, organized by feature (TestGetPlaybookAttacks, TestMitreGetPlaybookAttacks)
+- **test_playbook_types.py**: Transform function tests
+- **test_integration.py**: Cross-component integration tests
+- **test_e2e.py**: E2E tests against real consoles (requires environment setup)
+- Pattern: each filter has dedicated test verifying results + `applied_filters` tracking
+
+### Files to Modify
+1. `safebreach_mcp_playbook/playbook_types.py` — add platform extraction + filter logic
+2. `safebreach_mcp_playbook/playbook_functions.py` — add parameters, validation, filter pass-through
+3. `safebreach_mcp_playbook/playbook_server.py` — add tool parameters + response rendering
+4. `safebreach_mcp_playbook/tests/test_playbook_functions.py` — add filter tests
+5. `safebreach_mcp_playbook/tests/test_playbook_types.py` — add transform tests
+6. `safebreach_mcp_playbook/tests/test_integration.py` — add integration tests
+7. `safebreach_mcp_playbook/tests/test_e2e.py` — add E2E platform filter tests
+
+## Problem Analysis
+
+### Problem Scope
+Add `attacker_platform` and `target_platform` filtering to `get_playbook_attacks` MCP tool.
+
+### Platform Data Location
+- Field: `content.nodes.{node_name}.constraints.os`
+- No top-level platform field — must be derived from node structure
+- Node-to-role mapping uses `isSource` (attacker) / `isDestination` (target) flags
+- Valid OS values: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+
+### Node Patterns
+| Pattern | Count | Attacker | Target |
+|---------|-------|----------|--------|
+| gold (host) | 2985 | N/A | gold |
+| green/red (network) | 6446 | isSource=True | isDestination=True |
+| attacker/target | 21 | attacker | target |
+| target only | 138 | N/A | target |
+| local only | 43 | N/A | local |
+
+### Coverage
+- Overall: 32.3% (3,125 / 9,683)
+- Host (gold): 93.8% (2,801 / 2,985)
+- Network (green/red): 3.7% (237 / 6,446)
+
+### Risks
+- Low OS coverage on network attacks
+- Green/Red roles not fixed — must use isSource/isDestination
+- Case variations in node names (Green/Red vs green/red)
+
+## Proposed Improvements
+See summary.md for complete proposed ticket content.

--- a/prds/SAF-29642-add-playbook-filtering-options/context.md
+++ b/prds/SAF-29642-add-playbook-filtering-options/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29642
 
 ## Status
-Phase 4: Investigation Complete
+Phase 6: PRD Created
 
 ## Mode
 Improving
@@ -48,13 +48,22 @@ Recently added via SAF-28305. Pattern:
 - Auto-enables MITRE data extraction when MITRE filters are active
 - Applied filters tracked in response metadata
 
-### Critical Unknown: Platform Field Names
-The raw API response from `/api/kb/vLatest/moves?details=true` has NOT been documented in the codebase for platform-related fields. Test mocks don't include platform data. The ticket explicitly requires discovering the field names and valid values from the live pentest01 console.
+### RESOLVED: Platform Field Names (from pentest01 live API)
+- **Field location**: `content.nodes.{node_name}.constraints.os`
+- **No top-level platform field** — must be derived from node structure
+- **Role mapping**: `isSource=True` = attacker, `isDestination=True` = target
+- **Valid OS values**: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+- **Node patterns**: gold (2985), green/red (6446), attacker/target (21), target-only (138), local-only (43)
+- **OS coverage**: 32.3% overall (93.8% host, 3.7% network)
 
-Likely field locations (to be confirmed):
-- Top-level: `attack['attackerPlatform']`, `attack['targetPlatform']`
-- Content nested: `attack['content']['attackerPlatform']`
-- Tags-based: similar to MITRE data in the `tags` array
+### Implementation Pattern (from MITRE filtering reference)
+The existing MITRE filtering provides the exact pattern to follow:
+1. **Extract**: `_extract_platform_data(nodes)` → `{'attacker_platform': str|None, 'target_platform': str|None}`
+2. **Transform**: Conditionally include in `transform_reduced_playbook_attack()` (always include, unlike MITRE)
+3. **Filter**: Comma-separated OR logic via `_attack_matches_attacker_platform()` helper
+4. **Auto-enable**: Not needed — platform data always extracted (simple string, not heavy like MITRE)
+5. **Track**: Add to `applied_filters` metadata
+6. **Render**: Add `**Attacker Platform:**` / `**Target Platform:**` lines in response
 
 ### Test Infrastructure
 - **test_playbook_functions.py**: Unit tests with mock data, organized by feature (TestGetPlaybookAttacks, TestMitreGetPlaybookAttacks)
@@ -101,6 +110,26 @@ Add `attacker_platform` and `target_platform` filtering to `get_playbook_attacks
 - Low OS coverage on network attacks
 - Green/Red roles not fixed — must use isSource/isDestination
 - Case variations in node names (Green/Red vs green/red)
+
+## Brainstorming Results
+
+### Chosen Approach: Platform as First-Class Fields (Always Extracted)
+- Always extract `attacker_platform` and `target_platform` in reduced transform — no conditional flag
+- `_extract_platform_data(content)` traverses `content.nodes`, maps roles via `isSource`/`isDestination`
+- Returns `{'attacker_platform': str|None, 'target_platform': str|None}`
+
+### Design Decisions
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Extraction | Always | Lightweight (2 strings), no include_platform flag needed |
+| Matching | Case-insensitive partial match | Consistent with name_filter and MITRE filters |
+| None handling | `None` for N/A | Clean, explicit "not applicable" for single-node attacks |
+| No OS data + filter | Include in results | Avoids hiding 67.7% of attacks; documented in tool description |
+| Response rendering | Always show | Platform data always visible in output |
+
+### Alternatives Considered
+- **Approach B (Conditional extraction)**: Add include_platform flag like MITRE. Rejected — unnecessary
+  complexity for lightweight string data.
 
 ## Proposed Improvements
 See summary.md for complete proposed ticket content.

--- a/prds/SAF-29642-add-playbook-filtering-options/prd.md
+++ b/prds/SAF-29642-add-playbook-filtering-options/prd.md
@@ -1,0 +1,685 @@
+# Platform Filtering for Playbook Attacks — SAF-29642
+
+## 1. Overview
+
+- **Title**: Attacker/Target Platform Filtering for `get_playbook_attacks`
+- **Task Type**: Feature
+- **Purpose**: Enable filtering playbook attacks by the OS/platform of attacker and target nodes,
+  allowing users to narrow results for environment-specific security assessments
+  (e.g., "show me all attacks targeting Windows")
+- **Target Consumer**: Internal — AI agents and MCP tool users querying the SafeBreach playbook
+- **Key Benefits**:
+  - Platform-specific attack discovery for targeted security assessments
+  - Consistent filtering experience alongside existing name, MITRE, and date filters
+  - Always-visible platform metadata for every attack in results
+- **Business Alignment**: Improves MCP tool usability and attack discoverability for SafeBreach users
+- **Originating Request**: [SAF-29642](https://safebreach.atlassian.net/browse/SAF-29642)
+
+---
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-03-31 14:10 |
+| **Owner** | AI Agent |
+| **Current Phase** | N/A |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution: Platform as First-Class Fields (Always Extracted)
+
+Always extract `attacker_platform` and `target_platform` from the raw API response during the
+transform step. Platform data is lightweight (two optional strings per attack), so no conditional
+`include_platform` flag is needed — unlike MITRE data which is complex and optionally included.
+
+Platform data is derived from `content.nodes.{node_name}.constraints.os` in the SafeBreach API
+response. Node-to-role mapping uses `isSource` (attacker) and `isDestination` (target) boolean flags.
+
+Filtering uses comma-separated values with OR logic and case-insensitive partial matching,
+consistent with existing `name_filter` and `mitre_technique_filter` patterns.
+
+**Key design decision**: When a platform filter is active, attacks with `None` platform values
+(no OS data) are **included** in results rather than excluded. This avoids hiding 67.7% of attacks
+that lack OS constraints. This behavior must be documented in the tool description.
+
+### Alternatives Considered
+
+**Approach B — Conditional Extraction (MITRE-like)**: Add `include_platform: bool = False` flag
+with auto-enable logic when filters are active. Rejected because platform data is just two optional
+strings — the overhead of conditional extraction adds complexity without meaningful performance gain.
+
+### Decision Rationale
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Extraction | Always | Lightweight (2 strings), no include_platform flag needed |
+| Matching | Case-insensitive partial match | Consistent with name_filter and MITRE filters |
+| None handling | `None` for N/A | Clean, explicit "not applicable" for single-node attacks |
+| No OS data + filter | Include in results | Avoids hiding 67.7% of attacks; documented in tool description |
+| Response rendering | Always show | Platform data always visible in output |
+
+---
+
+## 3. Core Feature Components
+
+### Component A: Platform Data Extraction (`playbook_types.py`)
+
+**Purpose**: New function to extract attacker/target platform from the raw attack node structure.
+
+**Key Features**:
+- Traverse `content.nodes` to find all nodes and their roles
+- Map each node to attacker (isSource=True) or target (isDestination=True) role
+- Extract `constraints.os` from the mapped nodes
+- Handle all 5 node patterns: gold, green/red, attacker/target, target-only, local-only
+- Case-insensitive node name matching (handles `Green`/`Red` vs `green`/`red`)
+- For single-node patterns (gold, local, target-only): target_platform = node OS, attacker_platform = None
+
+### Component B: Platform Filtering (`playbook_types.py`)
+
+**Purpose**: Add platform filter parameters to the existing `filter_attacks_by_criteria()` function.
+
+**Key Features**:
+- Two new parameters: `attacker_platform_filter` and `target_platform_filter`
+- Comma-separated values with OR logic (e.g., "WINDOWS,LINUX" matches either)
+- Case-insensitive partial matching (e.g., "win" matches "WINDOWS")
+- Attacks with `None` platform values pass through the filter (not excluded)
+- Helper functions `_attack_matches_attacker_platform()` and `_attack_matches_target_platform()`
+
+### Component C: Parameter Pass-Through (`playbook_functions.py`)
+
+**Purpose**: Wire new filter parameters through the business logic layer.
+
+**Key Features**:
+- Add `attacker_platform_filter` and `target_platform_filter` to `sb_get_playbook_attacks()` signature
+- Pass parameters to `filter_attacks_by_criteria()`
+- Track in `applied_filters` response metadata
+
+### Component D: MCP Tool Interface (`playbook_server.py`)
+
+**Purpose**: Expose platform filters as MCP tool parameters with proper documentation.
+
+**Key Features**:
+- Add parameters to `get_playbook_attacks` tool signature
+- Update tool description to document platform filter behavior, including None pass-through
+- Render `**Attacker Platform:**` and `**Target Platform:**` in response output for each attack
+
+---
+
+## 4. API Endpoints and Integration
+
+### Existing API Consumed
+
+- **API Name**: SafeBreach Playbook Moves API
+- **URL**: `GET {base_url}/api/kb/vLatest/moves?details=true`
+- **Headers**: `x-apitoken`, `Content-Type: application/json`
+- **Relevant Response Fields** (per attack in `data` array):
+  - `content.nodes` — dict of node objects keyed by node name
+  - `content.nodes.{name}.isSource` — boolean, True = attacker role
+  - `content.nodes.{name}.isDestination` — boolean, True = target role
+  - `content.nodes.{name}.constraints.os` — string OS value (optional)
+- **Valid OS Values**: `AWS`, `AZURE`, `GCP`, `LINUX`, `MAC`, `WEBAPPLICATION`, `WINDOWS`
+
+### Node Pattern Reference
+
+| Pattern | Node Names | Attacker Node | Target Node | Count |
+|---------|-----------|---------------|-------------|-------|
+| Host | `gold` | N/A | `gold` | 2,985 |
+| Network | `green`, `red` | `isSource=True` | `isDestination=True` | 6,446 |
+| Explicit | `attacker`, `target` | `attacker` | `target` | 21 |
+| Target-only | `target` | N/A | `target` | 138 |
+| Local-only | `local` | N/A | `local` | 43 |
+| Case variant | `Green`, `Red` | `isSource=True` | `isDestination=True` | 2 |
+
+---
+
+## 6. Non-Functional Requirements
+
+### Technical Constraints
+
+- **Backward Compatibility**: No breaking changes. New fields (`attacker_platform`, `target_platform`)
+  are added to the reduced format. Existing responses gain two new fields set to None when unavailable.
+- **Performance**: Platform extraction is O(n) where n = number of nodes per attack (typically 1-2).
+  No additional API calls required — data comes from the same `/moves?details=true` response.
+- **Caching**: No cache changes needed. Platform data is extracted from already-cached raw attack data.
+
+---
+
+## 7. Definition of Done
+
+- [ ] `_extract_platform_data()` correctly extracts platform from all 5 node patterns
+- [ ] `attacker_platform` and `target_platform` always present in reduced attack format
+- [ ] `attacker_platform_filter` and `target_platform_filter` parameters accepted by `get_playbook_attacks`
+- [ ] Comma-separated OR logic with case-insensitive partial matching works correctly
+- [ ] Attacks with None platform pass through filters (not excluded)
+- [ ] Applied filters tracked in response metadata
+- [ ] Platform values rendered in MCP tool response output
+- [ ] Node name matching is case-insensitive (handles Green/Red vs green/red)
+- [ ] Unit tests for platform extraction from all 5 node patterns
+- [ ] Unit tests for platform filtering (single value, comma-separated, combined with other filters)
+- [ ] Unit tests for None pass-through behavior
+- [ ] Integration tests for platform filtering across multi-attack datasets
+- [ ] E2E tests for platform filtering against live console
+- [ ] Tool description documents None pass-through behavior
+- [ ] CLAUDE.md updated with new filter documentation
+- [ ] All existing tests continue to pass
+
+---
+
+## 8. Testing Strategy
+
+### Unit Testing (`test_playbook_types.py`) — Phase 5
+
+- **Scope**: `_extract_platform_data()` function and platform filter helpers
+- **Key Scenarios**:
+  - Extract from gold node (single node, target only)
+  - Extract from green/red nodes (dual node, role-mapped via isSource/isDestination)
+  - Extract from attacker/target nodes (explicit names)
+  - Extract from target-only and local-only patterns
+  - Handle missing `content.nodes` gracefully (return None/None)
+  - Handle missing `constraints.os` (return None for that role)
+  - Case-insensitive node name handling (Green vs green)
+  - Filter by single platform value
+  - Filter by comma-separated values (OR logic)
+  - Filter partial match (e.g., "win" matches "WINDOWS")
+  - Filter with None platform values passes through
+  - Combined platform filter with other filters
+- **Framework**: pytest
+- **Coverage Target**: Maintain existing coverage level
+
+### Unit Testing (`test_playbook_functions.py`) — Phase 6
+
+- **Scope**: `sb_get_playbook_attacks()` with platform parameters
+- **Key Scenarios**:
+  - Platform fields always present in response (without filter)
+  - `attacker_platform_filter` filters correctly
+  - `target_platform_filter` filters correctly
+  - Combined platform + name/MITRE filters
+  - Applied filters metadata includes platform filters
+  - Attacks with None platform included when filter active
+- **Class**: New `TestPlatformGetPlaybookAttacks` class following `TestMitreGetPlaybookAttacks` pattern
+
+### Integration Testing (`test_integration.py`) — Phase 7
+
+- **Scope**: End-to-end flow from function call through transform, filter, and pagination
+- **Key Scenarios**:
+  - Platform filtering across dataset with mixed node patterns
+  - Platform + MITRE + name combined filtering
+  - Pagination with platform filters applied
+
+### E2E Testing (`test_e2e.py`) — Phase 7 (Zero Mocks)
+
+All E2E tests run against the live console with **zero mocks**. They call `sb_get_playbook_attacks()`
+and `sb_get_playbook_attack_details()` which hit the real SafeBreach API.
+
+- **Scope**: Full real API calls against live console for every filtering option
+- **Test Cases**:
+
+  **Platform fields presence**:
+  - `test_platform_fields_real_api`: Verify `attacker_platform` and `target_platform` keys exist
+    in every attack returned by the real API (values can be None or a valid OS string)
+
+  **Single platform filter — attacker**:
+  - `test_attacker_platform_filter_windows`: Filter `attacker_platform_filter="WINDOWS"`,
+    verify all returned attacks with non-None attacker_platform contain "WINDOWS"
+  - `test_attacker_platform_filter_linux`: Filter `attacker_platform_filter="LINUX"`,
+    verify matches
+
+  **Single platform filter — target**:
+  - `test_target_platform_filter_windows`: Filter `target_platform_filter="WINDOWS"`,
+    verify all returned attacks with non-None target_platform contain "WINDOWS"
+  - `test_target_platform_filter_linux`: Same for LINUX
+
+  **Multi-value comma-separated filter (OR logic)**:
+  - `test_target_platform_filter_multi_value`: Filter `target_platform_filter="WINDOWS,LINUX"`,
+    verify returned attacks match either WINDOWS or LINUX (or have None platform)
+  - Verify total_attacks >= individual filter counts (OR expands results)
+
+  **Partial match**:
+  - `test_platform_filter_partial_match`: Filter `target_platform_filter="win"`,
+    verify matches WINDOWS attacks
+
+  **Case insensitivity**:
+  - `test_platform_filter_case_insensitive`: Filter `target_platform_filter="windows"` (lowercase),
+    verify matches WINDOWS attacks
+
+  **None pass-through verification**:
+  - `test_platform_filter_none_pass_through`: Filter by a platform, verify result includes attacks
+    where the filtered platform field is None. Compare total with filter vs count of matching +
+    count of None to confirm None attacks are preserved.
+
+  **Combined filters**:
+  - `test_platform_plus_name_filter`: Combine `target_platform_filter="WINDOWS"` with
+    `name_filter="registry"`, verify results satisfy both conditions
+  - `test_platform_plus_mitre_filter`: Combine `target_platform_filter="WINDOWS"` with
+    `mitre_tactic_filter="Discovery"`, verify results satisfy both conditions
+
+  **Applied filters metadata**:
+  - `test_platform_filter_metadata_real_api`: Verify `applied_filters` dict contains
+    `attacker_platform_filter` and/or `target_platform_filter` when set
+
+  **No matches**:
+  - `test_platform_filter_no_match`: Filter by a nonexistent platform value
+    (e.g., "NONEXISTENT_OS"), verify total_attacks equals the count of attacks with None platform
+    (since None passes through, but no real matches exist)
+
+  **Pagination with platform filter**:
+  - `test_platform_filter_pagination`: Apply platform filter, verify pagination metadata is correct
+    (total_pages, page_number) and page 0 and page 1 have disjoint attack IDs
+
+---
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Platform extraction | Pending | - | - | |
+| Phase 2: Platform filtering | Pending | - | - | |
+| Phase 3: Business logic wiring | Pending | - | - | |
+| Phase 4: MCP tool interface | Pending | - | - | |
+| Phase 5: Unit tests (types) | Pending | - | - | |
+| Phase 6: Unit tests (functions) | Pending | - | - | |
+| Phase 7: Integration + E2E tests | Pending | - | - | |
+| Phase 8: Documentation | Pending | - | - | |
+
+### Phase 1: Platform Data Extraction
+
+**Semantic Change**: Add platform extraction function to `playbook_types.py`
+
+**Deliverables**: `_extract_platform_data()` function that derives attacker/target platform
+from the raw attack data's `content.nodes` structure.
+
+**Implementation Details**:
+
+1. Create `_extract_platform_data(content_data: Dict) -> Dict[str, Optional[str]]` function:
+   - Accept the `content` dict from the raw attack data
+   - Initialize result as `{'attacker_platform': None, 'target_platform': None}`
+   - Get `nodes` dict from content_data, return defaults if missing or not a dict
+   - Iterate over all node entries (case-insensitive key handling)
+   - For each node that is a dict:
+     - Check `isSource` flag — if True, extract `constraints.os` as `attacker_platform`
+     - Check `isDestination` flag — if True, extract `constraints.os` as `target_platform`
+   - **Special case for single-node patterns** (gold, local, target-only):
+     When only one node exists and neither `isSource` nor `isDestination` is True,
+     assign the node's OS to `target_platform` (single-node attacks are target-centric)
+   - Return the result dict
+
+2. Update `transform_reduced_playbook_attack()`:
+   - After the existing mapping loop, call `_extract_platform_data(attack_data.get('content', {}))`
+   - Merge the returned dict into `result` using `result.update(platform_data)`
+   - This runs unconditionally (no boolean flag)
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/playbook_types.py` | Add `_extract_platform_data()` function |
+| `safebreach_mcp_playbook/playbook_types.py` | Update `transform_reduced_playbook_attack()` to call it |
+
+**Git Commit**: `feat(playbook): extract attacker/target platform from attack nodes (SAF-29642)`
+
+---
+
+### Phase 2: Platform Filtering Logic
+
+**Semantic Change**: Add platform filter parameters and helpers to `filter_attacks_by_criteria()`
+
+**Deliverables**: Platform filtering with comma-separated OR logic, case-insensitive partial match,
+and None pass-through behavior.
+
+**Implementation Details**:
+
+1. Add two new parameters to `filter_attacks_by_criteria()`:
+   - `attacker_platform_filter: Optional[str] = None`
+   - `target_platform_filter: Optional[str] = None`
+
+2. Create `_attack_matches_platform(platform_value: Optional[str], filter_values: List[str]) -> bool`:
+   - If `platform_value` is None, return True (None pass-through — attacks without OS data are included)
+   - For each filter value, check if it appears as a substring in `platform_value.lower()`
+   - Return True if any filter value matches (OR logic)
+   - Return False if no matches
+
+3. Add filtering blocks at the end of `filter_attacks_by_criteria()`, after the MITRE filter blocks:
+   - If `attacker_platform_filter` is set:
+     Parse comma-separated values: `[v.strip().lower() for v in filter.split(',') if v.strip()]`
+     Filter using list comprehension with `_attack_matches_platform(attack.get('attacker_platform'), values)`
+   - Same pattern for `target_platform_filter` using `attack.get('target_platform')`
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/playbook_types.py` | Add `_attack_matches_platform()` helper |
+| `safebreach_mcp_playbook/playbook_types.py` | Add parameters and filter blocks to `filter_attacks_by_criteria()` |
+
+**Git Commit**: `feat(playbook): add platform filtering logic with None pass-through (SAF-29642)`
+
+---
+
+### Phase 3: Business Logic Wiring
+
+**Semantic Change**: Wire platform filter parameters through `sb_get_playbook_attacks()`
+
+**Deliverables**: Platform filters passed from business logic to types layer, tracked in metadata.
+
+**Implementation Details**:
+
+1. Add parameters to `sb_get_playbook_attacks()` function signature:
+   - `attacker_platform_filter: Optional[str] = None`
+   - `target_platform_filter: Optional[str] = None`
+   - Place after `mitre_tactic_filter` to maintain parameter grouping
+
+2. Pass new parameters to `filter_attacks_by_criteria()` call (around line 165-177):
+   - Add `attacker_platform_filter=attacker_platform_filter`
+   - Add `target_platform_filter=target_platform_filter`
+
+3. Add to applied_filters tracking (around line 183-203):
+   - `if attacker_platform_filter: applied_filters['attacker_platform_filter'] = attacker_platform_filter`
+   - `if target_platform_filter: applied_filters['target_platform_filter'] = target_platform_filter`
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/playbook_functions.py` | Add parameters, pass-through, applied_filters tracking |
+
+**Git Commit**: `feat(playbook): wire platform filters through business logic (SAF-29642)`
+
+---
+
+### Phase 4: MCP Tool Interface
+
+**Semantic Change**: Expose platform filters as MCP tool parameters with response rendering
+
+**Deliverables**: Platform filter parameters in tool definition, updated description,
+platform rendering in response.
+
+**Implementation Details**:
+
+1. Update tool description string to include new parameters:
+   - Add to the description: `attacker_platform_filter` and `target_platform_filter`
+     with documentation that they use comma-separated OR logic, case-insensitive partial match
+   - Document that attacks without platform data are included in results when filters are active
+
+2. Add parameters to `get_playbook_attacks()` MCP handler:
+   - `attacker_platform_filter: Optional[str] = None`
+   - `target_platform_filter: Optional[str] = None`
+
+3. Pass parameters to `sb_get_playbook_attacks()` call
+
+4. Add platform rendering in the response loop (after MITRE rendering, before `response_parts.append("")`):
+   - Get `attacker_platform` and `target_platform` from the attack dict
+   - If `attacker_platform` is not None, append `**Attacker Platform:** {value}`
+   - If `target_platform` is not None, append `**Target Platform:** {value}`
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/playbook_server.py` | Add parameters, update description, add response rendering |
+
+**Git Commit**: `feat(playbook): expose platform filters in MCP tool interface (SAF-29642)`
+
+---
+
+### Phase 5: Unit Tests — Types Layer
+
+**Semantic Change**: Add unit tests for platform extraction and filtering in `playbook_types.py`
+
+**Deliverables**: Comprehensive test coverage for `_extract_platform_data()`,
+`_attack_matches_platform()`, and platform-aware `filter_attacks_by_criteria()`.
+
+**Implementation Details**:
+
+1. Add test fixtures with platform data:
+   - `sample_attack_gold_with_os`: Single gold node with `constraints.os = "WINDOWS"`
+   - `sample_attack_green_red_with_os`: Green/red nodes with different OS values
+   - `sample_attack_attacker_target`: Explicit attacker/target node names
+   - `sample_attack_target_only`: Single target node
+   - `sample_attack_no_os`: Node without constraints.os
+   - `sample_attack_case_variant`: Green/Red with capital case node names
+   - `sample_attacks_with_platform_list`: Mixed list of attacks with various platform patterns
+     (already transformed with `attacker_platform`/`target_platform` fields for filter testing)
+
+2. Add `TestExtractPlatformData` class:
+   - Test gold node extraction (target only, attacker=None)
+   - Test green/red node extraction with isSource/isDestination mapping
+   - Test attacker/target explicit node names
+   - Test target-only and local-only patterns
+   - Test missing content.nodes (returns None/None)
+   - Test missing constraints.os (returns None for that role)
+   - Test case-insensitive node names (Green vs green)
+
+3. Add `TestAttackMatchesPlatform` class:
+   - Test None platform value returns True (pass-through)
+   - Test exact match (case-insensitive)
+   - Test partial match ("win" matches "WINDOWS")
+   - Test no match returns False
+   - Test multiple filter values (OR logic)
+
+4. Add `TestPlatformFiltering` class:
+   - Test `filter_attacks_by_criteria()` with `attacker_platform_filter`
+   - Test with `target_platform_filter`
+   - Test comma-separated values
+   - Test combined with name_filter
+   - Test None pass-through (attacks without platform included)
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/tests/test_playbook_types.py` | Add fixtures and 3 test classes |
+
+**Git Commit**: `test(playbook): add unit tests for platform extraction and filtering (SAF-29642)`
+
+---
+
+### Phase 6: Unit Tests — Functions Layer
+
+**Semantic Change**: Add unit tests for platform parameters in `sb_get_playbook_attacks()`
+
+**Deliverables**: Tests verifying platform filter pass-through, applied_filters metadata,
+and always-present platform fields.
+
+**Implementation Details**:
+
+1. Add `sample_attack_data_with_platform` fixture:
+   - Two attacks with different platform configurations from raw API format
+   - First attack: gold node with `constraints.os = "WINDOWS"` (host attack)
+   - Second attack: green/red nodes, green has `constraints.os = "LINUX"` (network attack)
+
+2. Add `TestPlatformGetPlaybookAttacks` class (following `TestMitreGetPlaybookAttacks` pattern):
+   - `test_platform_fields_always_present`: Verify `attacker_platform` and `target_platform`
+     in response without any filter
+   - `test_attacker_platform_filter`: Filter by attacker platform, verify correct results
+   - `test_target_platform_filter`: Filter by target platform, verify correct results
+   - `test_platform_filter_combined_with_name`: Platform + name filter combination
+   - `test_platform_filter_applied_filters_metadata`: Verify filters appear in `applied_filters`
+   - `test_platform_filter_none_pass_through`: Attacks without OS data included in results
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/tests/test_playbook_functions.py` | Add fixture and test class |
+
+**Git Commit**: `test(playbook): add unit tests for platform filter business logic (SAF-29642)`
+
+---
+
+### Phase 7: Integration + E2E Tests
+
+**Semantic Change**: Add integration tests and comprehensive E2E tests (zero mocks) for platform filtering
+
+**Deliverables**: Cross-component integration tests with mocked data and comprehensive E2E tests
+against the live SafeBreach API with zero mocks.
+
+**Implementation Details**:
+
+#### Integration Tests (`test_integration.py`)
+
+1. Update `comprehensive_attack_dataset` fixture:
+   - Add `content.nodes` with platform data to existing attacks
+   - Attack 1027: gold node with `constraints.os = "WINDOWS"` (host attack)
+   - Attack 2048: green/red nodes, green `isSource=True` with `constraints.os = "LINUX"`,
+     red `isDestination=True` with `constraints.os = "WINDOWS"` (network attack)
+   - Attack 3141: no OS constraints in nodes (tests None pass-through)
+   - Attack 4096: gold node with `constraints.os = "MAC"` (another host attack)
+
+2. Add integration test methods:
+   - `test_platform_filtering_integration`: Filter by `target_platform_filter="WINDOWS"`,
+     verify attacks 1027 and 2048 match (both have WINDOWS target) plus 3141 (None pass-through)
+   - `test_platform_combined_filtering`: Combine `target_platform_filter="WINDOWS"` with
+     `name_filter="DNS"`, verify only attack 1027 matches
+   - `test_platform_pagination`: Apply filter resulting in >10 matches, verify pagination metadata
+
+#### E2E Tests (`test_e2e.py`) — Zero Mocks
+
+All E2E tests call the real SafeBreach API. No mocking of any kind.
+
+3. Add E2E test class `TestPlatformE2E`:
+
+   **a. Platform fields presence** (`test_platform_fields_real_api`):
+   - Call `sb_get_playbook_attacks(console=E2E_CONSOLE)` with no filters
+   - Verify every attack in result has `attacker_platform` and `target_platform` keys
+   - Verify values are either None or a string from the valid OS set
+
+   **b. Single target platform filter** (`test_target_platform_filter_windows`):
+   - Call with `target_platform_filter="WINDOWS"`
+   - Verify `total_attacks > 0`
+   - For each attack in page: if `target_platform` is not None, assert "WINDOWS" in value
+   - Verify `applied_filters['target_platform_filter'] == 'WINDOWS'`
+
+   **c. Single attacker platform filter** (`test_attacker_platform_filter_linux`):
+   - Call with `attacker_platform_filter="LINUX"`
+   - Verify returned attacks: those with non-None attacker_platform contain "LINUX"
+
+   **d. Multi-value OR filter** (`test_platform_filter_multi_value`):
+   - Call with `target_platform_filter="WINDOWS,LINUX"`
+   - Verify returned attacks: non-None target_platform matches either "WINDOWS" or "LINUX"
+   - Call individually with "WINDOWS" and "LINUX", verify combined total >= max(individual totals)
+
+   **e. Partial match** (`test_platform_filter_partial_match`):
+   - Call with `target_platform_filter="win"`
+   - Verify matches — all non-None target_platform values contain "win" (case-insensitive)
+   - Total should equal the WINDOWS filter result total
+
+   **f. Case insensitivity** (`test_platform_filter_case_insensitive`):
+   - Call with `target_platform_filter="windows"` (lowercase)
+   - Call with `target_platform_filter="WINDOWS"` (uppercase)
+   - Verify both return identical `total_attacks`
+
+   **g. None pass-through** (`test_platform_filter_none_pass_through`):
+   - Call with `target_platform_filter="WINDOWS"`
+   - Scan multiple pages to find at least one attack where `target_platform` is None
+   - This confirms None attacks are not excluded by the filter
+
+   **h. Combined platform + name** (`test_platform_plus_name_filter`):
+   - Call with `target_platform_filter="WINDOWS"` and `name_filter="registry"`
+   - Verify all returned attacks: name contains "registry" (case-insensitive) AND
+     (target_platform contains "WINDOWS" OR target_platform is None)
+   - Verify total_attacks <= WINDOWS-only total AND <= registry-only total
+
+   **i. Combined platform + MITRE** (`test_platform_plus_mitre_filter`):
+   - Call with `target_platform_filter="WINDOWS"` and `mitre_tactic_filter="Discovery"`
+   - Verify all returned attacks: have Discovery tactic AND
+     (target_platform contains "WINDOWS" OR target_platform is None)
+
+   **j. Applied filters metadata** (`test_platform_filter_metadata`):
+   - Call with both `attacker_platform_filter="LINUX"` and `target_platform_filter="WINDOWS"`
+   - Verify `applied_filters` contains both keys with correct values
+
+   **k. No real matches** (`test_platform_filter_nonexistent`):
+   - Call with `target_platform_filter="NONEXISTENT_OS"`
+   - Verify total_attacks > 0 (None pass-through means attacks without OS data still appear)
+   - Verify no attack in results has a non-None target_platform
+
+   **l. Pagination with filter** (`test_platform_filter_pagination`):
+   - Call with `target_platform_filter="WINDOWS"`, page_number=0
+   - If total_pages > 1, call page_number=1
+   - Verify pages have disjoint attack IDs
+   - Verify consistent total_attacks across pages
+
+   **m. Platform in attack details** (`test_platform_in_attack_details`):
+   - Get a WINDOWS attack ID from filtered list
+   - Call `sb_get_playbook_attack_details()` for that attack
+   - Verify the detail response is valid (basic fields present)
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_playbook/tests/test_integration.py` | Update fixture, add 3 integration test methods |
+| `safebreach_mcp_playbook/tests/test_e2e.py` | Add `TestPlatformE2E` class with 13 E2E test methods |
+
+**Git Commit**: `test(playbook): add integration and comprehensive E2E tests for platform filtering (SAF-29642)`
+
+---
+
+### Phase 8: Documentation
+
+**Semantic Change**: Update CLAUDE.md with platform filter documentation
+
+**Deliverables**: Updated tool documentation reflecting new filtering capabilities.
+
+**Implementation Details**:
+
+1. Update CLAUDE.md sections:
+   - In "MCP Tools Available > Playbook Server" section: Add `attacker_platform_filter` and
+     `target_platform_filter` to the `get_playbook_attacks` tool description
+   - In "Filtering and Search Capabilities" section: Add a new subsection documenting
+     platform filtering behavior, valid OS values, and None pass-through
+   - Note that attacks without platform data are included when filters are active
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | Update playbook tool docs and filtering section |
+
+**Git Commit**: `docs: document platform filtering for playbook attacks (SAF-29642)`
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Low OS coverage on network attacks (3.7%) | Medium — platform filter less useful for network attacks | Document coverage limitation; None pass-through ensures no attacks hidden |
+| New node patterns in future API versions | Low — extraction handles unknown patterns gracefully | Default to None/None for unrecognized patterns |
+| Performance with always-on extraction | Low — extraction is O(1-2) per attack | Platform data is two strings, negligible overhead |
+
+### Assumptions
+
+- The SafeBreach API's `content.nodes` structure is stable and the `isSource`/`isDestination` role
+  mapping convention will be maintained
+- The 7 discovered OS values (AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS) represent the
+  complete set; partial matching handles future additions gracefully
+- Single-node attacks should map their node OS to `target_platform` (since host attacks are
+  target-centric by nature)
+
+---
+
+## 12. Executive Summary
+
+- **Issue**: The `get_playbook_attacks` MCP tool lacked platform-based filtering, preventing users
+  from narrowing attacks by OS/platform
+- **What Was Built**: Two new filter parameters (`attacker_platform_filter`, `target_platform_filter`)
+  with always-on platform extraction from attack node data
+- **Key Technical Decisions**: Always extract (no conditional flag); None pass-through to avoid
+  hiding attacks without OS data; case-insensitive partial matching consistent with existing filters
+- **Business Value**: Enables environment-specific attack discovery, critical for targeted security
+  assessments on specific platforms
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-03-31 14:10 | PRD created — initial draft |

--- a/prds/SAF-29642-add-playbook-filtering-options/summary.md
+++ b/prds/SAF-29642-add-playbook-filtering-options/summary.md
@@ -1,0 +1,140 @@
+# Ticket Summary: SAF-29642
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: safebreach-mcp
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] Allow filtering the playbook attacks by the attacker platform and target platform attributes of the attacks
+**Issues Identified**: No acceptance criteria defined, no technical details about field locations or valid values
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp (Playbook Server)
+- Platform data lives at `content.nodes.{node_name}.constraints.os` in raw API responses
+- No top-level platform field exists — must be **derived** from node structure
+- Node-to-role mapping: `isSource=True` = attacker, `isDestination=True` = target
+- 7 valid OS values discovered from pentest01: `AWS`, `AZURE`, `GCP`, `LINUX`, `MAC`, `WEBAPPLICATION`, `WINDOWS`
+- Overall OS coverage: 32.3% (3,125 / 9,683 attacks)
+- Host attacks have 93.8% OS coverage; network attacks only 3.7%
+- MITRE filtering (recently added) provides the closest implementation pattern
+- Relevant files:
+  - `safebreach_mcp_playbook/playbook_types.py` — data transforms, filtering logic
+  - `safebreach_mcp_playbook/playbook_functions.py` — business logic, parameters
+  - `safebreach_mcp_playbook/playbook_server.py` — MCP tool definitions
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The `get_playbook_attacks` MCP tool supports filtering by name, description, ID range, dates, and MITRE ATT&CK data, but lacks platform-based filtering. Users need to filter attacks by the OS/platform of the attacker and target nodes to narrow results (e.g., "show me all attacks targeting Windows" or "find attacks requiring a Linux attacker").
+
+Platform data is embedded in the attack's `content.nodes` structure, with varying node naming conventions (gold, green/red, attacker/target). The role mapping (attacker vs target) is determined by `isSource`/`isDestination` boolean flags, not by node names.
+
+### Impact Assessment
+- **User value**: Enables platform-specific attack discovery, critical for environment-specific security assessments
+- **Implementation scope**: 3 source files + 4 test files, following established MITRE filtering pattern
+
+### Risks & Edge Cases
+- Network attacks have very low OS coverage (~3.7%) — platform filtering will primarily match host attacks
+- Green/Red node roles are not fixed — must use `isSource`/`isDestination` flags
+- Some attacks have OS on only one node (attacker OR target, not both)
+- 2 attacks use case-variant node names (`Green`/`Red` vs `green`/`red`) — extraction must be case-insensitive
+- Single-node attacks (gold, local, target-only) have no attacker platform
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Add attacker_platform and target_platform filtering to get_playbook_attacks
+
+### Description
+
+**Background**
+The `get_playbook_attacks` playbook MCP tool needs two new filtering parameters — `attacker_platform_filter` and `target_platform_filter` — to allow users to narrow playbook attacks by the OS/platform of the attacker and target nodes.
+
+**Technical Context**
+* Platform data lives at `content.nodes.{node_name}.constraints.os` in the SafeBreach API response
+* Node-to-role mapping uses `isSource` (attacker) and `isDestination` (target) boolean flags
+* 5 node patterns exist: `gold` (host), `green`/`red` (network), `attacker`/`target`, `target`-only, `local`-only
+* 7 valid OS values: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+* OS coverage: 32.3% overall (93.8% for host attacks, 3.7% for network attacks)
+* pentest01 console has 9,683 total attacks
+
+**Problem Description**
+* Currently no way to filter playbook attacks by platform/OS constraints
+* Platform data extraction requires traversing `content.nodes` structure and mapping nodes to attacker/target roles
+* Implementation should follow the established MITRE filtering pattern (comma-separated, OR logic, case-insensitive)
+
+**Affected Areas**
+* `safebreach_mcp_playbook/`: playbook_types.py, playbook_functions.py, playbook_server.py
+* `safebreach_mcp_playbook/tests/`: test_playbook_functions.py, test_playbook_types.py, test_integration.py, test_e2e.py
+
+### Acceptance Criteria
+
+- [ ] `get_playbook_attacks` accepts `attacker_platform_filter` parameter (comma-separated, OR logic, case-insensitive)
+- [ ] `get_playbook_attacks` accepts `target_platform_filter` parameter (comma-separated, OR logic, case-insensitive)
+- [ ] Platform data extracted from `content.nodes.{node}.constraints.os` with correct role mapping via `isSource`/`isDestination`
+- [ ] Reduced attack format includes `attacker_platform` and `target_platform` fields (always present, None when not available)
+- [ ] Platform filters work in combination with all existing filters
+- [ ] Applied filters tracked in response metadata
+- [ ] Platform values rendered in MCP tool response output
+- [ ] Node name matching is case-insensitive (handles `Green`/`Red` vs `green`/`red`)
+- [ ] Unit tests for platform extraction from all 5 node patterns
+- [ ] Unit tests for platform filtering (single value, comma-separated, combined filters)
+- [ ] Integration tests for platform filtering across multi-attack datasets
+- [ ] E2E tests for platform filtering against live console
+- [ ] CLAUDE.md updated with new filter documentation
+
+### Suggested Labels/Components
+- Component: playbook-server
+- Labels: enhancement, filtering
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+The `get_playbook_attacks` playbook MCP tool needs two new filtering parameters — `attacker_platform_filter` and `target_platform_filter` — to allow users to narrow playbook attacks by the OS/platform of the attacker and target nodes.
+
+### Technical Context
+* Platform data lives at `content.nodes.{node_name}.constraints.os` in the SafeBreach API response
+* Node-to-role mapping uses `isSource` (attacker) and `isDestination` (target) boolean flags
+* 5 node patterns: `gold` (host), `green`/`red` (network), `attacker`/`target`, `target`-only, `local`-only
+* 7 valid OS values: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS
+* OS coverage: 32.3% overall (93.8% host, 3.7% network) from pentest01 (9,683 attacks)
+
+### Problem Description
+* No platform-based filtering exists for playbook attacks
+* Platform data extraction requires traversing `content.nodes` and mapping nodes to attacker/target roles via `isSource`/`isDestination` flags
+* Implementation follows established MITRE filtering pattern (comma-separated, OR logic, case-insensitive)
+
+### Affected Areas
+* `safebreach_mcp_playbook/`: playbook_types.py, playbook_functions.py, playbook_server.py + 4 test files
+```
+
+**Acceptance Criteria:**
+```markdown
+* `get_playbook_attacks` accepts `attacker_platform_filter` (comma-separated, OR logic, case-insensitive)
+* `get_playbook_attacks` accepts `target_platform_filter` (comma-separated, OR logic, case-insensitive)
+* Platform extracted from `content.nodes.{node}.constraints.os` with role mapping via `isSource`/`isDestination`
+* Reduced format includes `attacker_platform` and `target_platform` fields (always present, None when N/A)
+* Platform filters combine with all existing filters
+* Applied filters tracked in response metadata
+* Platform values rendered in MCP tool response
+* Node name matching case-insensitive
+* Unit tests for extraction from all 5 node patterns + filtering
+* Integration and E2E tests for platform filtering
+* CLAUDE.md updated
+```

--- a/safebreach_mcp_playbook/playbook_functions.py
+++ b/safebreach_mcp_playbook/playbook_functions.py
@@ -107,7 +107,9 @@ def sb_get_playbook_attacks(
     published_date_end: Optional[str] = None,
     include_mitre_techniques: bool = False,
     mitre_technique_filter: Optional[str] = None,
-    mitre_tactic_filter: Optional[str] = None
+    mitre_tactic_filter: Optional[str] = None,
+    attacker_platform_filter: Optional[str] = None,
+    target_platform_filter: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Get filtered and paginated playbook attacks.
@@ -126,6 +128,8 @@ def sb_get_playbook_attacks(
         include_mitre_techniques: Whether to include MITRE ATT&CK data
         mitre_technique_filter: Comma-separated technique IDs/names (OR, case-insensitive partial)
         mitre_tactic_filter: Comma-separated tactic names (OR, case-insensitive partial)
+        attacker_platform_filter: Comma-separated platform values (OR, case-insensitive partial). None passes through.
+        target_platform_filter: Comma-separated platform values (OR, case-insensitive partial). None passes through.
 
     Returns:
         Dict containing paginated attacks and metadata
@@ -173,7 +177,9 @@ def sb_get_playbook_attacks(
             published_date_start=published_date_start,
             published_date_end=published_date_end,
             mitre_technique_filter=mitre_technique_filter,
-            mitre_tactic_filter=mitre_tactic_filter
+            mitre_tactic_filter=mitre_tactic_filter,
+            attacker_platform_filter=attacker_platform_filter,
+            target_platform_filter=target_platform_filter
         )
 
         # Paginate results
@@ -201,6 +207,10 @@ def sb_get_playbook_attacks(
             applied_filters['mitre_technique_filter'] = mitre_technique_filter
         if mitre_tactic_filter:
             applied_filters['mitre_tactic_filter'] = mitre_tactic_filter
+        if attacker_platform_filter:
+            applied_filters['attacker_platform_filter'] = attacker_platform_filter
+        if target_platform_filter:
+            applied_filters['target_platform_filter'] = target_platform_filter
 
         paginated_result['applied_filters'] = applied_filters
 

--- a/safebreach_mcp_playbook/playbook_server.py
+++ b/safebreach_mcp_playbook/playbook_server.py
@@ -38,14 +38,19 @@ class SafeBreachPlaybookServer(SafeBreachMCPBase):
         @self.mcp.tool(
             name="get_playbook_attacks",
             description="""Returns a filtered and paginated list of SafeBreach playbook attacks.
-Supports filtering by name, description, ID range, date ranges, and MITRE ATT&CK techniques/tactics.
-Results are paginated with 10 items per page.
+Supports filtering by name, description, ID range, date ranges, MITRE ATT&CK techniques/tactics, and platform.
+Results are paginated with 10 items per page. Each attack includes attacker_platform and target_platform fields.
 Parameters: console (required), page_number (default 0), name_filter (partial match), description_filter (partial match),
 id_min (minimum ID), id_max (maximum ID), modified_date_start (ISO date), modified_date_end (ISO date),
 published_date_start (ISO date), published_date_end (ISO date),
 include_mitre_techniques (default False - include MITRE ATT&CK tactics/techniques/sub-techniques),
 mitre_technique_filter (comma-separated technique IDs or names, OR logic, case-insensitive partial match),
-mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, case-insensitive partial match)"""
+mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, case-insensitive partial match),
+attacker_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - OR logic, case-insensitive partial match.
+  Attacks without platform data are INCLUDED in results when this filter is active),
+target_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - OR logic, case-insensitive partial match.
+  Attacks without platform data are INCLUDED in results when this filter is active).
+Valid platform values: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS"""
         )
         def get_playbook_attacks(
             console: str = "default",
@@ -60,7 +65,9 @@ mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, 
             published_date_end: Optional[str] = None,
             include_mitre_techniques: bool = False,
             mitre_technique_filter: Optional[str] = None,
-            mitre_tactic_filter: Optional[str] = None
+            mitre_tactic_filter: Optional[str] = None,
+            attacker_platform_filter: Optional[str] = None,
+            target_platform_filter: Optional[str] = None
         ) -> str:
             """Get filtered and paginated playbook attacks."""
             try:
@@ -77,7 +84,9 @@ mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, 
                     published_date_end=published_date_end,
                     include_mitre_techniques=include_mitre_techniques,
                     mitre_technique_filter=mitre_technique_filter,
-                    mitre_tactic_filter=mitre_tactic_filter
+                    mitre_tactic_filter=mitre_tactic_filter,
+                    attacker_platform_filter=attacker_platform_filter,
+                    target_platform_filter=target_platform_filter
                 )
                 
                 if 'error' in result:
@@ -125,6 +134,14 @@ mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, 
                     if mitre_sub_techniques:
                         sub_names = ', '.join(t.get('display_name', t.get('id', '')) for t in mitre_sub_techniques)
                         response_parts.append(f"**MITRE Sub-Techniques:** {sub_names}")
+
+                    # Render platform data
+                    attacker_platform = attack.get('attacker_platform')
+                    target_platform = attack.get('target_platform')
+                    if attacker_platform:
+                        response_parts.append(f"**Attacker Platform:** {attacker_platform}")
+                    if target_platform:
+                        response_parts.append(f"**Target Platform:** {target_platform}")
 
                     response_parts.append("")
                 

--- a/safebreach_mcp_playbook/playbook_server.py
+++ b/safebreach_mcp_playbook/playbook_server.py
@@ -47,10 +47,12 @@ include_mitre_techniques (default False - include MITRE ATT&CK tactics/technique
 mitre_technique_filter (comma-separated technique IDs or names, OR logic, case-insensitive partial match),
 mitre_tactic_filter (comma-separated tactic names or IDs like TA0006, OR logic, case-insensitive partial match),
 attacker_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - OR logic, case-insensitive partial match.
-  Attacks without platform data are INCLUDED in results when this filter is active),
+  Strict: only attacks matching the specified platform(s) are returned.
+  Add ANY to also include platform-agnostic attacks, e.g. WINDOWS,ANY),
 target_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - OR logic, case-insensitive partial match.
-  Attacks without platform data are INCLUDED in results when this filter is active).
-Valid platform values: AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS"""
+  Strict: only attacks matching the specified platform(s) are returned.
+  Add ANY to also include platform-agnostic attacks, e.g. WINDOWS,ANY).
+Valid platform values: ANY, AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS"""
         )
         def get_playbook_attacks(
             console: str = "default",

--- a/safebreach_mcp_playbook/playbook_server.py
+++ b/safebreach_mcp_playbook/playbook_server.py
@@ -50,7 +50,7 @@ attacker_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - O
   Attacks without platform data are INCLUDED in results when this filter is active),
 target_platform_filter (comma-separated platform values e.g. WINDOWS,LINUX - OR logic, case-insensitive partial match.
   Attacks without platform data are INCLUDED in results when this filter is active).
-Valid platform values: AWS, AZURE, GCP, LINUX, MAC, WEBAPPLICATION, WINDOWS"""
+Valid platform values: AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS"""
         )
         def get_playbook_attacks(
             console: str = "default",

--- a/safebreach_mcp_playbook/playbook_types.py
+++ b/safebreach_mcp_playbook/playbook_types.py
@@ -187,6 +187,67 @@ def _extract_mitre_data(tags_data: Any) -> Dict[str, Any]:
     return result
 
 
+def _extract_platform_data(content_data: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """
+    Extract attacker and target platform from attack node structure.
+
+    Traverses content.nodes to find OS constraints, mapping nodes to roles
+    via isSource (attacker) and isDestination (target) flags.
+
+    For single-node attacks where neither isSource nor isDestination is set,
+    the node's OS is assigned to target_platform (host attacks are target-centric).
+
+    Args:
+        content_data: The 'content' dict from raw attack data
+
+    Returns:
+        Dict with 'attacker_platform' and 'target_platform' (each str or None)
+    """
+    result: Dict[str, Optional[str]] = {
+        'attacker_platform': None,
+        'target_platform': None
+    }
+
+    if not content_data or not isinstance(content_data, dict):
+        return result
+
+    nodes = content_data.get('nodes')
+    if not nodes or not isinstance(nodes, dict):
+        return result
+
+    has_role_flags = False
+
+    for node_data in nodes.values():
+        if not isinstance(node_data, dict):
+            continue
+
+        is_source = node_data.get('isSource', False)
+        is_destination = node_data.get('isDestination', False)
+        constraints = node_data.get('constraints', {})
+        os_value = constraints.get('os') if isinstance(constraints, dict) else None
+
+        if is_source:
+            has_role_flags = True
+            if os_value:
+                result['attacker_platform'] = os_value
+        if is_destination:
+            has_role_flags = True
+            if os_value:
+                result['target_platform'] = os_value
+
+    # Single-node fallback: if no isSource/isDestination flags found,
+    # assign the single node's OS to target_platform
+    if not has_role_flags and len(nodes) == 1:
+        single_node = next(iter(nodes.values()))
+        if isinstance(single_node, dict):
+            constraints = single_node.get('constraints', {})
+            os_value = constraints.get('os') if isinstance(constraints, dict) else None
+            if os_value:
+                result['target_platform'] = os_value
+
+    return result
+
+
 def get_reduced_playbook_attack_mapping() -> Dict[str, str]:
     """
     Get mapping for reduced playbook attack objects.
@@ -249,6 +310,10 @@ def transform_reduced_playbook_attack(attack_data: Dict[str, Any],
             result[output_key] = value
         else:
             result[output_key] = attack_data.get(source_key)
+
+    # Always extract platform data (lightweight — two optional strings)
+    platform_data = _extract_platform_data(attack_data.get('content', {}))
+    result.update(platform_data)
 
     if include_mitre_techniques:
         mitre_data = _extract_mitre_data(attack_data.get('tags', []))

--- a/safebreach_mcp_playbook/playbook_types.py
+++ b/safebreach_mcp_playbook/playbook_types.py
@@ -194,8 +194,13 @@ def _extract_platform_data(content_data: Dict[str, Any]) -> Dict[str, Optional[s
     Traverses content.nodes to find OS constraints, mapping nodes to roles
     via isSource (attacker) and isDestination (target) flags.
 
+    Platform values:
+    - Specific OS string (e.g., "WINDOWS", "LINUX") when constraints.os is set
+    - "ANY" when a node exists but has no OS constraint (runs on any platform)
+    - None only when there are no nodes at all (no platform data available)
+
     For single-node attacks where neither isSource nor isDestination is set,
-    the node's OS is assigned to target_platform (host attacks are target-centric).
+    the node's platform is assigned to target_platform (host attacks are target-centric).
 
     Args:
         content_data: The 'content' dict from raw attack data
@@ -225,25 +230,23 @@ def _extract_platform_data(content_data: Dict[str, Any]) -> Dict[str, Optional[s
         is_destination = node_data.get('isDestination', False)
         constraints = node_data.get('constraints', {})
         os_value = constraints.get('os') if isinstance(constraints, dict) else None
+        platform = os_value if os_value else "ANY"
 
         if is_source:
             has_role_flags = True
-            if os_value:
-                result['attacker_platform'] = os_value
+            result['attacker_platform'] = platform
         if is_destination:
             has_role_flags = True
-            if os_value:
-                result['target_platform'] = os_value
+            result['target_platform'] = platform
 
     # Single-node fallback: if no isSource/isDestination flags found,
-    # assign the single node's OS to target_platform
+    # assign the single node's platform to target_platform
     if not has_role_flags and len(nodes) == 1:
         single_node = next(iter(nodes.values()))
         if isinstance(single_node, dict):
             constraints = single_node.get('constraints', {})
             os_value = constraints.get('os') if isinstance(constraints, dict) else None
-            if os_value:
-                result['target_platform'] = os_value
+            result['target_platform'] = os_value if os_value else "ANY"
 
     return result
 
@@ -532,18 +535,20 @@ def _attack_matches_platform(platform_value: Optional[str], filter_values: List[
     """
     Check if a platform value matches any of the filter values.
 
-    None platform values always pass through (return True) — attacks without
-    OS data are included in results when platform filters are active.
+    Strict matching: only returns True when the platform value matches a filter.
+    None platform values (no nodes at all) do NOT match any filter.
+    "ANY" platform values only match if "any" is in the filter values
+    (e.g., target_platform_filter="WINDOWS,ANY").
 
     Args:
-        platform_value: The attack's platform value (e.g., 'WINDOWS') or None
+        platform_value: The attack's platform value (e.g., 'WINDOWS', 'ANY') or None
         filter_values: List of lowercased filter values to match against
 
     Returns:
-        True if platform is None (pass-through) or matches any filter value
+        True if platform matches any filter value, False otherwise
     """
     if platform_value is None:
-        return True
+        return False
 
     platform_lower = platform_value.lower()
     for fv in filter_values:

--- a/safebreach_mcp_playbook/playbook_types.py
+++ b/safebreach_mcp_playbook/playbook_types.py
@@ -373,7 +373,9 @@ def filter_attacks_by_criteria(attacks: List[Dict[str, Any]],
                                published_date_start: Optional[str] = None,
                                published_date_end: Optional[str] = None,
                                mitre_technique_filter: Optional[str] = None,
-                               mitre_tactic_filter: Optional[str] = None) -> List[Dict[str, Any]]:
+                               mitre_tactic_filter: Optional[str] = None,
+                               attacker_platform_filter: Optional[str] = None,
+                               target_platform_filter: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     Filter attacks based on various criteria.
 
@@ -389,6 +391,10 @@ def filter_attacks_by_criteria(attacks: List[Dict[str, Any]],
         published_date_end: End date for published date range (ISO format)
         mitre_technique_filter: Comma-separated technique IDs or names (OR logic, case-insensitive partial match)
         mitre_tactic_filter: Comma-separated tactic names or IDs like TA0006 (OR logic, case-insensitive partial match)
+        attacker_platform_filter: Comma-separated platform values (OR logic, case-insensitive partial match).
+            Attacks with None attacker_platform pass through (are included).
+        target_platform_filter: Comma-separated platform values (OR logic, case-insensitive partial match).
+            Attacks with None target_platform pass through (are included).
 
     Returns:
         Filtered list of attacks
@@ -469,6 +475,22 @@ def filter_attacks_by_criteria(attacks: List[Dict[str, Any]],
             if _attack_matches_mitre_tactic(attack, filter_values)
         ]
 
+    # Filter by attacker platform (comma-separated OR, case-insensitive partial match, None passes through)
+    if attacker_platform_filter:
+        filter_values = [v.strip().lower() for v in attacker_platform_filter.split(',') if v.strip()]
+        filtered_attacks = [
+            attack for attack in filtered_attacks
+            if _attack_matches_platform(attack.get('attacker_platform'), filter_values)
+        ]
+
+    # Filter by target platform (comma-separated OR, case-insensitive partial match, None passes through)
+    if target_platform_filter:
+        filter_values = [v.strip().lower() for v in target_platform_filter.split(',') if v.strip()]
+        filtered_attacks = [
+            attack for attack in filtered_attacks
+            if _attack_matches_platform(attack.get('target_platform'), filter_values)
+        ]
+
     return filtered_attacks
 
 
@@ -506,7 +528,32 @@ def _attack_matches_mitre_tactic(attack: Dict[str, Any], filter_values: List[str
     return False
 
 
-def paginate_attacks(attacks: List[Dict[str, Any]], 
+def _attack_matches_platform(platform_value: Optional[str], filter_values: List[str]) -> bool:
+    """
+    Check if a platform value matches any of the filter values.
+
+    None platform values always pass through (return True) — attacks without
+    OS data are included in results when platform filters are active.
+
+    Args:
+        platform_value: The attack's platform value (e.g., 'WINDOWS') or None
+        filter_values: List of lowercased filter values to match against
+
+    Returns:
+        True if platform is None (pass-through) or matches any filter value
+    """
+    if platform_value is None:
+        return True
+
+    platform_lower = platform_value.lower()
+    for fv in filter_values:
+        if fv in platform_lower:
+            return True
+
+    return False
+
+
+def paginate_attacks(attacks: List[Dict[str, Any]],
                      page_number: int = 0, 
                      page_size: int = 10) -> Dict[str, Any]:
     """

--- a/safebreach_mcp_playbook/tests/test_e2e.py
+++ b/safebreach_mcp_playbook/tests/test_e2e.py
@@ -416,3 +416,258 @@ class TestPlaybookE2E:
 
         except Exception as e:
             pytest.fail(f"E2E test failed: {str(e)}")
+
+
+VALID_OS_VALUES = {'AWS', 'AZURE', 'GCP', 'LINUX', 'MAC', 'WEBAPPLICATION', 'WINDOWS'}
+
+
+@skip_e2e
+@pytest.mark.e2e
+class TestPlatformE2E:
+    """End-to-end tests for platform filtering — zero mocks."""
+
+    def setup_method(self):
+        clear_playbook_cache()
+
+    def test_platform_fields_real_api(self):
+        """Verify platform fields exist on every attack from real API."""
+        result = sb_get_playbook_attacks(console=E2E_CONSOLE, page_number=0)
+        assert result['total_attacks'] > 0
+
+        for attack in result['attacks_in_page']:
+            assert 'attacker_platform' in attack
+            assert 'target_platform' in attack
+            # Values are either None or a valid OS string
+            for field in ['attacker_platform', 'target_platform']:
+                val = attack[field]
+                assert val is None or val in VALID_OS_VALUES, \
+                    f"Attack {attack['id']} has unexpected {field}={val}"
+
+        print(f"✅ Platform fields verified for {len(result['attacks_in_page'])} attacks")
+
+    def test_target_platform_filter_windows(self):
+        """Filter by target_platform=WINDOWS returns matching attacks."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+        assert result['total_attacks'] > 0
+        assert result['applied_filters']['target_platform_filter'] == 'WINDOWS'
+
+        for attack in result['attacks_in_page']:
+            tp = attack.get('target_platform')
+            # Either matches WINDOWS or is None (pass-through)
+            assert tp is None or 'WINDOWS' in tp, \
+                f"Attack {attack['id']} has target_platform={tp}, expected WINDOWS or None"
+
+        print(f"✅ WINDOWS target filter: {result['total_attacks']} attacks")
+
+    def test_attacker_platform_filter_linux(self):
+        """Filter by attacker_platform=LINUX returns matching attacks."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, attacker_platform_filter="LINUX"
+        )
+        assert result['total_attacks'] > 0
+
+        for attack in result['attacks_in_page']:
+            ap = attack.get('attacker_platform')
+            assert ap is None or 'LINUX' in ap, \
+                f"Attack {attack['id']} has attacker_platform={ap}, expected LINUX or None"
+
+        print(f"✅ LINUX attacker filter: {result['total_attacks']} attacks")
+
+    def test_target_platform_filter_linux(self):
+        """Filter by target_platform=LINUX returns matching attacks."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="LINUX"
+        )
+        assert result['total_attacks'] > 0
+
+        for attack in result['attacks_in_page']:
+            tp = attack.get('target_platform')
+            assert tp is None or 'LINUX' in tp
+
+        print(f"✅ LINUX target filter: {result['total_attacks']} attacks")
+
+    def test_platform_filter_multi_value(self):
+        """Multi-value OR filter: WINDOWS,LINUX."""
+        combined = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS,LINUX"
+        )
+        assert combined['total_attacks'] > 0
+
+        for attack in combined['attacks_in_page']:
+            tp = attack.get('target_platform')
+            assert tp is None or 'WINDOWS' in tp or 'LINUX' in tp
+
+        # Combined should be >= individual filters
+        win_only = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+        linux_only = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="LINUX"
+        )
+        assert combined['total_attacks'] >= max(win_only['total_attacks'], linux_only['total_attacks'])
+
+        print(f"✅ Multi-value filter: {combined['total_attacks']} attacks")
+
+    def test_platform_filter_partial_match(self):
+        """Partial match: 'win' should match WINDOWS."""
+        partial = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="win"
+        )
+        full = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+        assert partial['total_attacks'] == full['total_attacks']
+
+        for attack in partial['attacks_in_page']:
+            tp = attack.get('target_platform')
+            assert tp is None or 'win' in tp.lower()
+
+        print(f"✅ Partial match: {partial['total_attacks']} attacks")
+
+    def test_platform_filter_case_insensitive(self):
+        """Case insensitivity: 'windows' == 'WINDOWS'."""
+        lower = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="windows"
+        )
+        upper = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+        assert lower['total_attacks'] == upper['total_attacks']
+
+        print(f"✅ Case insensitive: both return {lower['total_attacks']} attacks")
+
+    def test_platform_filter_none_pass_through(self):
+        """None platform attacks are included when filter is active."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+
+        # Scan pages to find at least one attack with None target_platform
+        found_none = False
+        for page in range(min(5, result['total_pages'])):
+            page_result = sb_get_playbook_attacks(
+                console=E2E_CONSOLE, target_platform_filter="WINDOWS", page_number=page
+            )
+            for attack in page_result['attacks_in_page']:
+                if attack.get('target_platform') is None:
+                    found_none = True
+                    break
+            if found_none:
+                break
+
+        assert found_none, "Expected at least one attack with None target_platform in filtered results"
+        print(f"✅ None pass-through verified")
+
+    def test_platform_plus_name_filter(self):
+        """Combined platform + name filter."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE,
+            target_platform_filter="WINDOWS",
+            name_filter="registry"
+        )
+
+        for attack in result['attacks_in_page']:
+            assert 'registry' in attack['name'].lower()
+            tp = attack.get('target_platform')
+            assert tp is None or 'WINDOWS' in tp
+
+        # Combined should be <= individual filters
+        win_only = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+        name_only = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, name_filter="registry"
+        )
+        assert result['total_attacks'] <= win_only['total_attacks']
+        assert result['total_attacks'] <= name_only['total_attacks']
+
+        print(f"✅ Platform + name: {result['total_attacks']} attacks")
+
+    def test_platform_plus_mitre_filter(self):
+        """Combined platform + MITRE tactic filter."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE,
+            target_platform_filter="WINDOWS",
+            mitre_tactic_filter="Discovery"
+        )
+
+        for attack in result['attacks_in_page']:
+            tp = attack.get('target_platform')
+            assert tp is None or 'WINDOWS' in tp
+            tactic_names = [t['name'].lower() for t in attack.get('mitre_tactics', [])]
+            assert any('discovery' in name for name in tactic_names), \
+                f"Attack {attack['id']} missing Discovery tactic"
+
+        print(f"✅ Platform + MITRE: {result['total_attacks']} attacks")
+
+    def test_platform_filter_metadata(self):
+        """Applied filters metadata contains both platform filters."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE,
+            attacker_platform_filter="LINUX",
+            target_platform_filter="WINDOWS"
+        )
+
+        assert result['applied_filters']['attacker_platform_filter'] == 'LINUX'
+        assert result['applied_filters']['target_platform_filter'] == 'WINDOWS'
+
+        print(f"✅ Filter metadata verified")
+
+    def test_platform_filter_nonexistent(self):
+        """Nonexistent platform returns only None pass-through attacks."""
+        result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="NONEXISTENT_OS"
+        )
+
+        # Should have results (None pass-through)
+        assert result['total_attacks'] > 0
+
+        # No attack should have a non-None target_platform
+        for attack in result['attacks_in_page']:
+            assert attack.get('target_platform') is None, \
+                f"Attack {attack['id']} has target_platform={attack.get('target_platform')}"
+
+        print(f"✅ Nonexistent filter: {result['total_attacks']} pass-through attacks")
+
+    def test_platform_filter_pagination(self):
+        """Pagination works correctly with platform filter."""
+        page0 = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS", page_number=0
+        )
+
+        if page0['total_pages'] > 1:
+            page1 = sb_get_playbook_attacks(
+                console=E2E_CONSOLE, target_platform_filter="WINDOWS", page_number=1
+            )
+
+            page0_ids = {a['id'] for a in page0['attacks_in_page']}
+            page1_ids = {a['id'] for a in page1['attacks_in_page']}
+            assert page0_ids.isdisjoint(page1_ids), "Pages have overlapping attacks"
+            assert page0['total_attacks'] == page1['total_attacks']
+
+            print(f"✅ Pagination: {page0['total_pages']} pages, disjoint verified")
+        else:
+            print(f"ℹ️ Only one page with WINDOWS filter")
+
+    def test_platform_in_attack_details(self):
+        """Get details for a WINDOWS attack from filtered list."""
+        attacks_result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS"
+        )
+
+        # Find first attack with actual WINDOWS platform (not None)
+        target_id = None
+        for attack in attacks_result['attacks_in_page']:
+            if attack.get('target_platform') == 'WINDOWS':
+                target_id = attack['id']
+                break
+
+        if target_id:
+            details = sb_get_playbook_attack_details(target_id, console=E2E_CONSOLE)
+            assert details['id'] == target_id
+            assert details['name'] is not None
+            print(f"✅ Attack details verified for {target_id}")
+        else:
+            print(f"ℹ️ No WINDOWS attacks found in first page")

--- a/safebreach_mcp_playbook/tests/test_e2e.py
+++ b/safebreach_mcp_playbook/tests/test_e2e.py
@@ -418,7 +418,7 @@ class TestPlaybookE2E:
             pytest.fail(f"E2E test failed: {str(e)}")
 
 
-VALID_OS_VALUES = {'AWS', 'AZURE', 'GCP', 'LINUX', 'MAC', 'WEBAPPLICATION', 'WINDOWS'}
+VALID_OS_VALUES = {'AWS', 'AZURE', 'DOCKER', 'GCP', 'LINUX', 'MAC', 'MAILBOX', 'WEBAPPLICATION', 'WINDOWS'}
 
 
 @skip_e2e

--- a/safebreach_mcp_playbook/tests/test_e2e.py
+++ b/safebreach_mcp_playbook/tests/test_e2e.py
@@ -418,7 +418,7 @@ class TestPlaybookE2E:
             pytest.fail(f"E2E test failed: {str(e)}")
 
 
-VALID_OS_VALUES = {'AWS', 'AZURE', 'DOCKER', 'GCP', 'LINUX', 'MAC', 'MAILBOX', 'WEBAPPLICATION', 'WINDOWS'}
+VALID_OS_VALUES = {'ANY', 'AWS', 'AZURE', 'DOCKER', 'GCP', 'LINUX', 'MAC', 'MAILBOX', 'WEBAPPLICATION', 'WINDOWS'}
 
 
 @skip_e2e
@@ -446,7 +446,7 @@ class TestPlatformE2E:
         print(f"✅ Platform fields verified for {len(result['attacks_in_page'])} attacks")
 
     def test_target_platform_filter_windows(self):
-        """Filter by target_platform=WINDOWS returns matching attacks."""
+        """Filter by target_platform=WINDOWS returns only WINDOWS attacks (strict)."""
         result = sb_get_playbook_attacks(
             console=E2E_CONSOLE, target_platform_filter="WINDOWS"
         )
@@ -455,14 +455,13 @@ class TestPlatformE2E:
 
         for attack in result['attacks_in_page']:
             tp = attack.get('target_platform')
-            # Either matches WINDOWS or is None (pass-through)
-            assert tp is None or 'WINDOWS' in tp, \
-                f"Attack {attack['id']} has target_platform={tp}, expected WINDOWS or None"
+            assert tp == 'WINDOWS', \
+                f"Attack {attack['id']} has target_platform={tp}, expected WINDOWS"
 
-        print(f"✅ WINDOWS target filter: {result['total_attacks']} attacks")
+        print(f"✅ WINDOWS target filter (strict): {result['total_attacks']} attacks")
 
     def test_attacker_platform_filter_linux(self):
-        """Filter by attacker_platform=LINUX returns matching attacks."""
+        """Filter by attacker_platform=LINUX returns only LINUX attacker attacks (strict)."""
         result = sb_get_playbook_attacks(
             console=E2E_CONSOLE, attacker_platform_filter="LINUX"
         )
@@ -470,13 +469,13 @@ class TestPlatformE2E:
 
         for attack in result['attacks_in_page']:
             ap = attack.get('attacker_platform')
-            assert ap is None or 'LINUX' in ap, \
-                f"Attack {attack['id']} has attacker_platform={ap}, expected LINUX or None"
+            assert ap == 'LINUX', \
+                f"Attack {attack['id']} has attacker_platform={ap}, expected LINUX"
 
-        print(f"✅ LINUX attacker filter: {result['total_attacks']} attacks")
+        print(f"✅ LINUX attacker filter (strict): {result['total_attacks']} attacks")
 
     def test_target_platform_filter_linux(self):
-        """Filter by target_platform=LINUX returns matching attacks."""
+        """Filter by target_platform=LINUX returns only LINUX attacks (strict)."""
         result = sb_get_playbook_attacks(
             console=E2E_CONSOLE, target_platform_filter="LINUX"
         )
@@ -484,7 +483,7 @@ class TestPlatformE2E:
 
         for attack in result['attacks_in_page']:
             tp = attack.get('target_platform')
-            assert tp is None or 'LINUX' in tp
+            assert tp == 'LINUX', f"Expected LINUX, got {tp}"
 
         print(f"✅ LINUX target filter: {result['total_attacks']} attacks")
 
@@ -497,7 +496,7 @@ class TestPlatformE2E:
 
         for attack in combined['attacks_in_page']:
             tp = attack.get('target_platform')
-            assert tp is None or 'WINDOWS' in tp or 'LINUX' in tp
+            assert tp in ('WINDOWS', 'LINUX'), f"Expected WINDOWS or LINUX, got {tp}"
 
         # Combined should be >= individual filters
         win_only = sb_get_playbook_attacks(
@@ -522,7 +521,7 @@ class TestPlatformE2E:
 
         for attack in partial['attacks_in_page']:
             tp = attack.get('target_platform')
-            assert tp is None or 'win' in tp.lower()
+            assert tp == 'WINDOWS', f"Expected WINDOWS, got {tp}"
 
         print(f"✅ Partial match: {partial['total_attacks']} attacks")
 
@@ -538,27 +537,27 @@ class TestPlatformE2E:
 
         print(f"✅ Case insensitive: both return {lower['total_attacks']} attacks")
 
-    def test_platform_filter_none_pass_through(self):
-        """None platform attacks are included when filter is active."""
-        result = sb_get_playbook_attacks(
+    def test_platform_filter_strict_excludes_any(self):
+        """Strict filter: WINDOWS filter excludes ANY platform attacks."""
+        strict_result = sb_get_playbook_attacks(
             console=E2E_CONSOLE, target_platform_filter="WINDOWS"
         )
+        with_any_result = sb_get_playbook_attacks(
+            console=E2E_CONSOLE, target_platform_filter="WINDOWS,ANY"
+        )
 
-        # Scan pages to find at least one attack with None target_platform
-        found_none = False
-        for page in range(min(5, result['total_pages'])):
-            page_result = sb_get_playbook_attacks(
-                console=E2E_CONSOLE, target_platform_filter="WINDOWS", page_number=page
-            )
-            for attack in page_result['attacks_in_page']:
-                if attack.get('target_platform') is None:
-                    found_none = True
-                    break
-            if found_none:
-                break
+        # Adding ANY should return more attacks
+        assert with_any_result['total_attacks'] > strict_result['total_attacks'], \
+            "WINDOWS,ANY should return more attacks than WINDOWS alone"
 
-        assert found_none, "Expected at least one attack with None target_platform in filtered results"
-        print(f"✅ None pass-through verified")
+        # Strict result should have no ANY attacks
+        for attack in strict_result['attacks_in_page']:
+            tp = attack.get('target_platform')
+            assert tp is None or 'WINDOWS' in tp, \
+                f"Strict filter returned non-WINDOWS: {tp}"
+
+        print(f"✅ Strict filtering verified: WINDOWS={strict_result['total_attacks']}, "
+              f"WINDOWS,ANY={with_any_result['total_attacks']}")
 
     def test_platform_plus_name_filter(self):
         """Combined platform + name filter."""
@@ -571,7 +570,7 @@ class TestPlatformE2E:
         for attack in result['attacks_in_page']:
             assert 'registry' in attack['name'].lower()
             tp = attack.get('target_platform')
-            assert tp is None or 'WINDOWS' in tp
+            assert tp == 'WINDOWS', f"Expected WINDOWS, got {tp}"
 
         # Combined should be <= individual filters
         win_only = sb_get_playbook_attacks(
@@ -595,7 +594,7 @@ class TestPlatformE2E:
 
         for attack in result['attacks_in_page']:
             tp = attack.get('target_platform')
-            assert tp is None or 'WINDOWS' in tp
+            assert tp == 'WINDOWS', f"Expected WINDOWS, got {tp}"
             tactic_names = [t['name'].lower() for t in attack.get('mitre_tactics', [])]
             assert any('discovery' in name for name in tactic_names), \
                 f"Attack {attack['id']} missing Discovery tactic"
@@ -616,20 +615,15 @@ class TestPlatformE2E:
         print(f"✅ Filter metadata verified")
 
     def test_platform_filter_nonexistent(self):
-        """Nonexistent platform returns only None pass-through attacks."""
+        """Nonexistent platform returns no results (strict matching)."""
         result = sb_get_playbook_attacks(
             console=E2E_CONSOLE, target_platform_filter="NONEXISTENT_OS"
         )
 
-        # Should have results (None pass-through)
-        assert result['total_attacks'] > 0
+        assert result['total_attacks'] == 0, \
+            f"Expected 0 attacks for nonexistent platform, got {result['total_attacks']}"
 
-        # No attack should have a non-None target_platform
-        for attack in result['attacks_in_page']:
-            assert attack.get('target_platform') is None, \
-                f"Attack {attack['id']} has target_platform={attack.get('target_platform')}"
-
-        print(f"✅ Nonexistent filter: {result['total_attacks']} pass-through attacks")
+        print(f"✅ Nonexistent filter: 0 attacks (strict)")
 
     def test_platform_filter_pagination(self):
         """Pagination works correctly with platform filter."""

--- a/safebreach_mcp_playbook/tests/test_integration.py
+++ b/safebreach_mcp_playbook/tests/test_integration.py
@@ -474,12 +474,11 @@ class TestPlatformIntegration:
         result = sb_get_playbook_attacks('test-console', target_platform_filter="WINDOWS")
 
         ids = [a['id'] for a in result['attacks_in_page']]
-        # 1027: target=WINDOWS (gold), 2048: target=WINDOWS (red),
-        # 3141: target=None (pass-through)
+        # 1027: target=WINDOWS (gold), 2048: target=WINDOWS (red)
         assert 1027 in ids
         assert 2048 in ids
-        assert 3141 in ids
-        # 4096: target=MAC (no match)
+        # 3141: target=ANY (excluded — strict), 4096: target=MAC (no match)
+        assert 3141 not in ids
         assert 4096 not in ids
 
     @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
@@ -509,7 +508,7 @@ class TestPlatformIntegration:
         assert attacks[2048]['target_platform'] == 'WINDOWS'
 
         assert attacks[3141]['attacker_platform'] is None
-        assert attacks[3141]['target_platform'] is None
+        assert attacks[3141]['target_platform'] == 'ANY'
 
         assert attacks[4096]['target_platform'] == 'MAC'
         assert attacks[4096]['attacker_platform'] is None

--- a/safebreach_mcp_playbook/tests/test_integration.py
+++ b/safebreach_mcp_playbook/tests/test_integration.py
@@ -56,7 +56,14 @@ def comprehensive_attack_dataset():
                         "description": "The malicious URL to query",
                         "values": [{"id": 1, "value": "www.malicious-domain.com", "displayValue": "www.malicious-domain.com"}]
                     }
-                ]
+                ],
+                "nodes": {
+                    "gold": {
+                        "isSource": False,
+                        "isDestination": False,
+                        "constraints": {"os": "WINDOWS", "framework": "3.100.0"}
+                    }
+                }
             }
         },
         {
@@ -84,7 +91,19 @@ def comprehensive_attack_dataset():
                         "description": "Size of the file to transfer",
                         "values": [{"id": 1, "value": "10", "displayValue": "10 MB"}]
                     }
-                ]
+                ],
+                "nodes": {
+                    "green": {
+                        "isSource": True,
+                        "isDestination": False,
+                        "constraints": {"os": "LINUX"}
+                    },
+                    "red": {
+                        "isSource": False,
+                        "isDestination": True,
+                        "constraints": {"os": "WINDOWS"}
+                    }
+                }
             }
         },
         {
@@ -110,7 +129,14 @@ def comprehensive_attack_dataset():
                             {"id": 2, "value": "root", "displayValue": "root"}
                         ]
                     }
-                ]
+                ],
+                "nodes": {
+                    "gold": {
+                        "isSource": False,
+                        "isDestination": False,
+                        "constraints": {"framework": "3.100.0"}
+                    }
+                }
             }
         },
         {
@@ -129,7 +155,14 @@ def comprehensive_attack_dataset():
             },
             "tags": ["windows", "registry", "persistence"],
             "content": {
-                "params": []
+                "params": [],
+                "nodes": {
+                    "gold": {
+                        "isSource": False,
+                        "isDestination": False,
+                        "constraints": {"os": "MAC", "framework": "3.120.0"}
+                    }
+                }
             }
         }
     ]
@@ -422,3 +455,61 @@ class TestPlaybookIntegration:
         
         # Verify both consoles were called separately
         assert mock_get_all_attacks.call_count == 2
+
+
+class TestPlatformIntegration:
+    """Integration tests for platform filtering across the full pipeline."""
+
+    def setup_method(self):
+        clear_playbook_cache()
+
+    def teardown_method(self):
+        clear_playbook_cache()
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_filtering_integration(self, mock_get_all, comprehensive_attack_dataset):
+        """Filter by target platform across mixed dataset."""
+        mock_get_all.return_value = comprehensive_attack_dataset
+
+        result = sb_get_playbook_attacks('test-console', target_platform_filter="WINDOWS")
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        # 1027: target=WINDOWS (gold), 2048: target=WINDOWS (red),
+        # 3141: target=None (pass-through)
+        assert 1027 in ids
+        assert 2048 in ids
+        assert 3141 in ids
+        # 4096: target=MAC (no match)
+        assert 4096 not in ids
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_combined_filtering(self, mock_get_all, comprehensive_attack_dataset):
+        """Platform + name filter combined."""
+        mock_get_all.return_value = comprehensive_attack_dataset
+
+        result = sb_get_playbook_attacks(
+            'test-console', target_platform_filter="WINDOWS", name_filter="DNS"
+        )
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        assert ids == [1027]
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_fields_in_results(self, mock_get_all, comprehensive_attack_dataset):
+        """Verify platform fields present and correct in all results."""
+        mock_get_all.return_value = comprehensive_attack_dataset
+
+        result = sb_get_playbook_attacks('test-console')
+        attacks = {a['id']: a for a in result['attacks_in_page']}
+
+        assert attacks[1027]['target_platform'] == 'WINDOWS'
+        assert attacks[1027]['attacker_platform'] is None
+
+        assert attacks[2048]['attacker_platform'] == 'LINUX'
+        assert attacks[2048]['target_platform'] == 'WINDOWS'
+
+        assert attacks[3141]['attacker_platform'] is None
+        assert attacks[3141]['target_platform'] is None
+
+        assert attacks[4096]['target_platform'] == 'MAC'
+        assert attacks[4096]['attacker_platform'] is None

--- a/safebreach_mcp_playbook/tests/test_playbook_functions.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_functions.py
@@ -652,3 +652,174 @@ class TestMitreGetPlaybookAttackDetails:
 
         assert 'mitre_tactics' not in result
         assert 'mitre_techniques' not in result
+
+
+# Platform-specific fixtures and tests
+
+@pytest.fixture
+def sample_attack_data_with_platform():
+    """Sample attack data with platform info in content.nodes structure."""
+    return [
+        {
+            "id": 1001,
+            "name": "Windows registry manipulation",
+            "description": "Modify Windows registry for persistence.",
+            "modifiedDate": "2024-05-20T16:45:12.000Z",
+            "publishedDate": "2021-07-15T11:30:00.000Z",
+            "metadata": {"fix_suggestions": []},
+            "tags": [],
+            "content": {
+                "params": [],
+                "nodes": {
+                    "gold": {
+                        "isSource": False,
+                        "isDestination": False,
+                        "constraints": {"os": "WINDOWS", "framework": "3.100.0"}
+                    }
+                }
+            }
+        },
+        {
+            "id": 1002,
+            "name": "HTTP file transfer exfiltration",
+            "description": "Transfer file over HTTP from Linux attacker.",
+            "modifiedDate": "2024-01-15T10:30:00.000Z",
+            "publishedDate": "2020-03-10T12:00:00.000Z",
+            "metadata": {"fix_suggestions": []},
+            "tags": [],
+            "content": {
+                "params": [],
+                "nodes": {
+                    "green": {
+                        "isSource": True,
+                        "isDestination": False,
+                        "constraints": {"os": "LINUX"}
+                    },
+                    "red": {
+                        "isSource": False,
+                        "isDestination": True,
+                        "constraints": {"os": "WINDOWS"}
+                    }
+                }
+            }
+        },
+        {
+            "id": 1003,
+            "name": "ARP scanning of local subnet",
+            "description": "Discover hosts on network via ARP.",
+            "modifiedDate": "2024-10-07T07:28:05.000Z",
+            "publishedDate": "2019-05-29T15:18:44.000Z",
+            "metadata": {"fix_suggestions": []},
+            "tags": [],
+            "content": {
+                "params": [],
+                "nodes": {
+                    "gold": {
+                        "isSource": False,
+                        "isDestination": False,
+                        "constraints": {"framework": "3.146.0"}
+                    }
+                }
+            }
+        }
+    ]
+
+
+class TestPlatformGetPlaybookAttacks:
+    """Test platform functionality in sb_get_playbook_attacks."""
+
+    def setup_method(self):
+        clear_playbook_cache()
+
+    def teardown_method(self):
+        clear_playbook_cache()
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_fields_always_present(self, mock_get_all, sample_attack_data_with_platform):
+        """Platform fields should always be present in response."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console')
+
+        for attack in result['attacks_in_page']:
+            assert 'attacker_platform' in attack
+            assert 'target_platform' in attack
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_extraction_values(self, mock_get_all, sample_attack_data_with_platform):
+        """Platform values extracted correctly from node data."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console')
+        attacks = {a['id']: a for a in result['attacks_in_page']}
+
+        # Attack 1001: gold node (host) — target=WINDOWS, attacker=None
+        assert attacks[1001]['target_platform'] == 'WINDOWS'
+        assert attacks[1001]['attacker_platform'] is None
+
+        # Attack 1002: green/red — attacker=LINUX, target=WINDOWS
+        assert attacks[1002]['attacker_platform'] == 'LINUX'
+        assert attacks[1002]['target_platform'] == 'WINDOWS'
+
+        # Attack 1003: gold node no OS — both None
+        assert attacks[1003]['attacker_platform'] is None
+        assert attacks[1003]['target_platform'] is None
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_target_platform_filter(self, mock_get_all, sample_attack_data_with_platform):
+        """Filter by target platform."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console', target_platform_filter="WINDOWS")
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        # 1001: target=WINDOWS (match), 1002: target=WINDOWS (match), 1003: target=None (pass-through)
+        assert set(ids) == {1001, 1002, 1003}
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_attacker_platform_filter(self, mock_get_all, sample_attack_data_with_platform):
+        """Filter by attacker platform."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console', attacker_platform_filter="LINUX")
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        # All pass: 1001 attacker=None (pass), 1002 attacker=LINUX (match), 1003 attacker=None (pass)
+        assert set(ids) == {1001, 1002, 1003}
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_filter_combined_with_name(self, mock_get_all, sample_attack_data_with_platform):
+        """Platform + name filter combination."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks(
+            'test-console', target_platform_filter="WINDOWS", name_filter="registry"
+        )
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        assert ids == [1001]
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_filter_applied_filters_metadata(self, mock_get_all, sample_attack_data_with_platform):
+        """Platform filters appear in applied_filters metadata."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks(
+            'test-console',
+            attacker_platform_filter="LINUX",
+            target_platform_filter="WINDOWS"
+        )
+
+        assert result['applied_filters']['attacker_platform_filter'] == 'LINUX'
+        assert result['applied_filters']['target_platform_filter'] == 'WINDOWS'
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_platform_filter_none_pass_through(self, mock_get_all, sample_attack_data_with_platform):
+        """Attacks without OS data included when filter active."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console', target_platform_filter="NONEXISTENT")
+
+        ids = [a['id'] for a in result['attacks_in_page']]
+        # Only attack 1003 has None target_platform (pass-through)
+        assert ids == [1003]

--- a/safebreach_mcp_playbook/tests/test_playbook_functions.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_functions.py
@@ -753,7 +753,7 @@ class TestPlatformGetPlaybookAttacks:
         result = sb_get_playbook_attacks('test-console')
         attacks = {a['id']: a for a in result['attacks_in_page']}
 
-        # Attack 1001: gold node (host) — target=WINDOWS, attacker=None
+        # Attack 1001: gold node (host) — target=WINDOWS, attacker=None (no nodes for attacker)
         assert attacks[1001]['target_platform'] == 'WINDOWS'
         assert attacks[1001]['attacker_platform'] is None
 
@@ -761,31 +761,41 @@ class TestPlatformGetPlaybookAttacks:
         assert attacks[1002]['attacker_platform'] == 'LINUX'
         assert attacks[1002]['target_platform'] == 'WINDOWS'
 
-        # Attack 1003: gold node no OS — both None
+        # Attack 1003: gold node no OS — target=ANY, attacker=None
         assert attacks[1003]['attacker_platform'] is None
-        assert attacks[1003]['target_platform'] is None
+        assert attacks[1003]['target_platform'] == 'ANY'
 
     @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
-    def test_target_platform_filter(self, mock_get_all, sample_attack_data_with_platform):
-        """Filter by target platform."""
+    def test_target_platform_filter_strict(self, mock_get_all, sample_attack_data_with_platform):
+        """Strict filter: only WINDOWS matches, ANY excluded."""
         mock_get_all.return_value = sample_attack_data_with_platform
 
         result = sb_get_playbook_attacks('test-console', target_platform_filter="WINDOWS")
 
         ids = [a['id'] for a in result['attacks_in_page']]
-        # 1001: target=WINDOWS (match), 1002: target=WINDOWS (match), 1003: target=None (pass-through)
+        # 1001: target=WINDOWS (match), 1002: target=WINDOWS (match), 1003: target=ANY (excluded)
+        assert set(ids) == {1001, 1002}
+
+    @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
+    def test_target_platform_filter_with_any(self, mock_get_all, sample_attack_data_with_platform):
+        """Filter WINDOWS,ANY includes WINDOWS + ANY platform attacks."""
+        mock_get_all.return_value = sample_attack_data_with_platform
+
+        result = sb_get_playbook_attacks('test-console', target_platform_filter="WINDOWS,ANY")
+
+        ids = [a['id'] for a in result['attacks_in_page']]
         assert set(ids) == {1001, 1002, 1003}
 
     @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
-    def test_attacker_platform_filter(self, mock_get_all, sample_attack_data_with_platform):
-        """Filter by attacker platform."""
+    def test_attacker_platform_filter_strict(self, mock_get_all, sample_attack_data_with_platform):
+        """Strict filter on attacker: only LINUX matches."""
         mock_get_all.return_value = sample_attack_data_with_platform
 
         result = sb_get_playbook_attacks('test-console', attacker_platform_filter="LINUX")
 
         ids = [a['id'] for a in result['attacks_in_page']]
-        # All pass: 1001 attacker=None (pass), 1002 attacker=LINUX (match), 1003 attacker=None (pass)
-        assert set(ids) == {1001, 1002, 1003}
+        # Only 1002 has attacker=LINUX; 1001,1003 have attacker=None (excluded)
+        assert set(ids) == {1002}
 
     @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
     def test_platform_filter_combined_with_name(self, mock_get_all, sample_attack_data_with_platform):
@@ -814,12 +824,10 @@ class TestPlatformGetPlaybookAttacks:
         assert result['applied_filters']['target_platform_filter'] == 'WINDOWS'
 
     @patch('safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api')
-    def test_platform_filter_none_pass_through(self, mock_get_all, sample_attack_data_with_platform):
-        """Attacks without OS data included when filter active."""
+    def test_platform_filter_nonexistent_returns_empty(self, mock_get_all, sample_attack_data_with_platform):
+        """Nonexistent platform returns no results (strict)."""
         mock_get_all.return_value = sample_attack_data_with_platform
 
         result = sb_get_playbook_attacks('test-console', target_platform_filter="NONEXISTENT")
 
-        ids = [a['id'] for a in result['attacks_in_page']]
-        # Only attack 1003 has None target_platform (pass-through)
-        assert ids == [1003]
+        assert result['total_attacks'] == 0

--- a/safebreach_mcp_playbook/tests/test_playbook_types.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_types.py
@@ -250,9 +250,10 @@ class TestTransformationFunctions:
         result = transform_reduced_playbook_attack(sample_attack_raw)
         
         # Verify all required fields are present
-        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate']
+        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate',
+                          'attacker_platform', 'target_platform']
         assert set(result.keys()) == set(expected_fields)
-        
+
         # Verify field values
         assert result['id'] == 1027
         assert result['name'] == "DNS queries of malicious URLs"
@@ -271,7 +272,8 @@ class TestTransformationFunctions:
         result = transform_reduced_playbook_attack(incomplete_data)
         
         # Should still have all expected keys, with None for missing values
-        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate']
+        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate',
+                          'attacker_platform', 'target_platform']
         assert set(result.keys()) == set(expected_fields)
         assert result['id'] == 123
         assert result['name'] == "Test Attack"
@@ -284,7 +286,8 @@ class TestTransformationFunctions:
         result = transform_full_playbook_attack(sample_attack_raw)
         
         # Should include all reduced fields plus all optional fields (default behavior)
-        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate', 
+        expected_fields = ['name', 'id', 'description', 'modifiedDate', 'publishedDate',
+                          'attacker_platform', 'target_platform',
                           'fix_suggestions', 'tags', 'params']
         assert set(result.keys()) == set(expected_fields)
         

--- a/safebreach_mcp_playbook/tests/test_playbook_types.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_types.py
@@ -14,6 +14,8 @@ from safebreach_mcp_playbook.playbook_types import (
     paginate_attacks,
     _transform_tags,
     _extract_mitre_data,
+    _extract_platform_data,
+    _attack_matches_platform,
     _resolve_tactic_filter_value
 )
 
@@ -910,3 +912,332 @@ class TestResolveTacticFilterValue:
         """Test higher tactic ID TA0040 (Impact) resolves correctly."""
         assert _resolve_tactic_filter_value("ta0040") == "impact"
         assert _resolve_tactic_filter_value("ta40") == "impact"
+
+
+# ============================================================================
+# Platform Extraction and Filtering Tests
+# ============================================================================
+
+class TestExtractPlatformData:
+    """Test _extract_platform_data() function."""
+
+    def test_gold_node_single_host_attack(self):
+        """Gold node: target_platform = OS, attacker_platform = None."""
+        content = {
+            "nodes": {
+                "gold": {
+                    "isSource": False,
+                    "isDestination": False,
+                    "constraints": {"os": "WINDOWS", "framework": "3.146.0"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] == "WINDOWS"
+
+    def test_green_red_network_attack(self):
+        """Green/red nodes: map via isSource/isDestination."""
+        content = {
+            "nodes": {
+                "green": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {"os": "LINUX"}
+                },
+                "red": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {"os": "WINDOWS"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] == "LINUX"
+        assert result['target_platform'] == "WINDOWS"
+
+    def test_green_red_reversed_roles(self):
+        """Green as destination, red as source."""
+        content = {
+            "nodes": {
+                "green": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {"os": "AZURE"}
+                },
+                "red": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {"os": "LINUX"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] == "LINUX"
+        assert result['target_platform'] == "AZURE"
+
+    def test_explicit_attacker_target_nodes(self):
+        """Explicit attacker/target node names with isSource/isDestination."""
+        content = {
+            "nodes": {
+                "attacker": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {"os": "LINUX"}
+                },
+                "target": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {"os": "WINDOWS"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] == "LINUX"
+        assert result['target_platform'] == "WINDOWS"
+
+    def test_target_only_pattern(self):
+        """Single target node: target_platform = OS, attacker = None."""
+        content = {
+            "nodes": {
+                "target": {
+                    "isSource": False,
+                    "isDestination": False,
+                    "constraints": {"os": "MAC"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] == "MAC"
+
+    def test_local_only_pattern(self):
+        """Single local node: target_platform = OS, attacker = None."""
+        content = {
+            "nodes": {
+                "local": {
+                    "isSource": False,
+                    "isDestination": False,
+                    "constraints": {"os": "LINUX"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] == "LINUX"
+
+    def test_missing_content(self):
+        """Empty or None content returns None/None."""
+        assert _extract_platform_data({}) == {'attacker_platform': None, 'target_platform': None}
+        assert _extract_platform_data(None) == {'attacker_platform': None, 'target_platform': None}
+
+    def test_missing_nodes(self):
+        """Content without nodes returns None/None."""
+        result = _extract_platform_data({"params": []})
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] is None
+
+    def test_missing_constraints_os(self):
+        """Node without constraints.os returns None for that role."""
+        content = {
+            "nodes": {
+                "gold": {
+                    "isSource": False,
+                    "isDestination": False,
+                    "constraints": {"framework": "3.146.0"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] is None
+
+    def test_case_variant_node_names(self):
+        """Capital case Green/Red should work the same as lowercase."""
+        content = {
+            "nodes": {
+                "Green": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {"os": "WEBAPPLICATION"}
+                },
+                "Red": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {"os": "LINUX"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] == "WEBAPPLICATION"
+        assert result['target_platform'] == "LINUX"
+
+    def test_green_red_no_os(self):
+        """Green/red nodes without OS constraints."""
+        content = {
+            "nodes": {
+                "green": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {}
+                },
+                "red": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] is None
+        assert result['target_platform'] is None
+
+    def test_cloud_platform_values(self):
+        """Test cloud platform values like AWS, AZURE, GCP."""
+        content = {
+            "nodes": {
+                "green": {
+                    "isSource": False,
+                    "isDestination": True,
+                    "constraints": {"os": "AWS"}
+                },
+                "red": {
+                    "isSource": True,
+                    "isDestination": False,
+                    "constraints": {"os": "GCP"}
+                }
+            }
+        }
+        result = _extract_platform_data(content)
+        assert result['attacker_platform'] == "GCP"
+        assert result['target_platform'] == "AWS"
+
+
+class TestAttackMatchesPlatform:
+    """Test _attack_matches_platform() helper function."""
+
+    def test_none_platform_passes_through(self):
+        """None platform always returns True (pass-through)."""
+        assert _attack_matches_platform(None, ["windows"]) is True
+        assert _attack_matches_platform(None, ["linux", "mac"]) is True
+
+    def test_exact_match_case_insensitive(self):
+        """Case-insensitive exact match."""
+        assert _attack_matches_platform("WINDOWS", ["windows"]) is True
+        assert _attack_matches_platform("windows", ["WINDOWS".lower()]) is True
+
+    def test_partial_match(self):
+        """Partial string match."""
+        assert _attack_matches_platform("WINDOWS", ["win"]) is True
+        assert _attack_matches_platform("WEBAPPLICATION", ["web"]) is True
+
+    def test_no_match(self):
+        """No match returns False."""
+        assert _attack_matches_platform("WINDOWS", ["linux"]) is False
+        assert _attack_matches_platform("LINUX", ["mac"]) is False
+
+    def test_multiple_filter_values_or_logic(self):
+        """Multiple filter values use OR logic."""
+        assert _attack_matches_platform("WINDOWS", ["linux", "windows"]) is True
+        assert _attack_matches_platform("MAC", ["linux", "mac"]) is True
+        assert _attack_matches_platform("AWS", ["linux", "mac"]) is False
+
+    def test_empty_filter_values(self):
+        """Empty filter values list returns False for non-None platform."""
+        assert _attack_matches_platform("WINDOWS", []) is False
+
+
+class TestPlatformFiltering:
+    """Test platform filtering in filter_attacks_by_criteria()."""
+
+    @pytest.fixture
+    def sample_attacks_with_platform(self):
+        """Mixed attacks with various platform configurations."""
+        return [
+            {"id": 1, "name": "Attack A", "attacker_platform": None, "target_platform": "WINDOWS"},
+            {"id": 2, "name": "Attack B", "attacker_platform": "LINUX", "target_platform": "WINDOWS"},
+            {"id": 3, "name": "Attack C", "attacker_platform": None, "target_platform": "LINUX"},
+            {"id": 4, "name": "Attack D", "attacker_platform": None, "target_platform": None},
+            {"id": 5, "name": "Attack E", "attacker_platform": "LINUX", "target_platform": "MAC"},
+        ]
+
+    def test_target_platform_filter_single(self, sample_attacks_with_platform):
+        """Filter by single target platform value."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="WINDOWS"
+        )
+        ids = [a['id'] for a in result]
+        # Attacks 1,2 match WINDOWS; attack 4 has None (pass-through)
+        assert 1 in ids
+        assert 2 in ids
+        assert 4 in ids
+        # Attack 3 has LINUX target, attack 5 has MAC target
+        assert 3 not in ids
+        assert 5 not in ids
+
+    def test_attacker_platform_filter_single(self, sample_attacks_with_platform):
+        """Filter by single attacker platform value."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, attacker_platform_filter="LINUX"
+        )
+        ids = [a['id'] for a in result]
+        # Attacks 2,5 have LINUX attacker; attacks 1,3,4 have None (pass-through)
+        assert set(ids) == {1, 2, 3, 4, 5}
+
+    def test_target_platform_filter_comma_separated(self, sample_attacks_with_platform):
+        """Filter by comma-separated target platforms (OR logic)."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="WINDOWS,MAC"
+        )
+        ids = [a['id'] for a in result]
+        # 1,2 = WINDOWS, 5 = MAC, 4 = None (pass-through)
+        assert 1 in ids
+        assert 2 in ids
+        assert 5 in ids
+        assert 4 in ids
+        # 3 = LINUX (no match)
+        assert 3 not in ids
+
+    def test_target_platform_filter_partial_match(self, sample_attacks_with_platform):
+        """Partial match on platform value."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="win"
+        )
+        ids = [a['id'] for a in result]
+        assert 1 in ids  # WINDOWS matches "win"
+        assert 2 in ids  # WINDOWS matches "win"
+        assert 4 in ids  # None pass-through
+
+    def test_none_pass_through(self, sample_attacks_with_platform):
+        """Attacks with None platform are included when filter active."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="NONEXISTENT"
+        )
+        ids = [a['id'] for a in result]
+        # Only attack 4 has None target_platform (pass-through)
+        assert ids == [4]
+
+    def test_combined_platform_and_name_filter(self, sample_attacks_with_platform):
+        """Platform filter combined with name filter."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform,
+            name_filter="Attack B",
+            target_platform_filter="WINDOWS"
+        )
+        ids = [a['id'] for a in result]
+        assert ids == [2]
+
+    def test_both_platform_filters(self, sample_attacks_with_platform):
+        """Both attacker and target platform filters applied."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform,
+            attacker_platform_filter="LINUX",
+            target_platform_filter="WINDOWS"
+        )
+        ids = [a['id'] for a in result]
+        # Attack 2: attacker=LINUX (match), target=WINDOWS (match)
+        # Attack 1: attacker=None (pass), target=WINDOWS (match)
+        # Attack 4: attacker=None (pass), target=None (pass)
+        assert 2 in ids
+        assert 1 in ids
+        assert 4 in ids

--- a/safebreach_mcp_playbook/tests/test_playbook_types.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_types.py
@@ -1038,7 +1038,7 @@ class TestExtractPlatformData:
         assert result['target_platform'] is None
 
     def test_missing_constraints_os(self):
-        """Node without constraints.os returns None for that role."""
+        """Node without constraints.os returns ANY for that role."""
         content = {
             "nodes": {
                 "gold": {
@@ -1050,7 +1050,7 @@ class TestExtractPlatformData:
         }
         result = _extract_platform_data(content)
         assert result['attacker_platform'] is None
-        assert result['target_platform'] is None
+        assert result['target_platform'] == "ANY"
 
     def test_case_variant_node_names(self):
         """Capital case Green/Red should work the same as lowercase."""
@@ -1073,7 +1073,7 @@ class TestExtractPlatformData:
         assert result['target_platform'] == "LINUX"
 
     def test_green_red_no_os(self):
-        """Green/red nodes without OS constraints."""
+        """Green/red nodes without OS constraints return ANY."""
         content = {
             "nodes": {
                 "green": {
@@ -1089,8 +1089,8 @@ class TestExtractPlatformData:
             }
         }
         result = _extract_platform_data(content)
-        assert result['attacker_platform'] is None
-        assert result['target_platform'] is None
+        assert result['attacker_platform'] == "ANY"
+        assert result['target_platform'] == "ANY"
 
     def test_cloud_platform_values(self):
         """Test cloud platform values like AWS, AZURE, GCP."""
@@ -1116,10 +1116,20 @@ class TestExtractPlatformData:
 class TestAttackMatchesPlatform:
     """Test _attack_matches_platform() helper function."""
 
-    def test_none_platform_passes_through(self):
-        """None platform always returns True (pass-through)."""
-        assert _attack_matches_platform(None, ["windows"]) is True
-        assert _attack_matches_platform(None, ["linux", "mac"]) is True
+    def test_none_platform_returns_false(self):
+        """None platform (no nodes) returns False — strict matching."""
+        assert _attack_matches_platform(None, ["windows"]) is False
+        assert _attack_matches_platform(None, ["linux", "mac"]) is False
+
+    def test_any_platform_matches_any_filter(self):
+        """ANY platform matches when 'any' is in the filter values."""
+        assert _attack_matches_platform("ANY", ["any"]) is True
+        assert _attack_matches_platform("ANY", ["windows", "any"]) is True
+
+    def test_any_platform_does_not_match_specific_filter(self):
+        """ANY platform does NOT match specific OS filters."""
+        assert _attack_matches_platform("ANY", ["windows"]) is False
+        assert _attack_matches_platform("ANY", ["linux"]) is False
 
     def test_exact_match_case_insensitive(self):
         """Case-insensitive exact match."""
@@ -1143,7 +1153,7 @@ class TestAttackMatchesPlatform:
         assert _attack_matches_platform("AWS", ["linux", "mac"]) is False
 
     def test_empty_filter_values(self):
-        """Empty filter values list returns False for non-None platform."""
+        """Empty filter values list returns False."""
         assert _attack_matches_platform("WINDOWS", []) is False
 
 
@@ -1154,34 +1164,46 @@ class TestPlatformFiltering:
     def sample_attacks_with_platform(self):
         """Mixed attacks with various platform configurations."""
         return [
-            {"id": 1, "name": "Attack A", "attacker_platform": None, "target_platform": "WINDOWS"},
+            {"id": 1, "name": "Attack A", "attacker_platform": "ANY", "target_platform": "WINDOWS"},
             {"id": 2, "name": "Attack B", "attacker_platform": "LINUX", "target_platform": "WINDOWS"},
-            {"id": 3, "name": "Attack C", "attacker_platform": None, "target_platform": "LINUX"},
-            {"id": 4, "name": "Attack D", "attacker_platform": None, "target_platform": None},
+            {"id": 3, "name": "Attack C", "attacker_platform": "ANY", "target_platform": "LINUX"},
+            {"id": 4, "name": "Attack D", "attacker_platform": "ANY", "target_platform": "ANY"},
             {"id": 5, "name": "Attack E", "attacker_platform": "LINUX", "target_platform": "MAC"},
+            {"id": 6, "name": "Attack F", "attacker_platform": None, "target_platform": None},
         ]
 
-    def test_target_platform_filter_single(self, sample_attacks_with_platform):
-        """Filter by single target platform value."""
+    def test_target_platform_filter_strict(self, sample_attacks_with_platform):
+        """Strict filter: only matching platforms, ANY and None excluded."""
         result = filter_attacks_by_criteria(
             sample_attacks_with_platform, target_platform_filter="WINDOWS"
         )
         ids = [a['id'] for a in result]
-        # Attacks 1,2 match WINDOWS; attack 4 has None (pass-through)
-        assert 1 in ids
-        assert 2 in ids
-        assert 4 in ids
-        # Attack 3 has LINUX target, attack 5 has MAC target
-        assert 3 not in ids
-        assert 5 not in ids
+        assert set(ids) == {1, 2}
 
-    def test_attacker_platform_filter_single(self, sample_attacks_with_platform):
-        """Filter by single attacker platform value."""
+    def test_target_platform_filter_with_any(self, sample_attacks_with_platform):
+        """Filter WINDOWS,ANY includes WINDOWS + ANY platform attacks."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="WINDOWS,ANY"
+        )
+        ids = [a['id'] for a in result]
+        # 1,2 = WINDOWS, 4 = ANY
+        assert set(ids) == {1, 2, 4}
+
+    def test_attacker_platform_filter_strict(self, sample_attacks_with_platform):
+        """Strict filter on attacker: only LINUX matches."""
         result = filter_attacks_by_criteria(
             sample_attacks_with_platform, attacker_platform_filter="LINUX"
         )
         ids = [a['id'] for a in result]
-        # Attacks 2,5 have LINUX attacker; attacks 1,3,4 have None (pass-through)
+        assert set(ids) == {2, 5}
+
+    def test_attacker_platform_filter_with_any(self, sample_attacks_with_platform):
+        """Filter LINUX,ANY includes LINUX + ANY attacker attacks."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, attacker_platform_filter="LINUX,ANY"
+        )
+        ids = [a['id'] for a in result]
+        # 2,5 = LINUX, 1,3,4 = ANY
         assert set(ids) == {1, 2, 3, 4, 5}
 
     def test_target_platform_filter_comma_separated(self, sample_attacks_with_platform):
@@ -1190,13 +1212,7 @@ class TestPlatformFiltering:
             sample_attacks_with_platform, target_platform_filter="WINDOWS,MAC"
         )
         ids = [a['id'] for a in result]
-        # 1,2 = WINDOWS, 5 = MAC, 4 = None (pass-through)
-        assert 1 in ids
-        assert 2 in ids
-        assert 5 in ids
-        assert 4 in ids
-        # 3 = LINUX (no match)
-        assert 3 not in ids
+        assert set(ids) == {1, 2, 5}
 
     def test_target_platform_filter_partial_match(self, sample_attacks_with_platform):
         """Partial match on platform value."""
@@ -1204,18 +1220,22 @@ class TestPlatformFiltering:
             sample_attacks_with_platform, target_platform_filter="win"
         )
         ids = [a['id'] for a in result]
-        assert 1 in ids  # WINDOWS matches "win"
-        assert 2 in ids  # WINDOWS matches "win"
-        assert 4 in ids  # None pass-through
+        assert set(ids) == {1, 2}
 
-    def test_none_pass_through(self, sample_attacks_with_platform):
-        """Attacks with None platform are included when filter active."""
+    def test_nonexistent_filter_returns_nothing(self, sample_attacks_with_platform):
+        """Nonexistent platform returns no results (strict)."""
         result = filter_attacks_by_criteria(
             sample_attacks_with_platform, target_platform_filter="NONEXISTENT"
         )
+        assert len(result) == 0
+
+    def test_none_platform_excluded(self, sample_attacks_with_platform):
+        """Attacks with None platform (no nodes) excluded from all filters."""
+        result = filter_attacks_by_criteria(
+            sample_attacks_with_platform, target_platform_filter="WINDOWS,ANY"
+        )
         ids = [a['id'] for a in result]
-        # Only attack 4 has None target_platform (pass-through)
-        assert ids == [4]
+        assert 6 not in ids
 
     def test_combined_platform_and_name_filter(self, sample_attacks_with_platform):
         """Platform filter combined with name filter."""
@@ -1227,17 +1247,13 @@ class TestPlatformFiltering:
         ids = [a['id'] for a in result]
         assert ids == [2]
 
-    def test_both_platform_filters(self, sample_attacks_with_platform):
-        """Both attacker and target platform filters applied."""
+    def test_both_platform_filters_strict(self, sample_attacks_with_platform):
+        """Both attacker and target platform filters applied strictly."""
         result = filter_attacks_by_criteria(
             sample_attacks_with_platform,
             attacker_platform_filter="LINUX",
             target_platform_filter="WINDOWS"
         )
         ids = [a['id'] for a in result]
-        # Attack 2: attacker=LINUX (match), target=WINDOWS (match)
-        # Attack 1: attacker=None (pass), target=WINDOWS (match)
-        # Attack 4: attacker=None (pass), target=None (pass)
-        assert 2 in ids
-        assert 1 in ids
-        assert 4 in ids
+        # Only attack 2: attacker=LINUX, target=WINDOWS
+        assert ids == [2]


### PR DESCRIPTION
## What

Add `attacker_platform_filter` and `target_platform_filter` parameters to `get_playbook_attacks` MCP tool, enabling platform-specific attack discovery.

## Why

[SAF-29642](https://safebreach.atlassian.net/browse/SAF-29642)

## Changes

- Extract platform data from `content.nodes.{node}.constraints.os` with role mapping via `isSource`/`isDestination` flags
- Nodes without OS constraints return `"ANY"` (runs on any platform); `None` only when no nodes exist
- Strict filtering by default — only explicit platform matches returned
- Add `ANY` to filter to include platform-agnostic attacks (e.g., `target_platform_filter="WINDOWS,ANY"`)
- Comma-separated OR logic, case-insensitive partial matching (consistent with existing filters)
- Platform fields (`attacker_platform`, `target_platform`) always present in response
- Valid values: ANY, AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPPLICATION, WINDOWS
- 9 valid OS values discovered from live pentest01 API (9,683 attacks analyzed)

## Testing

- 41 new unit tests for platform extraction (5 node patterns), matching helper, and filtering logic
- 3 integration tests for cross-component platform filtering
- 14 E2E tests (zero mocks) against live SafeBreach API covering: single/multi-value filters, partial match, case insensitivity, strict ANY exclusion, combined filters (platform+name, platform+MITRE), pagination, and applied filters metadata
- All 152 unit/integration + 14 E2E tests passing

## JIRA

[SAF-29642](https://safebreach.atlassian.net/browse/SAF-29642)