### PR TITLE
SAF-29415: Add get_peer_benchmark_score MCP tool to Data Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ This is a Model Context Protocol (MCP) server that bridges AI agents with SafeBr
 per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to bound memory:
 - **Config Server**: `simulators` — maxsize=5, TTL=3600s
 - **Data Server**: `tests` (5/1800s), `simulations` (3/600s), `security_control_events` (3/600s),
-  `findings` (3/600s), `full_simulation_logs` (2/300s)
+  `findings` (3/600s), `full_simulation_logs` (2/300s), `peer_benchmark` (3/600s)
 - **Playbook Server**: `playbook_attacks` — maxsize=5, TTL=1800s
 - **Studio Server**: `studio_drafts` — maxsize=5, TTL=1800s
 - **Cache Monitoring**: Background task logs stats every 5 minutes, warns when caches are at capacity
@@ -288,9 +288,18 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 12. `get_full_simulation_logs` ✨ **NEW** - Retrieves comprehensive execution logs with role-based structure: `target` (always present) and `attacker` (present for dual-script exfil/infil/lateral attacks, null for host attacks). Each role contains ~40KB LOGS, simulation_steps, error, output, os_type, and state. For deep troubleshooting, forensic analysis, step-by-step execution analysis, and detailed log correlation
 13. `get_simulation_result_drifts` ✨ **NEW** - Time-window-based **posture-level** drift analysis showing transitions between blocked (FAIL) and not-blocked (SUCCESS) states. Two-phase usage: summary (grouped counts by result transition) then drill-down (paginated records). Groups by FAIL/SUCCESS for coarse posture view. Includes `final_status_breakdown`, `attack_summary` (with `attack_name`), `look_back_time` (7-day default), and zero-results smart hints. Supports `attack_id`, `attack_type`, and `attack_name` filters.
 14. `get_simulation_status_drifts` ✨ **NEW** - Time-window-based **security-control-level** drift analysis showing transitions between final statuses (prevented, stopped, detected, logged, missed, inconsistent). Two-phase usage: summary then drill-down. Groups by finalStatus for fine-grained control view. Includes `attack_summary` (with `attack_name`), `look_back_time`, and zero-results smart hints. Supports `attack_id`, `attack_type`, and `attack_name` filters.
+15. `get_peer_benchmark_score` ✨ **NEW** - Returns the customer's security posture score compared to SafeBreach peers
+  for a given time window. Wraps `POST /api/data/v1/accounts/{account_id}/score` (delivered in SAF-27621). Required
+  `start_date` / `end_date` accept epoch ms/seconds or ISO 8601 strings; optional `include_test_ids_filter` /
+  `exclude_test_ids_filter` (comma-separated planRunIds, mutually exclusive). Returns `customer_score`,
+  `all_peers_score` (across **all** SafeBreach customers), and `customer_industry_scores` (scoped to the customer's
+  **own** industry only via server-side Salesforce mapping; not overridable; typically 0 or 1 element). Each score
+  includes `score_blocked` / `score_detected` / `score_unblocked` and a `security_control_breakdown[]`. Surfaces
+  `peer_snapshot_month`, `peer_data_through_date` (ETL freshness; may be null), `custom_attacks_filtered_count`
+  (auto-excluded custom attacks with `moveId >= 10_000_000`), and a `hint_to_agent` when data is missing or HTTP 204.
 
 **Playbook Server (Port 8003):**
-15. `get_playbook_attacks` ✨ **Enhanced** - Filtered and paginated playbook attacks with comprehensive filtering
+16. `get_playbook_attacks` ✨ **Enhanced** - Filtered and paginated playbook attacks with comprehensive filtering
   (name, description, ID range, date ranges, MITRE ATT&CK techniques/tactics, attacker/target platform) and pagination.
   Supports `include_mitre_techniques`, `mitre_technique_filter` (comma-separated, OR logic),
   `mitre_tactic_filter` (comma-separated, OR logic),
@@ -298,12 +307,12 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
   and `target_platform_filter` (comma-separated, OR logic, case-insensitive partial match).
   Each attack always includes `attacker_platform` and `target_platform` fields.
   Attacks without platform data are included when platform filters are active (None pass-through)
-16. `get_playbook_attack_details` ✨ **Enhanced** - Detailed attack information with verbosity options
+17. `get_playbook_attack_details` ✨ **Enhanced** - Detailed attack information with verbosity options
   (fix suggestions, tags, parameters, MITRE ATT&CK data with URLs) for specific attack techniques
 
 **Utilities Server (Port 8002):**
-17. `convert_datetime_to_epoch` - Convert ISO datetime strings to Unix epoch timestamps for API filtering
-18. `convert_epoch_to_datetime` - Convert Unix epoch timestamps to readable datetime strings
+18. `convert_datetime_to_epoch` - Convert ISO datetime strings to Unix epoch timestamps for API filtering
+19. `convert_epoch_to_datetime` - Convert Unix epoch timestamps to readable datetime strings
 
 
 ## Filtering and Search Capabilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,9 +294,13 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
   `exclude_test_ids_filter` (comma-separated planRunIds, mutually exclusive). Returns `customer_score`,
   `all_peers_score` (across **all** SafeBreach customers), and `customer_industry_scores` (scoped to the customer's
   **own** industry only via server-side Salesforce mapping; not overridable; typically 0 or 1 element). Each score
-  includes `score_blocked` / `score_detected` / `score_unblocked` and a `security_control_breakdown[]`. Surfaces
-  `peer_snapshot_month`, `peer_data_through_date` (ETL freshness; may be null), `custom_attacks_filtered_count`
-  (auto-excluded custom attacks with `moveId >= 10_000_000`), and a `hint_to_agent` when data is missing or HTTP 204.
+  includes `score_blocked` / `score_detected` / `score_missed` (the fully-evaded portion; aligns with the `missed`
+  simulation status) and a `security_control_breakdown[]` sorted alphabetically by `control_category_name` so
+  customer / peer / industry breakdowns can be merged position-wise. Always-on response metadata: `scoring_formula`
+  (the literal `"score = 1.0 * blocked + 0.5 * detected"`), `scope_note` (explains that customer score is the exact
+  window while peer/industry scores are full-month aggregates of `peer_snapshot_month`), `peer_snapshot_month`,
+  `peer_data_through_date` (ETL freshness; may be null), and `custom_attacks_filtered_count`. A `hint_to_agent` is
+  added when data is missing or HTTP 204.
 
 **Playbook Server (Port 8003):**
 16. `get_playbook_attacks` ✨ **Enhanced** - Filtered and paginated playbook attacks with comprehensive filtering

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29415
 
 ## Status
-Phase 8: JIRA Updated
+Phase 4: Document Findings (planning-dev-task)
 
 ## Mode
 Improving
@@ -104,6 +104,93 @@ Toggle via `SB_MCP_CACHE_DATA=true`. Size convention for data tools: `maxsize=3,
 - Cache-config env var docs (no new env var; reuses `SB_MCP_CACHE_DATA`)
 
 **No pre-existing peer/benchmark code** in `safebreach_mcp_data/` — greenfield addition.
+
+### SafeBreach backend `data` service (/Users/yossiattas/projects/data) — ground-truth research
+
+Route: `POST /data/v1/accounts/{accountId}/score`, OperationId `getScore`, defined in `src/api/dashboardapi.json` (OpenAPI 2.0 Swagger). Handler chain:
+- `src/dashboardApi/api/scoreApi.js` — `ScoreApi.getScore({accountId, params})`
+- `src/dashboardApi/controller/scoreController.js` — business logic
+- `src/common/dal/executionsHistoryDao.js` — Elasticsearch aggregation
+- `src/dashboardApi/service/dataInsightsService.js` — POST `/api/v1.0/peer-benchmark` to data-insights-gateway
+
+**Auth**: standard signed-request via `@safebreach/common` (x-account-id + signed header). **No endpoint-level RBAC** — all users in an account can call it.
+
+**Request schema** (body as `params`):
+- `startDate` (required, ISO 8601 date-time string, UTC)
+- `endDate` (required, ISO 8601 date-time string, UTC)
+- `includeTestIds` (optional, array of strings — planRunIds)
+- `excludeTestIds` (optional, array of strings — planRunIds)
+- **No other fields.** No query-string params. No pagination. No platform/industry override.
+
+**Backend validation** (scoreApi.js `validateParams`, lines ~37-53):
+1. `startDate` and `endDate` both required → 400 `"startDate and endDate are required"`
+2. `startDate < endDate` enforced → 400 `"startDate must be before endDate"`
+3. `includeTestIds` XOR `excludeTestIds` (mutually exclusive when both non-empty) → 400 `"Cannot provide both includeTestIds and excludeTestIds..."`
+4. Empty/omitted both → defaults to "all tests in range"
+5. Dates are ISO-only — **no epoch accepted at backend**
+
+**Response schema** — authoritative, from Swagger + handler + tests:
+
+Top-level `ScoreResponse` fields (all present unless noted):
+- `startDate`, `endDate` — echo of request
+- `snapshotMonth` — `YYYY-MM`; backend falls back to `endDate.slice(0,7)` if gateway omits
+- `dataThroughDate` — `YYYY-MM-DD`; **can be `null`** if gateway has no snapshot
+- `attackIds: string[]` — standard (non-custom) attack IDs queried
+- `attackIdsQueried: int`
+- `customAttackIdsFiltered: int` — count of custom attacks (moveId ≥ `10_000_000`) filtered out
+- `customerScore: ScoreBreakdown | null` — null when no executions
+- `peerScore: ScoreBreakdown | null` — null when gateway has no `all_industries` bucket
+- `industryScores: ScoreBreakdown[]` — filtered to non-null scores; can be empty
+
+`ScoreBreakdown`:
+- `score: float` (= 1.0 × blocked + 0.5 × detected)
+- `scoreBlocked: float`
+- `scoreDetected: float`
+- `scoreUnblocked: float`
+- `totalSimulations: int` — **customerScore only**
+- `industry: string` — **industryScores elements only**
+- `securityControlCategory: ControlScore[]`
+
+`ControlScore`:
+- `name: string` (e.g., "Network Inspection", "Network Access", "Email")
+- `score`, `scoreBlocked`, `scoreDetected` — floats
+- `scoreUnblocked: float` — **customerScore entries only; omitted in peer/industry**
+
+**HTTP response codes**:
+- `200 OK` — normal success (with payload above)
+- `204 No Content` — empty body when: no executions in ES match the filters, OR all returned attacks are custom (moveId ≥ 10,000,000). **Real code path, not error.**
+- `400` — validation failures (see list)
+- `401` — signed-auth failure (upstream middleware)
+- `403` — not expected from this endpoint (no RBAC gate), but possible from upstream deployment blocker
+- `404` — not returned by this endpoint
+- `500` — ES query failure or gateway timeout/unavailable
+
+**Business-logic nuggets** (for docstring accuracy):
+- `customAttackIdsFiltered` semantics: custom-attack IDs (≥ 10M) are never unique across accounts, so they are excluded from peer comparison automatically
+- Industry of customer is determined server-side from Salesforce mapping; callers cannot override
+- Peer aggregation uses a monthly S3 snapshot via data-insights-gateway; no caching on data service itself
+- Staging / private-dev gateways use a frozen prod snapshot
+- Score formula documented literally: `score = 1.0 × blocked + 0.5 × detected`
+
+**Test fixture example** (from `test/dashboardApi/api/scoreApi.test.js`):
+```js
+GATEWAY_RESPONSE = {
+  snapshot_month: '2026-02',
+  data_through_date: '2026-02-28',
+  scores: [
+    { attackid: '10054', industry_bucket: 'all_industries', security_control_category: 'Network Inspection', blocked_percentage: 0.7, detected_percentage: 0.04, total_all: 48000 },
+    { attackid: '10054', industry_bucket: 'Healthcare', security_control_category: 'Network Inspection', blocked_percentage: 0.75, detected_percentage: 0.01, total_all: 6000 },
+  ]
+}
+```
+
+**Key implications for MCP tool**:
+1. Must handle HTTP 204 — `response.status_code == 204` → return a friendly structured result with `hint_to_agent` explaining "no executions in window or all attacks are custom".
+2. Must handle null `customerScore` / `peerScore` / `dataThroughDate` and empty `industryScores[]` gracefully — include `hint_to_agent` per condition.
+3. `include_test_ids_filter` vs `exclude_test_ids_filter` — decide whether to enforce mutual exclusivity client-side or let backend 400 be surfaced. (Decision deferred to brainstorm.)
+4. Date validation at MCP boundary is optional (backend validates), but catching `start >= end` locally gives better UX.
+5. Tool docstring should explicitly document the custom-attack threshold (`moveId ≥ 10_000_000`), the 204 case, null fields, and the peer industry mapping (server-side, not overridable).
+6. No RBAC gating needed — remove 403 test from the AC's unit-test list (keep generic "API error" case).
 
 ## Problem Analysis
 

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29415
 
 ## Status
-Phase 5: Brainstorm Complete
+Phase 6: PRD Created
 
 ## Mode
 Improving
@@ -240,7 +240,7 @@ GATEWAY_RESPONSE = {
      | `customAttackIdsFiltered` | `custom_attacks_filtered_count` | clarify count; "IDs filtered" ambiguous |
      | `customerScore` | `customer_score` | snake_case |
      | `peerScore` | `all_peers_score` | disambiguate: **all SafeBreach peers** (not customer's industry peers) |
-     | `industryScores` | `industry_scores` | snake_case |
+     | `industryScores` | `customer_industry_scores` | explicit scope: customer's own industry only (Salesforce mapping, server-side, not overridable) |
      | `industry` (inside) | `industry_name` | explicit |
      | `score` / `scoreBlocked` / `scoreDetected` / `scoreUnblocked` | `score` / `score_blocked` / `score_detected` / `score_unblocked` | snake_case |
      | `totalSimulations` | `total_simulations` | snake_case |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29415
 
 ## Status
-Phase 4: Document Findings (planning-dev-task)
+Phase 5: Brainstorm Complete
 
 ## Mode
 Improving
@@ -222,5 +222,61 @@ GATEWAY_RESPONSE = {
 
 **Non-Goals**: NL intent parsing (MCP client's job); new datetime helpers; explainability computed locally.
 
-## Proposed Improvements
-(Phase 6)
+## Brainstorm Outcomes (Phase 5)
+
+**Locked-in decisions** (all approved by user):
+
+1. **Response shape — A1: Pass-through with rename mapping + additive hint_to_agent.**
+   - Applied via a key-rename mapping in `data_types.py` (same pattern as `reduced_test_summary_mapping` at lines 13-20).
+   - Semantic content preserved 1:1; no field dropped; no score re-computation.
+   - Rename mapping:
+     | Backend (camelCase) | MCP response | Why |
+     |---|---|---|
+     | `startDate` / `endDate` | `start_date` / `end_date` | snake_case |
+     | `snapshotMonth` | `peer_snapshot_month` | clarify this is peer snapshot, not query window |
+     | `dataThroughDate` | `peer_data_through_date` | explicit: peer data freshness |
+     | `attackIds` | `attack_ids` | snake_case |
+     | `attackIdsQueried` | `attack_ids_count` | clarify it's a count |
+     | `customAttackIdsFiltered` | `custom_attacks_filtered_count` | clarify count; "IDs filtered" ambiguous |
+     | `customerScore` | `customer_score` | snake_case |
+     | `peerScore` | `all_peers_score` | disambiguate: **all SafeBreach peers** (not customer's industry peers) |
+     | `industryScores` | `industry_scores` | snake_case |
+     | `industry` (inside) | `industry_name` | explicit |
+     | `score` / `scoreBlocked` / `scoreDetected` / `scoreUnblocked` | `score` / `score_blocked` / `score_detected` / `score_unblocked` | snake_case |
+     | `totalSimulations` | `total_simulations` | snake_case |
+     | `securityControlCategory` (array) | `security_control_breakdown` | it's a breakdown *by* category |
+     | `name` (inside breakdown) | `control_category_name` | explicit |
+   - Additive top-level field: `hint_to_agent: str` — only present when HTTP 204 or any of `customer_score` / `all_peers_score` / `industry_scores` are null/empty.
+
+2. **Caching — B1: Full-key cache.**
+   - `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)`.
+   - Key: `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes_csv}_{sorted_excludes_csv}"`.
+   - Gated by `is_caching_enabled("data")` (env var `SB_MCP_CACHE_DATA`).
+
+3. **Filter-ID style — C1: Comma-separated string + `_filter` suffix.**
+   - `include_test_ids_filter: Optional[str] = None`, `exclude_test_ids_filter: Optional[str] = None`.
+   - Split via `[v.strip() for v in s.split(",") if v.strip()]`.
+   - Omitted from API body when empty/null.
+
+4. **Mutual exclusivity — validate at MCP boundary.**
+   - If both `include_test_ids_filter` and `exclude_test_ids_filter` are non-empty after parsing, raise a clean `ValueError` with a clear message (faster agent feedback than a backend 400).
+   - Still surface backend 400s gracefully in case of ordering / date issues.
+
+5. **HTTP 204 / null scores — structured empty result with hint.**
+   - On 204: return `{start_date, end_date, customer_score: None, all_peers_score: None, industry_scores: [], hint_to_agent: "No executions in the requested window, or all matched attacks were custom (peer benchmark excludes custom attack IDs >= 10_000_000)."}`.
+   - On 200 with `customerScore == null`: pass through with hint explaining "no executions in window".
+   - On 200 with `peerScore == null` / `industryScores == []`: hint explaining "no peer data for this window (possibly frozen snapshot on staging/private-dev)".
+   - Hints are composed when multiple conditions apply.
+
+6. **Docstring requirements** (from backend findings):
+   - Document custom-attack threshold: `moveId >= 10_000_000`.
+   - Document that industry is server-side determined (Salesforce mapping, not overridable).
+   - Document peer snapshot monthly granularity + ETL daily-update behavior.
+   - Document 204 handling.
+   - Drop 403 from unit tests (no RBAC on this endpoint); keep generic 500/backend-error case.
+
+**Out of scope (confirmed non-goals)**:
+- NL intent parsing (MCP client's responsibility).
+- Score re-computation.
+- Explainability beyond what API returns.
+- Platform / industry override (API doesn't support it).

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/context.md
@@ -1,0 +1,139 @@
+# Ticket Context: SAF-29415
+
+## Status
+Phase 8: JIRA Updated
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: Add the new Peer Benchmark Score API to the DATA MCP
+- **Status**: In Progress
+- **Assignee**: Yossi Attas
+- **Reporter**: Shahaf Raviv
+- **Priority**: Medium
+- **Created**: 2026-03-24
+- **Link**: https://safebreach.atlassian.net/browse/SAF-29415
+
+### Description (original)
+**User Story**: As a SafeBreach user via MCP, I want to query Peer Benchmark scores using natural language, so that I can compare my security posture to peers and industry without using the UI.
+
+**UX/UI**: No UI changes (MCP-only). Exposed as MCP tool. Return structured JSON (agent-friendly). Support summarized + raw data.
+
+Example queries:
+- "What is my peer benchmark score?"
+- "Compare me to my industry peers last month"
+- "Show benchmark scores for Jan 1–31"
+- "Include tests X, Y" / "Exclude test Z"
+- "Breakdown by control category"
+
+**Functional Requirements** (upstream API: SAF-27621):
+1. Expose Peer Benchmark via MCP (uses existing API)
+2. Return: customer score, peer score, customer's industry score, security control category breakdown
+3. Support filters: `start_time`, `end_time`, `include_test_ids[]`, `exclude_test_ids[]`
+4. Support combined filters
+5. Translate natural language → API request
+6. Return structured response with filters + results
+7. Handle errors (invalid input, no data, permissions)
+
+**Non-Functional**: Match API/UI exactly; respect RBAC (viewer supported); fast/interactive; consistent schema.
+
+**DOD**: MCP tool implemented + accessible from console AI chat; supports time + test filters; returns customer/peer/industry + breakdown; NL queries work; results match API/UI; product reviewed.
+
+### Comments (summarized)
+1. **Endpoint examples (Yossi, 2026-04-13)**: `POST /api/data/v1/accounts/{account}/score` with body `{startDate, endDate, includeTestIds?, excludeTestIds?}`. Response shape includes `snapshotMonth`, `dataThroughDate`, `attackIds`, `attackIdsQueried`, `customAttackIdsFiltered`, `customerScore`, `peerScore`, `industryScores[]`. Each score: `score`, `scoreBlocked`, `scoreDetected`, `scoreUnblocked` + `securityControlCategory[]`. Formula: `score = 1.0*blocked + 0.5*detected`.
+2. **Q&A (Yossi, 2026-04-13)**:
+   - `snapshotMonth`: full month peer snapshot used for comparison (customer score still uses exact range)
+   - `dataThroughDate`: last day ETL included; freshness indicator; ETL daily
+   - `customAttackIdsFiltered`: count of custom attacks excluded (custom IDs aren't unique across customers)
+   - Staging/private-dev uses frozen production snapshot
+
+## Task Scope
+Add a new MCP tool to the Data Server (port 8001) that wraps the Peer Benchmark Score API. Should follow existing data-server patterns (types → functions → server → tests), integrate with `SafeBreachAuth`, be cached if appropriate, and support the documented filters (`startDate`, `endDate`, `includeTestIds`, `excludeTestIds`).
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp (branch: saf-29415-add-peer-benchmark-to-data-mcp)
+
+## Investigation Findings
+
+### safebreach-mcp (Data Server)
+
+**Layer architecture** (for every new tool):
+1. `safebreach_mcp_data/data_types.py` — mapping dicts + transform funcs (e.g., `get_reduced_test_summary_mapping`)
+2. `safebreach_mcp_data/data_functions.py` — business logic: `sb_get_*` async-style funcs; HTTP via `requests`; caching; pagination/filtering
+3. `safebreach_mcp_data/data_server.py` — MCP tool registration via `@self.mcp.tool(name=..., description=...)` decorator under `_register_tools()`; normalizes timestamps then delegates
+
+**HTTP / Auth pattern (data module uses `x-apitoken`, NOT Bearer):**
+```python
+apitoken = get_secret_for_console(console)
+base_url = get_api_base_url(console, 'data')
+account_id = get_api_account_id(console)
+api_url = f"{base_url}/api/data/v1/accounts/{account_id}/<endpoint>"
+headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+response = requests.post(api_url, headers=headers, json=data, timeout=120)
+response.raise_for_status()
+```
+Confirmed by `data_functions.py:659-687`. Peer benchmark endpoint `POST /api/data/v1/accounts/{account_id}/score` slots into this pattern unchanged.
+
+**Caching:** `SafeBreachCache` (cachetools.TTLCache wrapper, thread-safe). Declared at module top (lines 32-35). Usage:
+```python
+if is_caching_enabled("data"):
+    cached = xxx_cache.get(cache_key); if cached is not None: return cached
+# ... API call ...
+if is_caching_enabled("data"):
+    xxx_cache.set(cache_key, result)
+```
+Toggle via `SB_MCP_CACHE_DATA=true`. Size convention for data tools: `maxsize=3, ttl=600` (10 min). Cache key pattern: `f"{name}_{console}_{param1}_{param2}..."`.
+
+**Datetime handling mismatch (important):**
+- Convention for existing tools: wrapper accepts epoch int OR ISO 8601 str via `normalize_timestamp()` → returns **epoch ms**, which downstream APIs expect.
+- Peer benchmark API, per endpoint docs in ticket comments, expects **ISO 8601 strings** in the request body (`"startDate": "2026-03-15T00:00:00.000Z"`). So this tool must accept epoch+ISO like the others, normalize to epoch ms, then convert **back** to ISO 8601 (UTC `Z` suffix) using `convert_epoch_to_datetime(ms)["iso_datetime"]` before POSTing.
+
+**Tool registration pattern to mirror** — `get_test_simulations_tool` (data_server.py:100-137) is a good template: typed Optional params, timestamp normalization, delegate to `sb_*` function.
+
+**Test conventions:**
+- Unit tests: `safebreach_mcp_data/tests/test_data_functions.py` — mock `requests.post`, `get_secret_for_console`, `get_api_account_id`, `get_api_base_url`. `setup_method` clears caches.
+- Integration tests: `test_integration.py` — multi-function flows with same mocks.
+- E2E tests: `test_e2e.py` — `@pytest.mark.e2e` + `e2e_console` fixture skips if `E2E_CONSOLE` unset.
+
+**Naming (matches convention):** `get_peer_benchmark_score` (tool), `sb_get_peer_benchmark_score` (function), `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)`.
+
+**Docs consumers to update:**
+- `CLAUDE.md` "Data Server (Port 8001)" tools list + Caching section (add new cache line)
+- `README.md` if it enumerates tools
+- Cache-config env var docs (no new env var; reuses `SB_MCP_CACHE_DATA`)
+
+**No pre-existing peer/benchmark code** in `safebreach_mcp_data/` — greenfield addition.
+
+## Problem Analysis
+
+**Problem Scope**: Peer Benchmark Score API (SAF-27621) is unreachable from MCP clients. SAF-29415 adds a Data-server MCP tool wrapping `POST /api/data/v1/accounts/{account_id}/score` so MCP clients and the console AI chat can retrieve customer/peer/industry scores + control-category breakdowns via natural language.
+
+**Affected Areas**:
+- `safebreach_mcp_data/data_functions.py` — new `sb_get_peer_benchmark_score`; new `peer_benchmark_cache`
+- `safebreach_mcp_data/data_types.py` — optional shaping helpers (pass-through preferred)
+- `safebreach_mcp_data/data_server.py` — new `get_peer_benchmark_score` MCP tool wrapper
+- `safebreach_mcp_data/tests/test_data_functions.py` — unit tests mocking `requests.post`
+- `safebreach_mcp_data/tests/test_e2e.py` — smoke E2E
+- `CLAUDE.md` — Data Server tools list + Caching section
+
+**Input Contract Decisions**:
+- Parameter names: snake_case at MCP boundary (`start_time`, `end_time`, `include_test_ids`, `exclude_test_ids`); convert to camelCase (`startDate`, etc.) in POST body.
+- Accept `str | int` timestamps; normalize via `normalize_timestamp()` → epoch ms (for cache-key stability + validation), then convert back to ISO 8601 UTC (`Z` suffix) via `convert_epoch_to_datetime()` for the API body.
+- `start_time` and `end_time` both **required**.
+- Response: return full payload by default (small size; supports both summarized + raw needs).
+
+**Risks & Edge Cases**:
+- Empty/frozen peer snapshot on staging/private-dev → surface `snapshotMonth` / `dataThroughDate` transparently; emit `hint_to_agent` if peer/industry scores absent.
+- Invalid date range / permission errors → rely on API `raise_for_status()`; log + re-raise clean error.
+- `include_test_ids` vs `exclude_test_ids` mutual exclusivity — treated as open question; default to pass-through (let API validate).
+- Cache key must include: console + startDate + endDate + sorted include/exclude lists.
+- `totalSimulations` exists on customerScore only.
+- `customAttackIdsFiltered` auto-handled server-side — document in docstring.
+
+**Dependencies**: Upstream API (SAF-27621) must be deployed on target console for E2E. No new Python deps; reuses `SB_MCP_CACHE_DATA`.
+
+**Non-Goals**: NL intent parsing (MCP client's job); new datetime helpers; explainability computed locally.
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/manual-tests.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/manual-tests.md
@@ -1,0 +1,130 @@
+# Manual Test Plan — Peer Benchmark Score MCP Tool (SAF-29415)
+
+> Generated from PRD: `prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md`
+> Branch: `saf-29415-add-peer-benchmark-to-data-mcp`
+> Date: 2026-04-13
+
+## Context for the Tester
+
+Automated coverage on this branch:
+- **36 unit tests** (10 transform + 16 business logic + 10 MCP wrapper) cover Python-side
+  contracts: rename mapping, HTTP body shape, ISO conversion, cache behavior, hint composition,
+  204 handling, mutual exclusivity, token-leak in `logger.error` format strings, FastMCP tool
+  registration via `list_tools()`.
+- **1 E2E smoke** (`@pytest.mark.e2e`, `peer_benchmark_e2e_console` fixture) verified live against
+  `staging.sbops.com` (customer 0.80 vs all-peers 0.53).
+
+The cases below cover what those tests structurally **cannot** verify — LLM behavior, MCP
+transport boundary, real-server log rendering, and the in-console / desktop UX surface called
+out in the ticket DOD.
+
+---
+
+## Tier 1: Direct Mission Critical
+
+- [ ] **T1.1 — Claude Desktop tool surface (transport boundary)** | Risk: High
+  - **Why**: Unit tests verify the tool registers Python-side via `list_tools()`. Manual
+    must confirm it survives the `mcp-remote` / SSE / streamable-http transport into Claude
+    Desktop and is invokable from there.
+  - **Steps**:
+    1. Start the data server locally: `uv run -m safebreach_mcp_data.data_server`.
+    2. Confirm `safebreach-data` (or your equivalent) entry exists in
+       `/Library/Application Support/Claude/claude_desktop_config.json` (see CLAUDE.md
+       § Claude Desktop Integration).
+    3. Restart Claude Desktop; in a fresh chat, type
+       *"What tools do you have for SafeBreach?"*.
+  - **Expected**: `get_peer_benchmark_score` appears in the listed tools with a description
+    derived from the PRD-mandated docstring (peers-vs-industry paragraph included).
+
+- [ ] **T1.2 — Console AI chat (ticket DOD)** | Risk: High
+  - **Why**: The ticket DOD explicitly requires the tool be accessible from the console AI
+    chat, not just Claude Desktop. Different MCP host; different transport plumbing.
+  - **Steps**:
+    1. Open the SafeBreach console AI chat (in an environment where the data MCP is wired in
+       and the `/score` endpoint is deployed — i.e., `staging.sbops.com` today).
+    2. Ask: *"How does my security posture compare to my peers last month?"*.
+  - **Expected**: The chat invokes `get_peer_benchmark_score` with a sane 30-day window,
+    receives the response, and produces a coherent narrative referencing customer score,
+    all-peers score, and (if any) the customer's industry score.
+
+- [ ] **T1.3 — LLM peers-vs-industry disambiguation** | Risk: High
+  - **Why**: The docstring is the **only** signal the LLM has to distinguish
+    `all_peers_score` (cross-industry mean) from `customer_industry_scores` (own-industry only,
+    not overridable). Unit tests verify the field names; manual verifies the LLM actually
+    reasons about them correctly when the user asks ambiguous follow-ups.
+  - **Steps** (in either Claude Desktop or console AI chat):
+    1. Run a successful query first (e.g., last 30 days).
+    2. Follow up with: *"Are these peer scores from companies in my industry?"*.
+    3. Then: *"Can I change my industry filter?"*.
+  - **Expected**:
+    - Step 2: LLM correctly explains `all_peers_score` is across **all** SafeBreach customers
+      regardless of industry, and `customer_industry_scores` is scoped to the customer's own
+      industry only.
+    - Step 3: LLM correctly says it can't be overridden — it's determined server-side by a
+      Salesforce industry mapping.
+
+---
+
+## Tier 2: Immediate Neighbors
+
+- [ ] **T2.1 — Cross-tool composition with utilities server** | Risk: Medium | Why:
+  utilities-server feeds epoch values into this tool when the user asks in natural-language
+  date terms ("last month", "Q1"). Unit tests verify the math in isolation; this verifies the
+  agent flow.
+  - **Steps**: In the same MCP client, ask: *"Show benchmark scores for January 1 through
+    January 31, 2026."*.
+  - **Expected**: The agent calls `convert_datetime_to_epoch` (utilities, port 8002) twice,
+    then `get_peer_benchmark_score` with those epoch values; result echoes
+    `start_date: 2026-01-01...` and `end_date: 2026-01-31...`.
+
+- [ ] **T2.2 — Frozen-snapshot hint surfaces in narrative** | Risk: Medium | Why: The
+  `hint_to_agent` field is the LLM's signal to explain "no peer data" rather than invent
+  numbers. Unit tests verify the hint string content; manual verifies the LLM actually
+  consumes and surfaces it.
+  - **Steps**: On a staging/private-dev console with a frozen peer snapshot, ask:
+    *"Compare my posture to peers last week."*.
+  - **Expected**: The LLM responds explaining no peer data is available for the window
+    (mentions frozen snapshot or staging caveat) — no fabricated peer percentages.
+
+- [ ] **T2.3 — Cache visibility in stats logger** | Risk: Low | Why: Phase 2 added
+    `peer_benchmark_cache`. The 5-min `SafeBreachCache` background task should pick it up.
+  - **Steps**:
+    1. Start data server with `SB_MCP_CACHE_DATA=true uv run -m safebreach_mcp_data.data_server`.
+    2. Trigger two identical tool calls (via Claude Desktop or `curl` through mcp-remote).
+    3. Wait up to 5 min for the cache stats log line.
+  - **Expected**: A log line includes `peer_benchmark` cache stats (size 1, hits ≥ 1).
+
+---
+
+## Tier 3: Ripple Effect
+
+- [ ] **T3.1 — Token leak audit on real server logs (500 path)** | Risk: Low | Why: Test 13
+  asserts no token in `logger.error`'s format string, but real server logs pass through
+  uvicorn / structured logging / SSE wrappers. Cheap eyeball.
+  - **Steps**: Force a 500 (e.g., temporarily point at an invalid `DATA_URL`, or use an
+    expired token), tail the data-server stdout/stderr, trigger one `get_peer_benchmark_score`
+    call.
+  - **Expected**: The error log line carries the console name and URL but NOT the token
+    value; no `Authorization`/`x-apitoken` header value appears anywhere in the captured
+    output.
+
+- [ ] **T3.2 — Pentest01 (endpoint-not-deployed) error UX** | Risk: Medium | Why: As of
+  2026-04-13 `/score` isn't on pentest01 — the default `E2E_CONSOLE` for this repo. Users
+  pointing the tool at pentest01 will get a 404. The error message that bubbles up to the
+  LLM should be intelligible enough for the agent to react gracefully.
+  - **Steps**: Manually invoke the tool against `pentest01.safebreach.com`. Either:
+    - Override `E2E_CONSOLE=pentest01` and run the tool from a Python REPL (bypassing the
+      Phase 4 fixture), or
+    - Configure pentest01 in your client and call the tool from Claude Desktop.
+  - **Expected**: A clean HTTPError surfaces to the agent (status 404 or routing error),
+    no stack trace leak; agent narrative apologizes and suggests trying a different console.
+
+---
+
+Total: 8 tests (3 critical, 3 neighbor, 2 ripple)
+Estimated time: ~14 minutes (3×3 + 3×2 + 2×2 = ~17 min, optimistic 14 if T2.3 cache wait
+overlaps with T1 walkthrough)
+
+**Sequencing tip**: Run T1.1 → T1.2 → T1.3 → T2.2 in one Claude Desktop / console AI chat
+session (they share the same setup); kick off T2.3 cache observation in the background; do
+T2.1 in the same session. Run T3.1 and T3.2 in a separate terminal session afterward.

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -19,10 +19,10 @@
 
 | Field | Value |
 |---|---|
-| **PRD Status** | In Progress |
-| **Last Updated** | 2026-04-13 16:35 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-04-13 16:50 |
 | **Owner** | Yossi Attas (with AI assistance) |
-| **Current Phase** | Phase 4 of 5 complete |
+| **Current Phase** | Complete (5 of 5 phases done) |
 
 ---
 
@@ -297,16 +297,16 @@ sequenceDiagram
 - [x] Mutual exclusivity of include/exclude filters enforced at the MCP boundary (raises `ValueError` before calling the backend).
 
 **Quality Gates**
-- [ ] Unit tests cover all cases listed in Section 8 and pass with `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"`.
+- [x] Unit tests cover all cases listed in Section 8 and pass with `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` (402 passed).
 - [x] One E2E test (`@pytest.mark.e2e`) passes against a real console with benchmark data (verified against `staging.sbops.com`: customer_score 0.80 vs all_peers 0.53).
-- [ ] Full cross-server test suite green: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m "not e2e"`.
-- [ ] No secrets committed; pre-commit hooks pass.
-- [ ] `CLAUDE.md` updated (Data Server tools list + Caching Strategy) so reviewers see the new tool and its cache.
+- [x] Full cross-server test suite green: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m "not e2e"` (604 passed).
+- [x] No secrets committed; pre-commit hooks pass (every commit on this branch passed the `Check for added large files` and secrets scan hooks).
+- [x] `CLAUDE.md` updated (Data Server tools list + Caching Strategy) so reviewers see the new tool and its cache.
 
 **Deployment Readiness**
-- [ ] No feature flag needed; tool is available as soon as merged.
+- [x] No feature flag needed; tool is available as soon as merged.
 - [ ] Validated end-to-end from Claude Desktop (manual smoke) or the console AI chat (per DOD in the ticket).
-- [ ] Rollback: revert the PR; no DB/infra state to unwind.
+- [x] Rollback: revert the PR; no DB/infra state to unwind.
 
 ---
 
@@ -362,7 +362,7 @@ tests belong to which Red-Green-Refactor cycle.
 | Phase 2: Business logic + cache (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 16 tests green; 392-test Data MCP suite green |
 | Phase 3: MCP tool registration (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 wrapper tests green; 402-test Data MCP suite green |
 | Phase 4: E2E test (pinned to staging) | ✅ Complete | 2026-04-13 | (pending commit) | Smoke test added with `peer_benchmark_e2e_console` fixture; verified green against real `staging.sbops.com` |
-| Phase 5: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
+| Phase 5: Docs (CLAUDE.md) | ✅ Complete | 2026-04-13 | (pending commit) | Tools list entry added (item 15); peer_benchmark cache added to Data Server cache line; downstream items renumbered |
 
 Phases 1–3 each follow a Red-Green-Refactor cycle: tests first, then implementation, then cleanup.
 A phase is complete only when its tests are green and no existing tests regressed.
@@ -790,3 +790,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 15:40 | Phase 2 complete — 16 TestPeerBenchmarkFunction tests green; sb_get_peer_benchmark_score function and peer_benchmark_cache (maxsize=3, ttl=600) added to data_functions.py; convert_epoch_to_datetime + get_reduced_peer_benchmark_response wired in; HTTP 204 / null-score hint composition / mutual-exclusivity / ISO conversion / token-leak protection all verified; 392 Data MCP tests pass |
 | 2026-04-13 16:10 | Phase 3 complete — 10 TestPeerBenchmarkToolWrapper tests green; get_peer_benchmark_score MCP tool registered on SafeBreachDataServer with full peers-vs-industry docstring (drives LLM tool selection); wrapper normalizes dates via normalize_timestamp, validates required dates, and delegates to sb_get_peer_benchmark_score by kwargs; new test_data_server.py uses asyncio.run + direct _tool_manager access; 402 Data MCP tests pass |
 | 2026-04-13 16:35 | Phase 4 complete — peer_benchmark_e2e_console fixture added to test_e2e.py (defaults to `staging`, override via PEER_BENCHMARK_E2E_CONSOLE; skips with explanatory message when staging creds missing); TestPeerBenchmarkScoreE2E.test_peer_benchmark_score_e2e smoke test added; verified green against real staging.sbops.com (customer_score 0.80 vs all_peers 0.53, 30-day window); non-e2e suite still 402 green; TODO comment notes follow-up to retire the dedicated fixture once /score lands on pentest01 |
+| 2026-04-13 16:50 | Phase 5 complete — CLAUDE.md updated: get_peer_benchmark_score added at item 15 of Data Server tools list with full peers-vs-industry explainer; downstream Playbook + Utilities tools renumbered (15→16, 16→17, 17→18, 18→19); `peer_benchmark (3/600s)` appended to Data Server cache line. PRD Status set to Complete (5/5 phases done). |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -20,9 +20,9 @@
 | Field | Value |
 |---|---|
 | **PRD Status** | In Progress |
-| **Last Updated** | 2026-04-13 15:40 |
+| **Last Updated** | 2026-04-13 16:10 |
 | **Owner** | Yossi Attas (with AI assistance) |
-| **Current Phase** | Phase 2 of 5 complete |
+| **Current Phase** | Phase 3 of 5 complete |
 
 ---
 
@@ -289,8 +289,8 @@ sequenceDiagram
 ## 7. Definition of Done
 
 **Core Functionality**
-- [ ] `get_peer_benchmark_score` MCP tool registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py`, mirroring the `get_tests_history_tool` pattern.
-- [ ] Tool accepts `console`, `start_date`, `end_date`, `include_test_ids_filter`, `exclude_test_ids_filter` with the types and defaults defined in Component C.
+- [x] `get_peer_benchmark_score` MCP tool registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py`, mirroring the `get_tests_history_tool` pattern.
+- [x] Tool accepts `console`, `start_date`, `end_date`, `include_test_ids_filter`, `exclude_test_ids_filter` with the types and defaults defined in Component C.
 - [x] Business logic function `sb_get_peer_benchmark_score` implemented in `data_functions.py` per Component B.
 - [x] Rename mapping and transform helper implemented in `data_types.py` per Component A.
 - [x] HTTP 204 handled explicitly; null `customer_score` / `all_peers_score` / empty `customer_industry_scores` produce a `hint_to_agent`.
@@ -360,7 +360,7 @@ tests belong to which Red-Green-Refactor cycle.
 |---|---|---|---|---|
 | Phase 1: Rename mapping + transform helper (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 tests green; 376-test Data MCP suite still green |
 | Phase 2: Business logic + cache (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 16 tests green; 392-test Data MCP suite green |
-| Phase 3: MCP tool registration (TDD) | ⏳ Pending | - | - | |
+| Phase 3: MCP tool registration (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 wrapper tests green; 402-test Data MCP suite green |
 | Phase 4: E2E test (pinned to staging) | ⏳ Pending | - | - | |
 | Phase 5: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
 
@@ -788,3 +788,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 14:45 | Restructured to TDD: merged standalone Phase 4 unit tests into Phases 1–3 (Red-Green-Refactor per phase); renumbered E2E → Phase 4 and Docs → Phase 5; rewrote Testing Strategy to describe the TDD flow and allocate test cases per phase |
 | 2026-04-13 15:10 | Phase 1 complete — 10 TestPeerBenchmarkTransform tests green; peer_benchmark_rename_mapping + peer_benchmark_score_field_mapping + peer_benchmark_control_field_mapping dicts and get_reduced_peer_benchmark_response helper added to data_types.py; 376 Data MCP tests still pass |
 | 2026-04-13 15:40 | Phase 2 complete — 16 TestPeerBenchmarkFunction tests green; sb_get_peer_benchmark_score function and peer_benchmark_cache (maxsize=3, ttl=600) added to data_functions.py; convert_epoch_to_datetime + get_reduced_peer_benchmark_response wired in; HTTP 204 / null-score hint composition / mutual-exclusivity / ISO conversion / token-leak protection all verified; 392 Data MCP tests pass |
+| 2026-04-13 16:10 | Phase 3 complete — 10 TestPeerBenchmarkToolWrapper tests green; get_peer_benchmark_score MCP tool registered on SafeBreachDataServer with full peers-vs-industry docstring (drives LLM tool selection); wrapper normalizes dates via normalize_timestamp, validates required dates, and delegates to sb_get_peer_benchmark_score by kwargs; new test_data_server.py uses asyncio.run + direct _tool_manager access; 402 Data MCP tests pass |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -1,0 +1,611 @@
+# Peer Benchmark Score MCP Tool — SAF-29415
+
+## 1. Overview
+
+| Field | Value |
+|---|---|
+| **Title** | Peer Benchmark Score MCP Tool — SAF-29415 |
+| **Task Type** | Feature |
+| **Purpose** | Expose SafeBreach's Peer Benchmark Score API through the Data MCP server so MCP clients (Claude Desktop, the console AI chat) can answer natural-language posture-comparison questions without users having to open the UI. |
+| **Target Consumer** | Internal: SafeBreach console AI-chat users and developer/SE users of Claude Desktop MCP integration. Customer-facing indirectly: end customers querying their own account's benchmark through the AI chat. |
+| **Target Roles (RBAC)** | Any role permitted to call `/api/data/v1/accounts/{id}/score` on the backend — this endpoint has **no endpoint-level RBAC gate** beyond the standard signed-request account auth, so all users in an account can call it (both `viewer` and higher). |
+| **Key Benefits** | (1) Natural-language posture comparison without UI context switch. (2) Parity between the MCP experience and the backend API/UI output. (3) Makes peer benchmark data available to AI-driven workflows (reports, comparative narratives). |
+| **Business Alignment** | Matches SafeBreach's MCP strategy of progressively exposing BAS capabilities to AI agents; completes the data-platform surface for posture analytics. |
+| **Originating Request** | [SAF-29415](https://safebreach.atlassian.net/browse/SAF-29415); upstream API delivered in SAF-27621. |
+
+---
+
+## 1.5 Document Status
+
+| Field | Value |
+|---|---|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-04-13 14:30 |
+| **Owner** | Yossi Attas (with AI assistance) |
+| **Current Phase** | N/A (not yet in implementation) |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution
+
+Add a single new MCP tool, `get_peer_benchmark_score`, to the Data Server (port 8001). The tool wraps the existing backend endpoint `POST /api/data/v1/accounts/{account_id}/score` following the established Data-server layering:
+
+- **`data_types.py`** gains a rename-mapping dictionary and a transform helper that renames the API's camelCase keys to self-explanatory snake_case keys while preserving every semantic value. No score re-computation; no field is dropped.
+- **`data_functions.py`** gains `sb_get_peer_benchmark_score(...)` which validates inputs, checks a new `peer_benchmark_cache` (`SafeBreachCache`, gated by `SB_MCP_CACHE_DATA`), builds the POST body with ISO 8601 UTC dates, calls the backend with `x-apitoken` auth, handles HTTP 204 explicitly, composes a `hint_to_agent` when scores are null/empty, transforms the payload, and caches the result.
+- **`data_server.py`** registers the MCP tool with the same docstring/typing style used by `get_tests_history_tool` and normalizes date inputs via `normalize_timestamp()` before delegating.
+- **Tests** cover the happy path, include-only / exclude-only / both-invalid filters, HTTP 204, null `customerScore` / `peerScore`, and backend 500 error. One E2E smoke test is added.
+- **Docs** in `CLAUDE.md` are updated (Data Server tools list, Caching Strategy section).
+
+### Alternatives Considered
+
+**Alternative A — Strict pass-through (verbatim camelCase)**
+- Pros: zero translation code; precisely matches API/UI output field names.
+- Cons: field names like `customAttackIdsFiltered` and `securityControlCategory` (an array, not a category) are misleading for an LLM consumer. Violates the convention already established by `reduced_test_summary_mapping` at `data_types.py:13-20`.
+- **Rejected**: the parity NFR is about semantic content, not raw field names.
+
+**Alternative B — Aggressive reduction (drop raw, compute summaries)**
+- Pros: very compact response; LLM can answer in one step.
+- Cons: loses the category breakdowns that make peer benchmark useful; violates the "support both summarized and raw" bullet in the ticket description; risk of score drift vs UI.
+- **Rejected**.
+
+**Alternative C — Python `list[str]` for `include_test_ids` / `exclude_test_ids`**
+- Pros: no comma-splitting code.
+- Cons: no other Data-MCP multi-value filter uses a list; breaks convention; cross-transport behavior is inconsistent.
+- **Rejected**.
+
+**Alternative D — Skip caching (every call hits the backend)**
+- Pros: always fresh.
+- Cons: diverges from every other Data MCP tool; an agent iterating on wording re-hits the backend.
+- **Rejected** — peer data updates daily (ETL), 600s TTL is a non-issue.
+
+### Decision Rationale
+
+The chosen solution is the minimum-deviation-from-convention approach. Every decision was made to keep this tool indistinguishable in style from the other Data MCP tools — same layering, same cache pattern, same auth header, same filter-param style, same test conventions. The only new element is explicit HTTP 204 handling and a hint-composition helper, both of which are unavoidable given backend behavior documented in `/Users/yossiattas/projects/data`.
+
+---
+
+## 3. Core Feature Components
+
+### Component A — Rename + Transform Layer (data_types.py, new)
+
+**Purpose** (new code): translates the backend's camelCase response into a self-explanatory snake_case shape without changing values. Callers of `sb_get_peer_benchmark_score` never see backend field names directly.
+
+**Key Features**:
+- A module-level `peer_benchmark_rename_mapping` dict maps every backend key to its MCP-facing key (see Section 4 for the full mapping).
+- A helper `get_reduced_peer_benchmark_response(backend_json, hint=None)` walks the payload, applies the rename mapping at each nested level (top-level → ScoreBreakdown → ControlScore), and returns the transformed dict. If `hint` is provided it's attached at the top as `hint_to_agent`.
+- Handles the edge cases recorded in the context: `customer_score` / `all_peers_score` / `peer_data_through_date` can be `None`; `industry_scores` can be `[]`; `score_unblocked` may be absent inside peer/industry control entries.
+
+### Component B — Business Logic (data_functions.py, new function + new cache)
+
+**Purpose** (new code): orchestrates validation, caching, HTTP call, 204 handling, hint composition, and transformation.
+
+**Key Features**:
+- New module-level cache `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside the existing caches.
+- `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None, exclude_test_ids_filter=None)`:
+  1. Parses the comma-separated filter strings (strip, drop empties).
+  2. Validates mutual exclusivity — raises `ValueError` when both filter lists are non-empty.
+  3. Computes a cache key from console + epoch-ms dates + sorted filter lists; returns cached value if present and caching is enabled.
+  4. Converts epoch-ms dates back to ISO 8601 UTC `Z`-suffixed strings via `convert_epoch_to_datetime()`.
+  5. Builds request body with camelCase keys; only includes `includeTestIds` / `excludeTestIds` when the corresponding list is non-empty.
+  6. Sends `requests.post(url, headers={"x-apitoken": ..., "Content-Type": "application/json"}, json=body, timeout=120)`.
+  7. If response is HTTP 204 → returns the empty-shape result plus a "no executions" hint.
+  8. Otherwise `response.raise_for_status()`; parses JSON.
+  9. Composes `hint_to_agent` based on nullity of `customerScore` / `peerScore` / `industryScores`.
+  10. Runs the transform helper (Component A), caches, returns.
+- Follows the existing `try/except` + `logger.error(...)` pattern; no token leakage.
+
+### Component C — MCP Tool Wrapper (data_server.py, new registration)
+
+**Purpose** (new code): exposes the business logic as an MCP tool and handles the datetime-input flexibility expected by callers.
+
+**Key Features**:
+- Registered via `@self.mcp.tool(name="get_peer_benchmark_score", description=...)` inside `_register_tools()`, mirroring `get_tests_history_tool`.
+- Parameters (snake_case, consistent with existing Data MCP tools):
+  - `console: str = "default"`
+  - `start_date: Optional[str | int]` — required (validated after normalization; either None or invalid raises a clear error).
+  - `end_date: Optional[str | int]` — required.
+  - `include_test_ids_filter: Optional[str] = None`.
+  - `exclude_test_ids_filter: Optional[str] = None`.
+- Normalizes dates via `normalize_timestamp()` before delegating to `sb_get_peer_benchmark_score`.
+- Docstring documents the score formula, custom-attack threshold (`moveId >= 10_000_000`), peer-snapshot semantics, 204 handling, and the hint field.
+
+### Component D — Tests (test_data_functions.py + test_e2e.py, new tests)
+
+**Purpose** (new code): verify the tool end-to-end within the MCP server boundary.
+
+**Key Features**:
+- Unit tests mock `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`.
+- Cases: happy path; include-only filter; exclude-only filter; both-non-empty (expects `ValueError`); epoch-input → ISO conversion; ISO-input pass-through; HTTP 204 → empty shape + hint; 200 with null `customerScore` → hint; 200 with null `peerScore` → hint; 200 with empty `industryScores` → hint; 500 backend error → logged + raised.
+- E2E: one `@pytest.mark.e2e` test using `e2e_console` fixture; skipped without `E2E_CONSOLE`.
+
+### Component E — Docs (CLAUDE.md, updated)
+
+**Purpose** (modification): keep the developer-facing reference in sync.
+
+**Key Features**:
+- Data Server tools list gains an entry for the new tool with a one-line description.
+- Caching Strategy bullet list gains `peer_benchmark — maxsize=3, ttl=600s`.
+
+---
+
+## 4. API Endpoints and Integration
+
+### Existing API Consumed
+
+| Property | Value |
+|---|---|
+| **API Name** | Peer Benchmark Score |
+| **URL** | `POST {DATA_URL}/api/data/v1/accounts/{account_id}/score` |
+| **Source Repository** | `/Users/yossiattas/projects/data` — handler at `src/dashboardApi/api/scoreApi.js`; Swagger in `src/api/dashboardapi.json`; controller at `src/dashboardApi/controller/scoreController.js` |
+| **Headers** | `x-apitoken: <account API token>`, `Content-Type: application/json` |
+| **Auth Model** | Standard signed-request account auth (no endpoint-level RBAC). 401 on auth failure; no 403 expected. |
+
+**Request body (authoritative schema)**:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `startDate` | string, ISO 8601 date-time UTC | Yes | Start of window. Example: `"2026-03-01T00:00:00.000Z"`. |
+| `endDate` | string, ISO 8601 date-time UTC | Yes | End of window. Must be strictly greater than `startDate`. |
+| `includeTestIds` | array of strings | No | planRunIds to restrict scoring to. |
+| `excludeTestIds` | array of strings | No | planRunIds to exclude. |
+
+**Backend validation** (failures return HTTP 400):
+- `startDate` or `endDate` missing → `"startDate and endDate are required"`.
+- `startDate >= endDate` → `"startDate must be before endDate"`.
+- Both `includeTestIds` and `excludeTestIds` non-empty → `"Cannot provide both includeTestIds and excludeTestIds. Omit both to include all tests."`.
+
+**Response (HTTP 200 OK)**:
+
+Top-level `ScoreResponse`:
+
+| Backend field | MCP-facing field | Type | Nullable | Notes |
+|---|---|---|---|---|
+| `startDate` | `start_date` | string | No | Echo of request. |
+| `endDate` | `end_date` | string | No | Echo of request. |
+| `snapshotMonth` | `peer_snapshot_month` | string `YYYY-MM` | No | Backend falls back to `endDate.slice(0,7)` if gateway omits. |
+| `dataThroughDate` | `peer_data_through_date` | string `YYYY-MM-DD` | **Yes** | Null when gateway has no snapshot. |
+| `attackIds` | `attack_ids` | string[] | No | Standard (non-custom) attack IDs queried. |
+| `attackIdsQueried` | `attack_ids_count` | int | No | Count of standard attack IDs. |
+| `customAttackIdsFiltered` | `custom_attacks_filtered_count` | int | No | Count of custom attacks (`moveId >= 10_000_000`) excluded. |
+| `customerScore` | `customer_score` | object | **Yes** | Null when no executions. |
+| `peerScore` | `all_peers_score` | object | **Yes** | Null when gateway lacks `all_industries`. |
+| `industryScores` | `customer_industry_scores` | array | No (can be empty) | Server-side filtered to the customer's **own** industry only (Salesforce mapping; not overridable). Typically length 0 or 1. |
+
+`ScoreBreakdown` (used by `customer_score`, `all_peers_score`, each `customer_industry_scores[]` element):
+
+| Backend field | MCP-facing field | Present in |
+|---|---|---|
+| `score` | `score` | all |
+| `scoreBlocked` | `score_blocked` | all |
+| `scoreDetected` | `score_detected` | all |
+| `scoreUnblocked` | `score_unblocked` | all |
+| `totalSimulations` | `total_simulations` | `customer_score` only |
+| `industry` | `industry_name` | `customer_industry_scores[]` only |
+| `securityControlCategory` | `security_control_breakdown` | all |
+
+`ControlScore` inside `security_control_breakdown[]`:
+
+| Backend field | MCP-facing field | Present in |
+|---|---|---|
+| `name` | `control_category_name` | all |
+| `score` | `score` | all |
+| `scoreBlocked` | `score_blocked` | all |
+| `scoreDetected` | `score_detected` | all |
+| `scoreUnblocked` | `score_unblocked` | `customer_score` breakdowns only |
+
+**Error responses**:
+- HTTP 204 — no executions found OR all matched attacks are custom. Empty body.
+- HTTP 400 — validation failure.
+- HTTP 401 — signed-auth failure.
+- HTTP 500 — Elasticsearch failure or gateway down.
+
+### No New APIs Created
+
+This tool consumes the existing endpoint only; no new backend endpoints are added.
+
+---
+
+## 5. Example Customer Flow
+
+### Primary Scenario — AI Chat Posture Question
+
+1. **Entry**: User in the SafeBreach console AI chat types *"How does my security posture compare to my peers last month?"*.
+2. **Agent planning**: The LLM recognizes the question as a peer-benchmark query and plans a call to `get_peer_benchmark_score`.
+3. **Date derivation**: The agent calls `convert_datetime_to_epoch` (utilities server) twice to compute the epoch-ms for `start_date` / `end_date` for "last month".
+4. **Tool call**: Agent invokes `get_peer_benchmark_score(console="my-console", start_date=<ms>, end_date=<ms>)`.
+5. **Inside the tool** (happy path):
+   - Cache miss.
+   - Dates normalized, converted back to ISO 8601 UTC.
+   - POST to backend with `x-apitoken`.
+   - 200 OK with full `ScoreResponse`.
+   - Rename transform applied.
+   - No hint composed (all fields populated).
+   - Response cached, returned.
+6. **Agent synthesis**: The LLM uses `customer_score.score` vs `all_peers_score.score` and the `security_control_breakdown` arrays to narrate a comparison.
+7. **User sees**: "Your score last month was 0.68 vs a peer average of 0.75. Your biggest gap is in Network Inspection (0.50 vs 0.75). In your industry (Information Technology) the average is 0.69."
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ConsoleChat as Console AI Chat
+    participant Utilities as Utilities MCP (8002)
+    participant Data as Data MCP (8001)
+    participant Backend as SafeBreach data service
+
+    User->>ConsoleChat: "Compare my posture to peers last month"
+    ConsoleChat->>Utilities: convert_datetime_to_epoch(start/end)
+    Utilities-->>ConsoleChat: epoch ms values
+    ConsoleChat->>Data: get_peer_benchmark_score(console, start_date, end_date)
+    Data->>Data: normalize_timestamp → cache check → ISO conversion
+    Data->>Backend: POST /api/data/v1/accounts/{id}/score
+    Backend-->>Data: 200 OK (full ScoreResponse)
+    Data->>Data: rename mapping + hint composition + cache set
+    Data-->>ConsoleChat: transformed response
+    ConsoleChat-->>User: Natural-language comparison
+```
+
+### Alternative Scenarios
+
+- **Empty window**: Backend returns HTTP 204 → tool returns `{start_date, end_date, customer_score: null, all_peers_score: null, customer_industry_scores: [], hint_to_agent: "No executions in the requested window, or all matched attacks were custom (peer benchmark excludes custom attack IDs >= 10_000_000)."}`. Agent explains the situation instead of inventing numbers.
+- **Frozen snapshot (staging/private-dev)**: Backend returns 200 with `peerScore: null` and `industryScores: []` when peer data is unavailable. Tool surfaces hint "No all-peers or customer-industry data for this window; on staging / private-dev environments peer data uses a frozen snapshot."
+- **Both include and exclude provided**: Tool raises `ValueError` before hitting the backend; agent gets a clear message to choose one.
+- **Invalid date range (end <= start)**: Backend returns 400; tool logs and raises; agent apologizes and asks for a valid range.
+
+---
+
+## 6. Non-Functional Requirements
+
+### Code Reuse
+- Reuse `SafeBreachCache`, `is_caching_enabled`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id` (all imported by existing Data MCP functions).
+- Reuse `normalize_timestamp` and `convert_epoch_to_datetime` from `safebreach_mcp_core/datetime_utils.py`.
+- Follow the transform-helper pattern already established in `data_types.py` (`reduced_test_summary_mapping` + mapping functions).
+
+### Security & Compliance
+- **Secrets**: API token fetched via the existing `get_secret_for_console(console)` factory (env var / AWS SSM / Secrets Manager per config); never logged.
+- **Authentication**: backend uses signed-request auth with `x-apitoken`; MCP external connections remain gated by the existing `SAFEBREACH_MCP_AUTH_TOKEN` policy.
+- **RBAC**: endpoint has no endpoint-level RBAC; behavior inherits from signed-request auth. No new RBAC surface is introduced.
+- **Audit Logging**: standard `logger.info` / `logger.error` convention (no token in messages; no PII beyond account id).
+
+### Performance Requirements
+- **Response time target**: interactive (typically < 2s on prod, bounded by backend latency and the 120s `requests.post` timeout).
+- **Throughput**: limited by the single `SafeBreachCache` (`maxsize=3, ttl=600`) and the Data MCP concurrency limit (`SAFEBREACH_MCP_CONCURRENCY_LIMIT`, default 2).
+- **Scalability**: stateless; scales with the existing Data MCP server.
+
+### Technical Constraints
+- **Integration**: consumes the existing backend endpoint only; no new infrastructure.
+- **Tech stack**: Python 3.12+; `requests`, `cachetools`, existing MCP/FastMCP framework.
+- **Backward compatibility**: purely additive — no existing tool or contract changes.
+- **Deployment**: no feature flag required; behavior is gated by the tool existing (off if not registered). Config-level `SB_MCP_CACHE_DATA` already controls caching.
+
+### Monitoring & Observability
+- **Logging**: `logger.info` on fetch start / cache hit / successful transform; `logger.error` with stack on backend failure (no token).
+- **Metrics**: existing `SafeBreachCache` background task logs cache stats every 5 min; new `peer_benchmark` cache will appear automatically.
+- **Activity tracking**: tool invocations are visible in the Data MCP server's standard logs.
+
+---
+
+## 7. Definition of Done
+
+**Core Functionality**
+- [ ] `get_peer_benchmark_score` MCP tool registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py`, mirroring the `get_tests_history_tool` pattern.
+- [ ] Tool accepts `console`, `start_date`, `end_date`, `include_test_ids_filter`, `exclude_test_ids_filter` with the types and defaults defined in Component C.
+- [ ] Business logic function `sb_get_peer_benchmark_score` implemented in `data_functions.py` per Component B.
+- [ ] Rename mapping and transform helper implemented in `data_types.py` per Component A.
+- [ ] HTTP 204 handled explicitly; null `customer_score` / `all_peers_score` / empty `industry_scores` produce a `hint_to_agent`.
+- [ ] Mutual exclusivity of include/exclude filters enforced at the MCP boundary (raises `ValueError` before calling the backend).
+
+**Quality Gates**
+- [ ] Unit tests cover all cases listed in Section 8 and pass with `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"`.
+- [ ] One E2E test (`@pytest.mark.e2e`) passes against a real console with benchmark data.
+- [ ] Full cross-server test suite green: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m "not e2e"`.
+- [ ] No secrets committed; pre-commit hooks pass.
+- [ ] `CLAUDE.md` updated (Data Server tools list + Caching Strategy) so reviewers see the new tool and its cache.
+
+**Deployment Readiness**
+- [ ] No feature flag needed; tool is available as soon as merged.
+- [ ] Validated end-to-end from Claude Desktop (manual smoke) or the console AI chat (per DOD in the ticket).
+- [ ] Rollback: revert the PR; no DB/infra state to unwind.
+
+---
+
+## 8. Testing Strategy
+
+### Unit Testing
+- **Scope**: `sb_get_peer_benchmark_score` (main logic), `get_reduced_peer_benchmark_response` (transform), the wrapper's parameter normalization.
+- **Framework**: `pytest` + `unittest.mock` (same stack as `test_data_functions.py`).
+- **Coverage target**: maintain existing file's baseline.
+- **Key scenarios**:
+  - Happy path with both filters absent.
+  - Include-only filter.
+  - Exclude-only filter.
+  - Both non-empty → raises `ValueError`.
+  - Epoch-ms input for dates → ISO conversion happens correctly in the POST body.
+  - ISO string input for dates → pass through unchanged.
+  - HTTP 204 → empty-shape response + hint.
+  - 200 with `customerScore: null` → hint composed.
+  - 200 with `peerScore: null` → hint composed (all-peers missing).
+  - 200 with `industryScores: []` → hint composed (customer-industry missing).
+  - 500 from backend → `logger.error` called, exception re-raised.
+  - Cache hit: second identical call returns cached value without a second `requests.post`.
+- **Mocks**: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`.
+
+### Integration / E2E Testing
+- **Scope**: tool exercised against a real console with benchmark data.
+- **Test env**: requires `E2E_CONSOLE` env var and valid API token per the existing `e2e_console` fixture.
+- **Assertions**: response has `start_date`, `end_date`, `peer_snapshot_month`, `customer_score` (may be null), `all_peers_score` (may be null), `customer_industry_scores` (list). Do not assert specific numeric scores (data changes).
+
+### Coverage Gaps
+- No UI test (MCP has no UI).
+- Console AI chat integration is validated manually per ticket DOD.
+
+---
+
+## 9. Implementation Phases
+
+### Phase Status Tracking
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|---|---|---|---|---|
+| Phase 1: Rename mapping + transform helper | ⏳ Pending | - | - | |
+| Phase 2: Business logic function + cache | ⏳ Pending | - | - | |
+| Phase 3: MCP tool registration | ⏳ Pending | - | - | |
+| Phase 4: Unit tests | ⏳ Pending | - | - | |
+| Phase 5: E2E test | ⏳ Pending | - | - | |
+| Phase 6: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
+
+### Phase 1 — Rename mapping + transform helper
+
+**Semantic change**: add the data-shape translator in `data_types.py` without wiring it in anywhere.
+
+**Deliverables**: a module-level `peer_benchmark_rename_mapping` dict and a `get_reduced_peer_benchmark_response(backend_json, hint=None)` helper.
+
+**Implementation details**:
+- **What**: define a dict that maps every backend field (top-level, ScoreBreakdown, ControlScore) to its MCP-facing name per Section 4's tables.
+- **Inputs / Outputs** of `get_reduced_peer_benchmark_response`:
+  - Input: `backend_json` (dict returned by the backend; may contain `null` at various levels), optional `hint` string.
+  - Output: dict with the renamed keys; preserves all values verbatim; adds `hint_to_agent` when `hint` is provided.
+- **Algorithm**:
+  1. Build the top-level result dict by iterating the backend payload keys and applying the mapping.
+  2. For `customer_score` / `all_peers_score` / `industry_scores` children, apply the ScoreBreakdown mapping recursively — if the value is `None`, pass `None` through.
+  3. For each `security_control_breakdown[]` element, apply the ControlScore mapping; preserve `score_unblocked` only when present in the source.
+  4. If `hint` is provided and non-empty, attach `result["hint_to_agent"] = hint`.
+- **Error scenarios**: defensive fallthrough — if the backend returns an unexpected shape, log a warning and return the partial result (do not crash). Missing keys are simply skipped (not error'd).
+- **Data flow**: backend JSON → this helper → cache + MCP response.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `safebreach_mcp_data/data_types.py` | Add `peer_benchmark_rename_mapping`, `peer_benchmark_score_field_mapping`, `peer_benchmark_control_field_mapping`; add `get_reduced_peer_benchmark_response`. |
+
+**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` still green (no behavioral change yet).
+
+**Suggested commit**: `feat(data-types): add peer benchmark rename mapping and transform helper (SAF-29415)`
+
+---
+
+### Phase 2 — Business logic function + cache
+
+**Semantic change**: implement `sb_get_peer_benchmark_score` plus the new cache in `data_functions.py`.
+
+**Deliverables**: a new async-compatible function that validates inputs, caches, POSTs to the backend, handles 204, composes hints, and returns the transformed response.
+
+**Implementation details**:
+- **What**: declare `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` alongside the other caches at the top of `data_functions.py`. Import `get_reduced_peer_benchmark_response` from `data_types`.
+- **Function signature**: `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None, exclude_test_ids_filter=None)`.
+- **Inputs**: `console: str`; `start_date: int` (epoch ms, already normalized by the wrapper); `end_date: int`; `include_test_ids_filter` / `exclude_test_ids_filter: Optional[str]` (comma-separated or None).
+- **Output**: dict matching the shape defined in Section 4 (renamed fields) plus optional `hint_to_agent`.
+- **Algorithm**:
+  1. **Parse filters**: for each of the two filter strings, produce a list by splitting on `,` and stripping; empty list when input is None/empty.
+  2. **Validate mutual exclusivity**: if both lists are non-empty, raise `ValueError` with the backend's own message ("Cannot provide both include_test_ids_filter and exclude_test_ids_filter...") for agent clarity.
+  3. **Validate date ordering**: if `start_date >= end_date`, raise `ValueError` ("start_date must be before end_date").
+  4. **Build cache key**: `f"peer_benchmark_{console}_{start_date}_{end_date}_{','.join(sorted(inc))}_{','.join(sorted(exc))}"`.
+  5. **Cache check**: if `is_caching_enabled("data")` and key present, return cached dict.
+  6. **Resolve API config**: `apitoken = get_secret_for_console(console)`; `base_url = get_api_base_url(console, 'data')`; `account_id = get_api_account_id(console)`.
+  7. **Convert dates**: epoch ms → ISO 8601 UTC string via `convert_epoch_to_datetime(ms)["iso_datetime"]`. Both start and end.
+  8. **Build request body**: `{"startDate": ..., "endDate": ...}`; conditionally add `includeTestIds` (when inc non-empty) or `excludeTestIds` (when exc non-empty). Never both — prevented by step 2.
+  9. **POST**: `requests.post(f"{base_url}/api/data/v1/accounts/{account_id}/score", headers={"x-apitoken": apitoken, "Content-Type": "application/json"}, json=body, timeout=120)`.
+  10. **Handle 204**: if `response.status_code == 204`, construct the empty-shape result manually (echo `start_date` / `end_date`, all scores `None`, `customer_industry_scores: []`, `hint_to_agent: "No executions in the requested window, or all matched attacks were custom (peer benchmark excludes custom attack IDs >= 10_000_000)."`), cache and return.
+  11. **Handle other errors**: `response.raise_for_status()` — any HTTPError is logged via `logger.error` and re-raised.
+  12. **Parse JSON**, build a hint string by inspecting `customerScore == null` (no executions), `peerScore == null` (no all-peers data), `industryScores == []` (no customer-industry breakdown — note this is the customer's own industry, not a cross-industry comparison); join with `"; "` and prepend an appropriate summary. If none applies, hint is `None`.
+  13. **Transform**: call `get_reduced_peer_benchmark_response(backend_json, hint=hint)`.
+  14. **Cache set + return**.
+- **Error scenarios**: covered in steps 2, 3, 11 (ValueError; HTTPError). No custom exception class introduced — conforms to existing Data MCP function style.
+- **Data flow**: MCP tool → this function → backend → transform → cache → return.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `safebreach_mcp_data/data_functions.py` | Add `peer_benchmark_cache`; add `sb_get_peer_benchmark_score`; import transform helper. |
+
+**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` — unit tests added in Phase 4 will exercise this. For now, lint passes and the module still imports.
+
+**Suggested commit**: `feat(data-functions): implement sb_get_peer_benchmark_score with caching and 204 handling (SAF-29415)`
+
+---
+
+### Phase 3 — MCP tool registration
+
+**Semantic change**: register the `get_peer_benchmark_score` tool on the Data Server so it's reachable over MCP.
+
+**Deliverables**: a new `@self.mcp.tool(...)` block inside `SafeBreachDataServer._register_tools()` that delegates to `sb_get_peer_benchmark_score`.
+
+**Implementation details**:
+- **What**: new async `get_peer_benchmark_score_tool(console, start_date, end_date, include_test_ids_filter, exclude_test_ids_filter)` that validates + normalizes, then calls the business function.
+- **Inputs / Outputs**: match Component C; output is the dict returned by the business function.
+- **Algorithm**:
+  1. Coerce `start_date` / `end_date` via `normalize_timestamp(value)`; if either becomes `None`, raise `ValueError("start_date and end_date are required")`.
+  2. Delegate: `return sb_get_peer_benchmark_score(console=console, start_date=..., end_date=..., include_test_ids_filter=..., exclude_test_ids_filter=...)`.
+- **Docstring content** (to write — the docstring doubles as the tool's MCP description, so clarity drives how the LLM chooses and interprets the tool):
+  - Purpose statement and API this wraps.
+  - Parameter block with the stock phrase "epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'" for the dates.
+  - Explanation of `include_test_ids_filter` / `exclude_test_ids_filter` (comma-separated, mutually exclusive).
+  - **Explicit peers-vs-industry distinction**: the docstring must state, in its own paragraph, that `all_peers_score` reflects the average across **all** SafeBreach customers regardless of industry (from the backend's `all_industries` bucket), whereas `customer_industry_scores` is an array scoped to the customer's **own** industry only — determined server-side from a Salesforce industry mapping and not overridable by the caller. In practice the array has 0 or 1 elements (empty when no industry data is available).
+  - Explanation of other returned fields: `peer_snapshot_month` (monthly peer snapshot used; peer/industry aggregation is always full-month even when the query window is shorter), `peer_data_through_date` (ETL freshness — may be null), `custom_attacks_filtered_count` (count of custom attacks with `moveId >= 10_000_000` that were auto-excluded from the peer comparison), the `hint_to_agent` field when data is missing.
+  - Score formula: `score = 1.0 * blocked + 0.5 * detected`.
+  - HTTP 204 behavior: if the backend returns no-content (no executions in window, or all matched attacks are custom), the tool returns the empty-shape response plus a `hint_to_agent` — the caller does not need to handle an exception.
+- **Error scenarios**: `ValueError` on missing/invalid dates; `ValueError` on both-filters-non-empty (raised by the business function).
+- **Data flow**: MCP client → tool wrapper → `normalize_timestamp` → `sb_get_peer_benchmark_score` → backend.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `safebreach_mcp_data/data_server.py` | Add `get_peer_benchmark_score_tool` registration and import `sb_get_peer_benchmark_score`. |
+
+**Verification**: start the data server locally and list tools via the MCP client; confirm the new tool appears and a trivial call returns a 400 about missing dates when both are omitted.
+
+**Suggested commit**: `feat(data-server): register get_peer_benchmark_score MCP tool (SAF-29415)`
+
+---
+
+### Phase 4 — Unit tests
+
+**Semantic change**: add unit tests covering all cases in Section 8.
+
+**Deliverables**: a new test class in `safebreach_mcp_data/tests/test_data_functions.py` (or a new file `test_peer_benchmark.py` if preferred by the reviewer — default to extending the existing file to match the repo's pattern).
+
+**Implementation details**:
+- **What**: 12 test methods matching the Key scenarios list. Mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`.
+- **Fixtures**: a `mock_backend_response` fixture returning a realistic payload; a second fixture for a 204 empty response.
+- **Algorithm**: each test patches the imports, calls `sb_get_peer_benchmark_score` with specific arguments, asserts return shape and `hint_to_agent` content; the cache test calls twice and asserts `mock_post.call_count == 1`.
+- **Error scenarios**: `pytest.raises(ValueError)` for both-filters-both-non-empty and invalid date ordering; `pytest.raises(requests.HTTPError)` for the 500 case.
+- **Setup**: `setup_method` clears `peer_benchmark_cache` before each test.
+- **Data flow**: tests → mocked `requests.post` → business function → assertions.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `safebreach_mcp_data/tests/test_data_functions.py` | Add test class for peer benchmark (or new file — decide during implementation). |
+
+**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` all green.
+
+**Suggested commit**: `test(data): add unit tests for sb_get_peer_benchmark_score (SAF-29415)`
+
+---
+
+### Phase 5 — E2E test
+
+**Semantic change**: add one `@pytest.mark.e2e` smoke test pinned to an environment where the backend endpoint is already deployed.
+
+**Deliverables**: a test in `safebreach_mcp_data/tests/test_e2e.py` using a **dedicated local fixture** (not the default `e2e_console` fixture) that resolves to a console where `/api/data/v1/accounts/{id}/score` is live.
+
+**Environment constraint (critical)**:
+- As of 2026-04-13, the `/score` endpoint is deployed on `staging.sbops.com` but **not yet** on `pentest01.safebreach.com`. The default E2E console for this repo is typically `pentest01`, which would cause this E2E test to fail with a 404 (or equivalent routing error) if it simply reused `e2e_console`.
+- Therefore the test must be wired to the `staging` console explicitly, and must skip (not fail) when that console is unreachable or not configured in the local environment.
+
+**Implementation details**:
+- **What**: call `sb_get_peer_benchmark_score` with a 30-day window ending now; assert response has all top-level renamed keys and the scores are either `None` or dicts with the expected sub-keys.
+- **Fixture**: introduce a module-level fixture `peer_benchmark_e2e_console` that resolves as follows:
+  1. Read `PEER_BENCHMARK_E2E_CONSOLE` env var. If set, use it.
+  2. Otherwise default to the literal string `"staging"` (the console key configured in `SAFEBREACH_ENVS_FILE` / `environments_metadata.py` pointing at `staging.sbops.com`).
+  3. If the resolved console is missing from `environments_metadata` or has no credentials in the local environment, `pytest.skip(...)` with a clear message ("Peer Benchmark E2E skipped: endpoint not yet deployed on the default E2E console; set PEER_BENCHMARK_E2E_CONSOLE to a console that has the API live.").
+- **Do NOT** reuse the shared `e2e_console` fixture for this test — the shared fixture points at a console that does not have the endpoint yet, which would cause red CI if the shared fixture were ever wired into CI.
+- **Algorithm**: compute epoch ms for now and (now - 30d); call the function against the resolved console; assert shape; log the hint if any.
+- **Error scenarios**: if the console has no benchmark data at all, the test should still pass because the structured empty shape still satisfies the structural assertions — just log a warning. If the backend route is missing (should not happen on staging but defensive), the test should surface the error clearly rather than pass silently.
+- **Data flow**: test → real staging backend → real transform.
+
+**Follow-up action (tracked in Risks, Section 10)**:
+- When the `/score` endpoint is deployed on `pentest01.safebreach.com`, the follow-up is to remove the dedicated fixture and fall back to the shared `e2e_console` fixture (or keep `PEER_BENCHMARK_E2E_CONSOLE` as a minor override knob and just change its default to whatever the shared default is). A comment at the top of the fixture should explicitly note this follow-up.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `safebreach_mcp_data/tests/test_e2e.py` | Add `peer_benchmark_e2e_console` fixture + `test_peer_benchmark_score_e2e` pinned to staging; include a TODO/follow-up comment about retiring the fixture once pentest01 has the endpoint. |
+
+**Verification**: `source .vscode/set_env.sh && uv run pytest -m "e2e" -v -k peer_benchmark` passes against staging. Without `PEER_BENCHMARK_E2E_CONSOLE` set and no `staging` console configured locally, the test skips with the explanatory message.
+
+**Suggested commit**: `test(data-e2e): add peer benchmark score smoke test pinned to staging (SAF-29415)`
+
+---
+
+### Phase 6 — Docs (CLAUDE.md)
+
+**Semantic change**: update developer documentation to reflect the new tool and cache.
+
+**Deliverables**: two edits in `CLAUDE.md` — tools list entry and cache-size line.
+
+**Implementation details**:
+- **What** (tools list): add an item describing `get_peer_benchmark_score` under the "Data Server (Port 8001)" section with one sentence covering what it does and its filters.
+- **What** (caching): add `peer_benchmark — maxsize=3, ttl=600s` to the "Data Server" bullet list in the Caching Strategy section.
+- **Algorithm**: plain documentation edits.
+
+**Changes**:
+
+| File | Change |
+|---|---|
+| `CLAUDE.md` | Add tools-list entry + caching bullet for `peer_benchmark`. |
+
+**Verification**: rendered Markdown review; no test impact.
+
+**Suggested commit**: `docs: document get_peer_benchmark_score tool and its cache (SAF-29415)`
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `/score` endpoint not yet deployed on `pentest01.safebreach.com` (only on `staging.sbops.com` as of 2026-04-13) | Medium | E2E test pinned to `staging` via a dedicated fixture (see Phase 5); shared `e2e_console` fixture is not reused. Once pentest01 gets the endpoint, follow up by retiring the dedicated fixture. |
+| Backend response schema drift (new fields, renamed fields) | Medium | Transform helper skips unknown keys rather than erroring; E2E catches catastrophic mismatches; PR reviewers familiar with the `data` service double-check schema references. |
+| Backend performance on large date ranges | Low | Interactive use typically requests ≤ 1 month; `timeout=120` prevents indefinite blocking. |
+| `data-insights-gateway` downtime | Low | Backend returns 500; tool logs and raises; agent surfaces the error. No offline fallback needed. |
+| Cache serving slightly stale data (up to 10 min) | Low | Peer data updates daily; 10 min staleness is invisible to users. Cache is off by default (`SB_MCP_CACHE_DATA=false`). |
+| Cache key collision from un-sorted filter lists | Low | Key builder sorts filter lists before concatenation. |
+| Token leakage through logs | Medium | Follow existing convention: `logger.error(...)` with `str(e)` but never the headers dict; unit test asserts token not in error messages. |
+
+### Assumptions Under Question
+- **Account scoping**: the existing `get_api_account_id(console)` returns the correct account for the target console (holds for all existing Data MCP tools). Confirmed by the generic backend URL pattern.
+- **`x-apitoken` header works for this endpoint**: confirmed — same header is used by every other Data MCP tool hitting `/api/data/v1/...`.
+- **ETL / snapshot semantics won't change during implementation**: monitored via SAF-27621 updates; if the response structure changes, Phase 1's rename mapping is the single point to adjust.
+- **Availability**: `/api/data/v1/accounts/{id}/score` is live on `staging.sbops.com` today (2026-04-13) but not yet on `pentest01.safebreach.com`. Unit tests use mocked HTTP and are unaffected. E2E is pinned to staging; see Phase 5 for the fixture.
+
+### Risk Mitigation Strategies
+- Each phase is independently committable and revertable.
+- No infrastructure / DB changes → zero-risk rollback.
+- Cache is opt-in → users can disable to diagnose staleness.
+
+---
+
+## 11. Future Enhancements
+
+- **Time-series benchmark**: a follow-up tool that calls this one over N consecutive months and returns a trend series (useful for "am I improving?").
+- **Industry drill-down tool**: a wrapper that takes an industry name and returns just that industry's breakdown (convenience over the current list).
+- **Score delta helper**: utility that compares two peer benchmark responses (e.g., this month vs last month) and summarizes the deltas.
+- **Pre-computed NL summary**: an optional `include_summary=True` parameter that returns a human-readable 1-paragraph posture summary alongside the raw data. Might be redundant with LLM capabilities — deferred pending signal from AI chat logs.
+
+---
+
+## 12. Executive Summary
+
+**Issue / Feature Description**: SafeBreach's Peer Benchmark Score API is reachable only from the UI today; MCP clients cannot answer "how do I compare to peers?" without direct HTTP calls.
+
+**What Was Built** (planned): a single new Data-server MCP tool, `get_peer_benchmark_score`, that wraps the existing `POST /api/data/v1/accounts/{id}/score` endpoint following every established Data MCP convention — same auth header, same cache pattern, same filter style, same test conventions — plus a rename mapping that gives the LLM consumer self-explanatory snake_case field names.
+
+**Key Technical Decisions**:
+- Pass-through with a rename mapping (not strict verbatim, not aggressive reduction).
+- Full-key caching gated by `SB_MCP_CACHE_DATA`.
+- Comma-separated `_filter` string params for include/exclude test IDs.
+- Mutual-exclusivity validated at the MCP boundary for fast feedback.
+- Explicit HTTP 204 handling with a structured empty-shape response and a contextual `hint_to_agent`.
+
+**Scope Changes**: none vs the ticket; several ambiguities resolved (field rename mapping, 204 semantics, include/exclude validation location).
+
+**Business Value Delivered**: natural-language posture comparison from the AI chat; zero context switch; matches the existing MCP data-surface trajectory.
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|---|---|
+| 2026-04-13 14:00 | PRD created — initial draft |
+| 2026-04-13 14:20 | Renamed `industry_scores` → `customer_industry_scores` for scope clarity; strengthened docstring requirements to include explicit peers-vs-industry distinction |
+| 2026-04-13 14:30 | Phase 5 pinned E2E test to `staging.sbops.com` via dedicated fixture (endpoint not yet deployed on pentest01); added corresponding risk entry |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -19,8 +19,8 @@
 
 | Field | Value |
 |---|---|
-| **PRD Status** | Complete |
-| **Last Updated** | 2026-04-13 16:50 |
+| **PRD Status** | Complete (post-UX-feedback polish applied) |
+| **Last Updated** | 2026-04-13 17:30 |
 | **Owner** | Yossi Attas (with AI assistance) |
 | **Current Phase** | Complete (5 of 5 phases done) |
 
@@ -791,3 +791,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 16:10 | Phase 3 complete — 10 TestPeerBenchmarkToolWrapper tests green; get_peer_benchmark_score MCP tool registered on SafeBreachDataServer with full peers-vs-industry docstring (drives LLM tool selection); wrapper normalizes dates via normalize_timestamp, validates required dates, and delegates to sb_get_peer_benchmark_score by kwargs; new test_data_server.py uses asyncio.run + direct _tool_manager access; 402 Data MCP tests pass |
 | 2026-04-13 16:35 | Phase 4 complete — peer_benchmark_e2e_console fixture added to test_e2e.py (defaults to `staging`, override via PEER_BENCHMARK_E2E_CONSOLE; skips with explanatory message when staging creds missing); TestPeerBenchmarkScoreE2E.test_peer_benchmark_score_e2e smoke test added; verified green against real staging.sbops.com (customer_score 0.80 vs all_peers 0.53, 30-day window); non-e2e suite still 402 green; TODO comment notes follow-up to retire the dedicated fixture once /score lands on pentest01 |
 | 2026-04-13 16:50 | Phase 5 complete — CLAUDE.md updated: get_peer_benchmark_score added at item 15 of Data Server tools list with full peers-vs-industry explainer; downstream Playbook + Utilities tools renumbered (15→16, 16→17, 17→18, 18→19); `peer_benchmark (3/600s)` appended to Data Server cache line. PRD Status set to Complete (5/5 phases done). |
+| 2026-04-13 17:30 | Post-UX-feedback polish (Claude Desktop testing): (1) renamed `score_unblocked` → `score_missed` everywhere (top-level + control entries) — aligns with `missed` simulation-status vocabulary; (2) added always-on top-level `scoring_formula` and `scope_note` fields so the response is self-contained for the agent (no need to carry the formula or peer-snapshot scope asymmetry in-context); (3) sorted `security_control_breakdown[]` alphabetically by `control_category_name` so customer / peer / industry breakdowns can be merged position-wise; (4) neutralized all 4 `hint_to_agent` strings to drop internal infra terms ("staging", "private-dev", "frozen snapshot", `>= 10_000_000`) — they reach end-users verbatim; (5) refactored 204 path to route through `get_reduced_peer_benchmark_response` so metadata applies uniformly. Tests +2 (new sort test + new sanitization test). Total 404 non-e2e + 1 live-verified E2E (customer 0.80 vs all-peers 0.53) green. CLAUDE.md updated. |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -20,9 +20,9 @@
 | Field | Value |
 |---|---|
 | **PRD Status** | In Progress |
-| **Last Updated** | 2026-04-13 15:10 |
+| **Last Updated** | 2026-04-13 15:40 |
 | **Owner** | Yossi Attas (with AI assistance) |
-| **Current Phase** | Phase 1 of 5 complete |
+| **Current Phase** | Phase 2 of 5 complete |
 
 ---
 
@@ -291,10 +291,10 @@ sequenceDiagram
 **Core Functionality**
 - [ ] `get_peer_benchmark_score` MCP tool registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py`, mirroring the `get_tests_history_tool` pattern.
 - [ ] Tool accepts `console`, `start_date`, `end_date`, `include_test_ids_filter`, `exclude_test_ids_filter` with the types and defaults defined in Component C.
-- [ ] Business logic function `sb_get_peer_benchmark_score` implemented in `data_functions.py` per Component B.
+- [x] Business logic function `sb_get_peer_benchmark_score` implemented in `data_functions.py` per Component B.
 - [x] Rename mapping and transform helper implemented in `data_types.py` per Component A.
-- [ ] HTTP 204 handled explicitly; null `customer_score` / `all_peers_score` / empty `industry_scores` produce a `hint_to_agent`.
-- [ ] Mutual exclusivity of include/exclude filters enforced at the MCP boundary (raises `ValueError` before calling the backend).
+- [x] HTTP 204 handled explicitly; null `customer_score` / `all_peers_score` / empty `customer_industry_scores` produce a `hint_to_agent`.
+- [x] Mutual exclusivity of include/exclude filters enforced at the MCP boundary (raises `ValueError` before calling the backend).
 
 **Quality Gates**
 - [ ] Unit tests cover all cases listed in Section 8 and pass with `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"`.
@@ -359,7 +359,7 @@ tests belong to which Red-Green-Refactor cycle.
 | Phase | Status | Completed | Commit SHA | Notes |
 |---|---|---|---|---|
 | Phase 1: Rename mapping + transform helper (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 tests green; 376-test Data MCP suite still green |
-| Phase 2: Business logic + cache (TDD) | ⏳ Pending | - | - | |
+| Phase 2: Business logic + cache (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 16 tests green; 392-test Data MCP suite green |
 | Phase 3: MCP tool registration (TDD) | ⏳ Pending | - | - | |
 | Phase 4: E2E test (pinned to staging) | ⏳ Pending | - | - | |
 | Phase 5: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
@@ -787,3 +787,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 14:30 | Phase 5 pinned E2E test to `staging.sbops.com` via dedicated fixture (endpoint not yet deployed on pentest01); added corresponding risk entry |
 | 2026-04-13 14:45 | Restructured to TDD: merged standalone Phase 4 unit tests into Phases 1–3 (Red-Green-Refactor per phase); renumbered E2E → Phase 4 and Docs → Phase 5; rewrote Testing Strategy to describe the TDD flow and allocate test cases per phase |
 | 2026-04-13 15:10 | Phase 1 complete — 10 TestPeerBenchmarkTransform tests green; peer_benchmark_rename_mapping + peer_benchmark_score_field_mapping + peer_benchmark_control_field_mapping dicts and get_reduced_peer_benchmark_response helper added to data_types.py; 376 Data MCP tests still pass |
+| 2026-04-13 15:40 | Phase 2 complete — 16 TestPeerBenchmarkFunction tests green; sb_get_peer_benchmark_score function and peer_benchmark_cache (maxsize=3, ttl=600) added to data_functions.py; convert_epoch_to_datetime + get_reduced_peer_benchmark_response wired in; HTTP 204 / null-score hint composition / mutual-exclusivity / ISO conversion / token-leak protection all verified; 392 Data MCP tests pass |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -19,10 +19,10 @@
 
 | Field | Value |
 |---|---|
-| **PRD Status** | Draft |
-| **Last Updated** | 2026-04-13 14:45 |
+| **PRD Status** | In Progress |
+| **Last Updated** | 2026-04-13 15:10 |
 | **Owner** | Yossi Attas (with AI assistance) |
-| **Current Phase** | N/A (not yet in implementation) |
+| **Current Phase** | Phase 1 of 5 complete |
 
 ---
 
@@ -292,7 +292,7 @@ sequenceDiagram
 - [ ] `get_peer_benchmark_score` MCP tool registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py`, mirroring the `get_tests_history_tool` pattern.
 - [ ] Tool accepts `console`, `start_date`, `end_date`, `include_test_ids_filter`, `exclude_test_ids_filter` with the types and defaults defined in Component C.
 - [ ] Business logic function `sb_get_peer_benchmark_score` implemented in `data_functions.py` per Component B.
-- [ ] Rename mapping and transform helper implemented in `data_types.py` per Component A.
+- [x] Rename mapping and transform helper implemented in `data_types.py` per Component A.
 - [ ] HTTP 204 handled explicitly; null `customer_score` / `all_peers_score` / empty `industry_scores` produce a `hint_to_agent`.
 - [ ] Mutual exclusivity of include/exclude filters enforced at the MCP boundary (raises `ValueError` before calling the backend).
 
@@ -358,7 +358,7 @@ tests belong to which Red-Green-Refactor cycle.
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |---|---|---|---|---|
-| Phase 1: Rename mapping + transform helper (TDD) | ⏳ Pending | - | - | |
+| Phase 1: Rename mapping + transform helper (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 tests green; 376-test Data MCP suite still green |
 | Phase 2: Business logic + cache (TDD) | ⏳ Pending | - | - | |
 | Phase 3: MCP tool registration (TDD) | ⏳ Pending | - | - | |
 | Phase 4: E2E test (pinned to staging) | ⏳ Pending | - | - | |
@@ -786,3 +786,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 14:20 | Renamed `industry_scores` → `customer_industry_scores` for scope clarity; strengthened docstring requirements to include explicit peers-vs-industry distinction |
 | 2026-04-13 14:30 | Phase 5 pinned E2E test to `staging.sbops.com` via dedicated fixture (endpoint not yet deployed on pentest01); added corresponding risk entry |
 | 2026-04-13 14:45 | Restructured to TDD: merged standalone Phase 4 unit tests into Phases 1–3 (Red-Green-Refactor per phase); renumbered E2E → Phase 4 and Docs → Phase 5; rewrote Testing Strategy to describe the TDD flow and allocate test cases per phase |
+| 2026-04-13 15:10 | Phase 1 complete — 10 TestPeerBenchmarkTransform tests green; peer_benchmark_rename_mapping + peer_benchmark_score_field_mapping + peer_benchmark_control_field_mapping dicts and get_reduced_peer_benchmark_response helper added to data_types.py; 376 Data MCP tests still pass |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -20,7 +20,7 @@
 | Field | Value |
 |---|---|
 | **PRD Status** | Draft |
-| **Last Updated** | 2026-04-13 14:30 |
+| **Last Updated** | 2026-04-13 14:45 |
 | **Owner** | Yossi Attas (with AI assistance) |
 | **Current Phase** | N/A (not yet in implementation) |
 
@@ -312,29 +312,39 @@ sequenceDiagram
 
 ## 8. Testing Strategy
 
-### Unit Testing
-- **Scope**: `sb_get_peer_benchmark_score` (main logic), `get_reduced_peer_benchmark_response` (transform), the wrapper's parameter normalization.
+### TDD Approach (applies to Phases 1–3)
+
+Tests lead implementation. For each code phase:
+
+1. **Red** — write the unit tests for that phase's code first. Run `uv run pytest <scope> -v -m "not e2e"`
+   and confirm the new tests fail for the right reason (import error / missing function / assertion
+   mismatch — not a setup bug).
+2. **Green** — implement the minimum code needed to make those tests pass. Run the suite again and confirm
+   green, plus no regression in the rest of the Data MCP tests.
+3. **Refactor** — tighten naming, extract helpers, improve docstrings. Tests stay green.
+
+Each phase's commit should contain **both** the test file changes and the implementation file changes,
+so the commit alone demonstrates the contract it's introducing.
+
+### Unit Testing — overall allocation
+
 - **Framework**: `pytest` + `unittest.mock` (same stack as `test_data_functions.py`).
-- **Coverage target**: maintain existing file's baseline.
-- **Key scenarios**:
-  - Happy path with both filters absent.
-  - Include-only filter.
-  - Exclude-only filter.
-  - Both non-empty → raises `ValueError`.
-  - Epoch-ms input for dates → ISO conversion happens correctly in the POST body.
-  - ISO string input for dates → pass through unchanged.
-  - HTTP 204 → empty-shape response + hint.
-  - 200 with `customerScore: null` → hint composed.
-  - 200 with `peerScore: null` → hint composed (all-peers missing).
-  - 200 with `industryScores: []` → hint composed (customer-industry missing).
-  - 500 from backend → `logger.error` called, exception re-raised.
-  - Cache hit: second identical call returns cached value without a second `requests.post`.
-- **Mocks**: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`.
+- **Coverage target**: maintain the existing `safebreach_mcp_data` baseline or better.
+- **Shared mocks** (used by Phase 2 + Phase 3 tests): `requests.post`, `get_secret_for_console`,
+  `get_api_base_url`, `get_api_account_id`.
+- **Cache hygiene**: every test class's `setup_method` clears `peer_benchmark_cache` to avoid cross-test
+  leakage.
+
+Test cases are enumerated inside each phase below (Phase 1 / 2 / 3 sections), so it's obvious which
+tests belong to which Red-Green-Refactor cycle.
 
 ### Integration / E2E Testing
 - **Scope**: tool exercised against a real console with benchmark data.
-- **Test env**: requires `E2E_CONSOLE` env var and valid API token per the existing `e2e_console` fixture.
-- **Assertions**: response has `start_date`, `end_date`, `peer_snapshot_month`, `customer_score` (may be null), `all_peers_score` (may be null), `customer_industry_scores` (list). Do not assert specific numeric scores (data changes).
+- **Test env**: dedicated `peer_benchmark_e2e_console` fixture (see Phase 4) — defaults to `staging`;
+  does **not** reuse the shared `e2e_console` fixture while the backend endpoint is not yet on pentest01.
+- **Assertions**: response has `start_date`, `end_date`, `peer_snapshot_month`, `customer_score`
+  (may be null), `all_peers_score` (may be null), `customer_industry_scores` (list). Do not assert
+  specific numeric scores (data changes).
 
 ### Coverage Gaps
 - No UI test (MCP has no UI).
@@ -348,147 +358,313 @@ sequenceDiagram
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |---|---|---|---|---|
-| Phase 1: Rename mapping + transform helper | ⏳ Pending | - | - | |
-| Phase 2: Business logic function + cache | ⏳ Pending | - | - | |
-| Phase 3: MCP tool registration | ⏳ Pending | - | - | |
-| Phase 4: Unit tests | ⏳ Pending | - | - | |
-| Phase 5: E2E test | ⏳ Pending | - | - | |
-| Phase 6: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
+| Phase 1: Rename mapping + transform helper (TDD) | ⏳ Pending | - | - | |
+| Phase 2: Business logic + cache (TDD) | ⏳ Pending | - | - | |
+| Phase 3: MCP tool registration (TDD) | ⏳ Pending | - | - | |
+| Phase 4: E2E test (pinned to staging) | ⏳ Pending | - | - | |
+| Phase 5: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
 
-### Phase 1 — Rename mapping + transform helper
+Phases 1–3 each follow a Red-Green-Refactor cycle: tests first, then implementation, then cleanup.
+A phase is complete only when its tests are green and no existing tests regressed.
 
-**Semantic change**: add the data-shape translator in `data_types.py` without wiring it in anywhere.
+### Phase 1 — Rename mapping + transform helper (TDD)
 
-**Deliverables**: a module-level `peer_benchmark_rename_mapping` dict and a `get_reduced_peer_benchmark_response(backend_json, hint=None)` helper.
+**Semantic change**: add the data-shape translator in `data_types.py`, driven by unit tests written first.
 
-**Implementation details**:
-- **What**: define a dict that maps every backend field (top-level, ScoreBreakdown, ControlScore) to its MCP-facing name per Section 4's tables.
-- **Inputs / Outputs** of `get_reduced_peer_benchmark_response`:
-  - Input: `backend_json` (dict returned by the backend; may contain `null` at various levels), optional `hint` string.
-  - Output: dict with the renamed keys; preserves all values verbatim; adds `hint_to_agent` when `hint` is provided.
-- **Algorithm**:
-  1. Build the top-level result dict by iterating the backend payload keys and applying the mapping.
-  2. For `customer_score` / `all_peers_score` / `industry_scores` children, apply the ScoreBreakdown mapping recursively — if the value is `None`, pass `None` through.
-  3. For each `security_control_breakdown[]` element, apply the ControlScore mapping; preserve `score_unblocked` only when present in the source.
-  4. If `hint` is provided and non-empty, attach `result["hint_to_agent"] = hint`.
-- **Error scenarios**: defensive fallthrough — if the backend returns an unexpected shape, log a warning and return the partial result (do not crash). Missing keys are simply skipped (not error'd).
-- **Data flow**: backend JSON → this helper → cache + MCP response.
+**Deliverables**:
+- A module-level `peer_benchmark_rename_mapping` dict (plus nested `peer_benchmark_score_field_mapping`,
+  `peer_benchmark_control_field_mapping`).
+- A `get_reduced_peer_benchmark_response(backend_json, hint=None)` helper.
+- Unit tests in `safebreach_mcp_data/tests/test_data_types.py` (or extend existing test file in that
+  module if one already exists — otherwise create it).
+
+#### Red — write the tests
+
+Add tests covering the transform helper in isolation. All tests use small inline dict fixtures; no HTTP
+is involved at this layer.
+
+**Test cases (Phase 1 — transform only)**:
+1. **Full-shape happy path** — full backend payload (all fields populated) → asserts every top-level key is
+   renamed per Section 4's tables; nested `customer_score`, `all_peers_score`, each `customer_industry_scores[]`
+   element have all `ScoreBreakdown` fields renamed; each `security_control_breakdown[]` entry has
+   `control_category_name` populated.
+2. **Customer-only `scoreUnblocked` in controls** — customer's `securityControlCategory[]` entries include
+   `scoreUnblocked` and must produce `score_unblocked` in the MCP shape; peer/industry control entries
+   without `scoreUnblocked` must not have the key injected.
+3. **`customerScore: null` pass-through** — input has `customerScore: None` → output has
+   `customer_score: None` (not an empty dict, not missing).
+4. **`peerScore: null` pass-through** — same for `all_peers_score`.
+5. **`industryScores: []` pass-through** — empty array stays as `customer_industry_scores: []`.
+6. **`dataThroughDate: null` pass-through** — output has `peer_data_through_date: None`.
+7. **Hint attached** — calling with `hint="x"` adds `hint_to_agent: "x"` at the top level.
+8. **Hint omitted / empty** — no `hint_to_agent` key present when `hint` is `None` or `""`.
+9. **Unknown top-level key defensive fallthrough** — payload contains a key not in the mapping → helper
+   logs a warning (use `caplog`) and still returns the known fields (not crash).
+10. **`industry` inside each `industryScores[]`** — top-level `industry` field becomes `industry_name`
+    inside each element of `customer_industry_scores`.
+
+Run: `uv run pytest safebreach_mcp_data/tests/test_data_types.py -v` → all new tests FAIL with
+`ImportError` (no helper yet) or `AttributeError`. This is the correct red state.
+
+#### Green — implement
+
+- Define the three mapping dicts at module top.
+- Implement `get_reduced_peer_benchmark_response(backend_json, hint=None)`:
+  1. Iterate known top-level keys, apply the mapping; for unknown keys, `logger.warning(...)` and skip.
+  2. For `customerScore` / `peerScore` children: if `None`, pass `None`; else apply ScoreBreakdown mapping
+     recursively — including the nested `securityControlCategory` → `security_control_breakdown`
+     transformation.
+  3. For `industryScores` elements: apply ScoreBreakdown mapping plus pick up `industry` → `industry_name`.
+  4. Inside each control entry, copy `scoreUnblocked` → `score_unblocked` only if the source key is present.
+  5. Attach `hint_to_agent` when `hint` is truthy.
+
+Re-run tests → all green. Run the broader suite: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"`
+— must stay green (no behavioral change to existing code).
+
+#### Refactor
+
+- Extract per-level helpers (`_rename_score_breakdown`, `_rename_control_entry`) if the main function grows
+  past ~30 lines.
+- Align naming with the existing `data_types.py` helper naming (`get_reduced_*`, `map_*`).
+- Docstrings for each helper; no code-change to the public contract.
 
 **Changes**:
 
 | File | Change |
 |---|---|
-| `safebreach_mcp_data/data_types.py` | Add `peer_benchmark_rename_mapping`, `peer_benchmark_score_field_mapping`, `peer_benchmark_control_field_mapping`; add `get_reduced_peer_benchmark_response`. |
+| `safebreach_mcp_data/data_types.py` | Add three mapping dicts + `get_reduced_peer_benchmark_response`. |
+| `safebreach_mcp_data/tests/test_data_types.py` | Add a `TestPeerBenchmarkTransform` class with the 10 test cases above. |
 
-**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` still green (no behavioral change yet).
+**Verification**:
+- `uv run pytest safebreach_mcp_data/tests/test_data_types.py -v` → all green.
+- `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` → still green.
 
-**Suggested commit**: `feat(data-types): add peer benchmark rename mapping and transform helper (SAF-29415)`
+**Suggested commit**: `feat(data-types): add peer benchmark rename mapping and transform helper with unit tests (SAF-29415)`
 
 ---
 
-### Phase 2 — Business logic function + cache
+### Phase 2 — Business logic + cache (TDD)
 
-**Semantic change**: implement `sb_get_peer_benchmark_score` plus the new cache in `data_functions.py`.
+**Semantic change**: implement `sb_get_peer_benchmark_score` plus the new `peer_benchmark_cache` in
+`data_functions.py`, driven by unit tests written first.
 
-**Deliverables**: a new async-compatible function that validates inputs, caches, POSTs to the backend, handles 204, composes hints, and returns the transformed response.
+**Deliverables**:
+- `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside
+  existing caches at module top.
+- `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None,
+  exclude_test_ids_filter=None)` function.
+- Unit tests in `safebreach_mcp_data/tests/test_data_functions.py` under a new
+  `TestPeerBenchmarkFunction` class.
 
-**Implementation details**:
-- **What**: declare `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` alongside the other caches at the top of `data_functions.py`. Import `get_reduced_peer_benchmark_response` from `data_types`.
-- **Function signature**: `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None, exclude_test_ids_filter=None)`.
-- **Inputs**: `console: str`; `start_date: int` (epoch ms, already normalized by the wrapper); `end_date: int`; `include_test_ids_filter` / `exclude_test_ids_filter: Optional[str]` (comma-separated or None).
-- **Output**: dict matching the shape defined in Section 4 (renamed fields) plus optional `hint_to_agent`.
-- **Algorithm**:
-  1. **Parse filters**: for each of the two filter strings, produce a list by splitting on `,` and stripping; empty list when input is None/empty.
-  2. **Validate mutual exclusivity**: if both lists are non-empty, raise `ValueError` with the backend's own message ("Cannot provide both include_test_ids_filter and exclude_test_ids_filter...") for agent clarity.
-  3. **Validate date ordering**: if `start_date >= end_date`, raise `ValueError` ("start_date must be before end_date").
-  4. **Build cache key**: `f"peer_benchmark_{console}_{start_date}_{end_date}_{','.join(sorted(inc))}_{','.join(sorted(exc))}"`.
-  5. **Cache check**: if `is_caching_enabled("data")` and key present, return cached dict.
-  6. **Resolve API config**: `apitoken = get_secret_for_console(console)`; `base_url = get_api_base_url(console, 'data')`; `account_id = get_api_account_id(console)`.
-  7. **Convert dates**: epoch ms → ISO 8601 UTC string via `convert_epoch_to_datetime(ms)["iso_datetime"]`. Both start and end.
-  8. **Build request body**: `{"startDate": ..., "endDate": ...}`; conditionally add `includeTestIds` (when inc non-empty) or `excludeTestIds` (when exc non-empty). Never both — prevented by step 2.
-  9. **POST**: `requests.post(f"{base_url}/api/data/v1/accounts/{account_id}/score", headers={"x-apitoken": apitoken, "Content-Type": "application/json"}, json=body, timeout=120)`.
-  10. **Handle 204**: if `response.status_code == 204`, construct the empty-shape result manually (echo `start_date` / `end_date`, all scores `None`, `customer_industry_scores: []`, `hint_to_agent: "No executions in the requested window, or all matched attacks were custom (peer benchmark excludes custom attack IDs >= 10_000_000)."`), cache and return.
-  11. **Handle other errors**: `response.raise_for_status()` — any HTTPError is logged via `logger.error` and re-raised.
-  12. **Parse JSON**, build a hint string by inspecting `customerScore == null` (no executions), `peerScore == null` (no all-peers data), `industryScores == []` (no customer-industry breakdown — note this is the customer's own industry, not a cross-industry comparison); join with `"; "` and prepend an appropriate summary. If none applies, hint is `None`.
-  13. **Transform**: call `get_reduced_peer_benchmark_response(backend_json, hint=hint)`.
-  14. **Cache set + return**.
-- **Error scenarios**: covered in steps 2, 3, 11 (ValueError; HTTPError). No custom exception class introduced — conforms to existing Data MCP function style.
-- **Data flow**: MCP tool → this function → backend → transform → cache → return.
+#### Red — write the tests
+
+All tests mock `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`.
+`setup_method` clears `peer_benchmark_cache`. Fixtures: `happy_backend_response` (full payload),
+`null_customer_response`, `null_peer_response`, `empty_industry_response` (each derived from the real
+backend shape).
+
+**Test cases (Phase 2 — business logic only)**:
+
+1. **Happy path, no filters** — both filter strings `None`. Asserts:
+   - `requests.post` called once with correct URL pattern `.../accounts/<id>/score`.
+   - Headers contain `x-apitoken` (not Bearer) and `Content-Type: application/json`.
+   - Request body has `startDate` / `endDate` in ISO 8601 UTC `Z` format; no `includeTestIds` /
+     `excludeTestIds` keys.
+   - `timeout=120` passed to `requests.post`.
+   - Return value matches the transformed shape (renamed keys).
+2. **Include-only filter** — `include_test_ids_filter="a, b , c"`. Request body contains
+   `includeTestIds=["a","b","c"]` (trimmed); no `excludeTestIds` key.
+3. **Exclude-only filter** — mirror of test 2 for `excludeTestIds`.
+4. **Mutual exclusivity** — both filters non-empty → `pytest.raises(ValueError)`; `requests.post` never
+   called.
+5. **Empty filter strings treated as absent** — `include_test_ids_filter=""` and
+   `exclude_test_ids_filter=None` → body has no filter keys.
+6. **Date ordering validation** — `start_date >= end_date` → `pytest.raises(ValueError)`; `requests.post`
+   never called.
+7. **Epoch → ISO conversion** — pass epoch ms integers; assert body's `startDate` / `endDate` end with `Z`.
+8. **HTTP 204 handling** — mocked response `status_code == 204` with empty body. Asserts:
+   - Function does **not** raise.
+   - Return dict has `customer_score: None`, `all_peers_score: None`,
+     `customer_industry_scores: []`, and a `hint_to_agent` mentioning "no executions" or "custom".
+9. **Null customerScore** — 200 with `customerScore: null`. `hint_to_agent` contains a substring
+   explaining no executions.
+10. **Null peerScore** — 200 with `peerScore: null`. `hint_to_agent` mentions all-peers data missing.
+11. **Empty industryScores** — 200 with `industryScores: []`. `hint_to_agent` mentions
+    customer-industry missing.
+12. **Composed hint** — 200 with both `peerScore: null` AND `industryScores: []`. `hint_to_agent`
+    contains both fragments joined (e.g., via `"; "`).
+13. **500 backend error** — mocked `response.raise_for_status()` raises `HTTPError`. Asserts:
+    - `logger.error` called (verified via `caplog`).
+    - The `HTTPError` propagates to the caller.
+    - The error log does **not** contain the API token string (security regression test).
+14. **Cache hit** — caching enabled; call the function twice with identical args. `requests.post` called
+    exactly once; second return value equals the first.
+15. **Cache disabled** — `is_caching_enabled("data")` patched to `False`. Two identical calls →
+    `requests.post.call_count == 2`.
+16. **Cache-key order-independence** — caching enabled; call once with `include_test_ids_filter="b,a"`,
+    then with `"a,b"`. Second call hits cache (key built from sorted list).
+
+Run: `uv run pytest safebreach_mcp_data/tests/test_data_functions.py::TestPeerBenchmarkFunction -v` →
+all FAIL (no function yet). Correct red state.
+
+#### Green — implement
+
+- Declare `peer_benchmark_cache` at module top alongside existing caches.
+- Import `get_reduced_peer_benchmark_response` from `.data_types`.
+- Implement `sb_get_peer_benchmark_score`:
+  1. Parse both filter strings via `[v.strip() for v in s.split(",") if v.strip()]`; `None` / empty → `[]`.
+  2. If both lists non-empty, raise `ValueError("Cannot provide both include_test_ids_filter and
+     exclude_test_ids_filter. Omit both to include all tests.")`.
+  3. If `start_date >= end_date`, raise `ValueError("start_date must be before end_date.")`.
+  4. Build cache key: sorted filter lists joined by `","`.
+  5. If `is_caching_enabled("data")` and key present → return cached dict.
+  6. Resolve API config (token, base URL, account id).
+  7. Convert epoch ms → ISO 8601 UTC `Z` strings via `convert_epoch_to_datetime(ms)["iso_datetime"]`.
+  8. Build body `{"startDate": ..., "endDate": ...}`; conditionally add `includeTestIds` or
+     `excludeTestIds` when its list is non-empty.
+  9. `requests.post(url, headers={...}, json=body, timeout=120)`.
+  10. If `response.status_code == 204`: build empty-shape result + 204-hint; cache; return.
+  11. `response.raise_for_status()` inside `try/except`; on failure, `logger.error(...)` (message must
+      not contain the token value); re-raise.
+  12. Parse JSON; inspect `customerScore` / `peerScore` / `industryScores` and compose hint from
+      applicable fragments joined with `"; "`.
+  13. Call `get_reduced_peer_benchmark_response(backend_json, hint=hint)`.
+  14. Cache (if enabled); return.
+
+Re-run tests → all green. Run the broader suite: `uv run pytest safebreach_mcp_data/tests/ -v -m
+"not e2e"` — still green.
+
+#### Refactor
+
+- If the body-building logic grows, extract a `_build_score_request_body(...)` helper inside the module
+  (private).
+- Extract the 204-empty-shape literal into a module-level constant or helper for reuse by tests and
+  implementation.
+- Improve log messages; ensure they include the console name but never the token.
 
 **Changes**:
 
 | File | Change |
 |---|---|
 | `safebreach_mcp_data/data_functions.py` | Add `peer_benchmark_cache`; add `sb_get_peer_benchmark_score`; import transform helper. |
+| `safebreach_mcp_data/tests/test_data_functions.py` | Add `TestPeerBenchmarkFunction` class with the 16 test cases above. |
 
-**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` — unit tests added in Phase 4 will exercise this. For now, lint passes and the module still imports.
+**Verification**:
+- `uv run pytest safebreach_mcp_data/tests/test_data_functions.py::TestPeerBenchmarkFunction -v` → all green.
+- `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` → still green.
 
-**Suggested commit**: `feat(data-functions): implement sb_get_peer_benchmark_score with caching and 204 handling (SAF-29415)`
+**Suggested commit**: `feat(data-functions): implement sb_get_peer_benchmark_score with caching, 204 handling, and unit tests (SAF-29415)`
 
 ---
 
-### Phase 3 — MCP tool registration
+### Phase 3 — MCP tool registration (TDD)
 
-**Semantic change**: register the `get_peer_benchmark_score` tool on the Data Server so it's reachable over MCP.
+**Semantic change**: register `get_peer_benchmark_score` on the Data Server as a thin wrapper over
+`sb_get_peer_benchmark_score`, driven by unit tests for the wrapper's contract.
 
-**Deliverables**: a new `@self.mcp.tool(...)` block inside `SafeBreachDataServer._register_tools()` that delegates to `sb_get_peer_benchmark_score`.
+**Deliverables**:
+- A new `@self.mcp.tool(name="get_peer_benchmark_score", ...)` block inside
+  `SafeBreachDataServer._register_tools()`.
+- Import of `sb_get_peer_benchmark_score` into `data_server.py`.
+- Unit tests exercising the wrapper's normalization / validation / delegation contract.
 
-**Implementation details**:
-- **What**: new async `get_peer_benchmark_score_tool(console, start_date, end_date, include_test_ids_filter, exclude_test_ids_filter)` that validates + normalizes, then calls the business function.
-- **Inputs / Outputs**: match Component C; output is the dict returned by the business function.
-- **Algorithm**:
-  1. Coerce `start_date` / `end_date` via `normalize_timestamp(value)`; if either becomes `None`, raise `ValueError("start_date and end_date are required")`.
-  2. Delegate: `return sb_get_peer_benchmark_score(console=console, start_date=..., end_date=..., include_test_ids_filter=..., exclude_test_ids_filter=...)`.
-- **Docstring content** (to write — the docstring doubles as the tool's MCP description, so clarity drives how the LLM chooses and interprets the tool):
+#### Red — write the tests
+
+Wrapper tests focus on (a) datetime normalization, (b) required-field validation, (c) delegation.
+They mock `sb_get_peer_benchmark_score` (the business function) directly so this layer's tests do not
+re-prove Phase 2 behavior.
+
+Tests live in `safebreach_mcp_data/tests/test_data_server.py` under a new
+`TestPeerBenchmarkToolWrapper` class (create the file if it doesn't exist — follow the existing pattern
+used by other server-level tests if present; otherwise use a lightweight `pytest.fixture` that
+instantiates `SafeBreachDataServer` and resolves the registered tool via `mcp.list_tools()` or by
+invoking the registered function directly through the server instance).
+
+**Test cases (Phase 3 — wrapper only)**:
+
+1. **Tool is registered** — after instantiating `SafeBreachDataServer`, `get_peer_benchmark_score`
+   appears in the list of registered MCP tools with the expected name.
+2. **Epoch input normalization** — calling the wrapper with `start_date=1700000000`,
+   `end_date=1702592000` → the mocked `sb_get_peer_benchmark_score` is called with both args
+   normalized to epoch milliseconds.
+3. **ISO input normalization** — calling with `start_date="2026-03-01T00:00:00Z"`,
+   `end_date="2026-03-31T23:59:59Z"` → business function receives the equivalent epoch-ms ints.
+4. **Missing `start_date` raises** — `start_date=None` (or omitted / empty string) →
+   `pytest.raises(ValueError)` matching "start_date and end_date are required"; business function
+   never called.
+5. **Missing `end_date` raises** — same as above for `end_date`.
+6. **Invalid `start_date` string raises** — passing a non-parseable string → `normalize_timestamp`
+   returns `None`, wrapper raises `ValueError`; business function never called.
+7. **Filters pass through** — `include_test_ids_filter="a,b"`, `exclude_test_ids_filter=None` are
+   forwarded to the business function unchanged.
+8. **Console default** — when `console` is not provided, the business function is called with
+   `console="default"`.
+9. **Return value pass-through** — the wrapper returns exactly what the business function returned
+   (identity test with a sentinel dict).
+10. **ValueError from business function propagates** — when the mocked business function raises
+    `ValueError` (e.g., mutual exclusivity), the wrapper surfaces the same exception unchanged.
+
+Run: `uv run pytest safebreach_mcp_data/tests/test_data_server.py::TestPeerBenchmarkToolWrapper -v` →
+all FAIL until the tool is registered. Correct red state.
+
+#### Green — implement
+
+- Import `sb_get_peer_benchmark_score` in `data_server.py`.
+- Inside `_register_tools()`, register the tool:
+  1. Async function `get_peer_benchmark_score_tool(console="default", start_date=None, end_date=None,
+     include_test_ids_filter=None, exclude_test_ids_filter=None)`.
+  2. Normalize both dates via `normalize_timestamp(value)`.
+  3. If either is `None` after normalization, raise `ValueError("start_date and end_date are required")`.
+  4. Delegate: `return sb_get_peer_benchmark_score(console=console, start_date=..., end_date=...,
+     include_test_ids_filter=..., exclude_test_ids_filter=...)`.
+- Docstring (doubles as the MCP tool description and drives LLM tool-selection):
   - Purpose statement and API this wraps.
-  - Parameter block with the stock phrase "epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'" for the dates.
-  - Explanation of `include_test_ids_filter` / `exclude_test_ids_filter` (comma-separated, mutually exclusive).
-  - **Explicit peers-vs-industry distinction**: the docstring must state, in its own paragraph, that `all_peers_score` reflects the average across **all** SafeBreach customers regardless of industry (from the backend's `all_industries` bucket), whereas `customer_industry_scores` is an array scoped to the customer's **own** industry only — determined server-side from a Salesforce industry mapping and not overridable by the caller. In practice the array has 0 or 1 elements (empty when no industry data is available).
-  - Explanation of other returned fields: `peer_snapshot_month` (monthly peer snapshot used; peer/industry aggregation is always full-month even when the query window is shorter), `peer_data_through_date` (ETL freshness — may be null), `custom_attacks_filtered_count` (count of custom attacks with `moveId >= 10_000_000` that were auto-excluded from the peer comparison), the `hint_to_agent` field when data is missing.
+  - Parameter block with the stock phrase "epoch ms/seconds or ISO 8601 string, e.g.
+    '2026-03-01T00:00:00Z'" for the dates.
+  - Explanation of `include_test_ids_filter` / `exclude_test_ids_filter` (comma-separated, mutually
+    exclusive).
+  - **Explicit peers-vs-industry distinction** (dedicated paragraph): `all_peers_score` reflects the
+    average across **all** SafeBreach customers regardless of industry (from the backend's
+    `all_industries` bucket); `customer_industry_scores` is an array scoped to the customer's **own**
+    industry only — determined server-side from a Salesforce industry mapping and not overridable by
+    the caller. In practice the array has 0 or 1 elements.
+  - Other fields: `peer_snapshot_month` (full-month peer snapshot used for comparison — peer/industry
+    aggregation is always full-month even when the query window is shorter), `peer_data_through_date`
+    (ETL freshness — may be null), `custom_attacks_filtered_count` (count of custom attacks with
+    `moveId >= 10_000_000` that were auto-excluded from the peer comparison), the `hint_to_agent`
+    field when data is missing.
   - Score formula: `score = 1.0 * blocked + 0.5 * detected`.
-  - HTTP 204 behavior: if the backend returns no-content (no executions in window, or all matched attacks are custom), the tool returns the empty-shape response plus a `hint_to_agent` — the caller does not need to handle an exception.
-- **Error scenarios**: `ValueError` on missing/invalid dates; `ValueError` on both-filters-non-empty (raised by the business function).
-- **Data flow**: MCP client → tool wrapper → `normalize_timestamp` → `sb_get_peer_benchmark_score` → backend.
+  - HTTP 204 behavior: if the backend returns no-content (no executions in window, or all matched
+    attacks are custom), the tool returns the empty-shape response plus a `hint_to_agent` — the caller
+    does not need to handle an exception.
+
+Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebreach_mcp_data/tests/ -v
+-m "not e2e"` — still green.
+
+#### Refactor
+
+- Factor out the docstring into a module-level constant if it's noisy, per the pattern used by other
+  Data MCP tools. Ensure the description still renders in MCP tool listings.
+- Minor cleanup (typing, formatting). Tests stay green.
 
 **Changes**:
 
 | File | Change |
 |---|---|
-| `safebreach_mcp_data/data_server.py` | Add `get_peer_benchmark_score_tool` registration and import `sb_get_peer_benchmark_score`. |
+| `safebreach_mcp_data/data_server.py` | Register `get_peer_benchmark_score_tool`; import business function. |
+| `safebreach_mcp_data/tests/test_data_server.py` | Add `TestPeerBenchmarkToolWrapper` class with the 10 test cases above (create file if missing). |
 
-**Verification**: start the data server locally and list tools via the MCP client; confirm the new tool appears and a trivial call returns a 400 about missing dates when both are omitted.
+**Verification**:
+- `uv run pytest safebreach_mcp_data/tests/test_data_server.py::TestPeerBenchmarkToolWrapper -v` → green.
+- `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` → still green.
+- Manually start the data server: `uv run -m safebreach_mcp_data.data_server` and verify the tool
+  appears in the registered tool list.
 
-**Suggested commit**: `feat(data-server): register get_peer_benchmark_score MCP tool (SAF-29415)`
-
----
-
-### Phase 4 — Unit tests
-
-**Semantic change**: add unit tests covering all cases in Section 8.
-
-**Deliverables**: a new test class in `safebreach_mcp_data/tests/test_data_functions.py` (or a new file `test_peer_benchmark.py` if preferred by the reviewer — default to extending the existing file to match the repo's pattern).
-
-**Implementation details**:
-- **What**: 12 test methods matching the Key scenarios list. Mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`.
-- **Fixtures**: a `mock_backend_response` fixture returning a realistic payload; a second fixture for a 204 empty response.
-- **Algorithm**: each test patches the imports, calls `sb_get_peer_benchmark_score` with specific arguments, asserts return shape and `hint_to_agent` content; the cache test calls twice and asserts `mock_post.call_count == 1`.
-- **Error scenarios**: `pytest.raises(ValueError)` for both-filters-both-non-empty and invalid date ordering; `pytest.raises(requests.HTTPError)` for the 500 case.
-- **Setup**: `setup_method` clears `peer_benchmark_cache` before each test.
-- **Data flow**: tests → mocked `requests.post` → business function → assertions.
-
-**Changes**:
-
-| File | Change |
-|---|---|
-| `safebreach_mcp_data/tests/test_data_functions.py` | Add test class for peer benchmark (or new file — decide during implementation). |
-
-**Verification**: `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"` all green.
-
-**Suggested commit**: `test(data): add unit tests for sb_get_peer_benchmark_score (SAF-29415)`
+**Suggested commit**: `feat(data-server): register get_peer_benchmark_score MCP tool with wrapper unit tests (SAF-29415)`
 
 ---
 
-### Phase 5 — E2E test
+### Phase 4 — E2E test
 
 **Semantic change**: add one `@pytest.mark.e2e` smoke test pinned to an environment where the backend endpoint is already deployed.
 
@@ -524,7 +700,7 @@ sequenceDiagram
 
 ---
 
-### Phase 6 — Docs (CLAUDE.md)
+### Phase 5 — Docs (CLAUDE.md)
 
 **Semantic change**: update developer documentation to reflect the new tool and cache.
 
@@ -553,7 +729,7 @@ sequenceDiagram
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| `/score` endpoint not yet deployed on `pentest01.safebreach.com` (only on `staging.sbops.com` as of 2026-04-13) | Medium | E2E test pinned to `staging` via a dedicated fixture (see Phase 5); shared `e2e_console` fixture is not reused. Once pentest01 gets the endpoint, follow up by retiring the dedicated fixture. |
+| `/score` endpoint not yet deployed on `pentest01.safebreach.com` (only on `staging.sbops.com` as of 2026-04-13) | Medium | E2E test pinned to `staging` via a dedicated fixture (see Phase 4); shared `e2e_console` fixture is not reused. Once pentest01 gets the endpoint, follow up by retiring the dedicated fixture. |
 | Backend response schema drift (new fields, renamed fields) | Medium | Transform helper skips unknown keys rather than erroring; E2E catches catastrophic mismatches; PR reviewers familiar with the `data` service double-check schema references. |
 | Backend performance on large date ranges | Low | Interactive use typically requests ≤ 1 month; `timeout=120` prevents indefinite blocking. |
 | `data-insights-gateway` downtime | Low | Backend returns 500; tool logs and raises; agent surfaces the error. No offline fallback needed. |
@@ -565,7 +741,7 @@ sequenceDiagram
 - **Account scoping**: the existing `get_api_account_id(console)` returns the correct account for the target console (holds for all existing Data MCP tools). Confirmed by the generic backend URL pattern.
 - **`x-apitoken` header works for this endpoint**: confirmed — same header is used by every other Data MCP tool hitting `/api/data/v1/...`.
 - **ETL / snapshot semantics won't change during implementation**: monitored via SAF-27621 updates; if the response structure changes, Phase 1's rename mapping is the single point to adjust.
-- **Availability**: `/api/data/v1/accounts/{id}/score` is live on `staging.sbops.com` today (2026-04-13) but not yet on `pentest01.safebreach.com`. Unit tests use mocked HTTP and are unaffected. E2E is pinned to staging; see Phase 5 for the fixture.
+- **Availability**: `/api/data/v1/accounts/{id}/score` is live on `staging.sbops.com` today (2026-04-13) but not yet on `pentest01.safebreach.com`. Unit tests use mocked HTTP and are unaffected. E2E is pinned to staging; see Phase 4 for the fixture.
 
 ### Risk Mitigation Strategies
 - Each phase is independently committable and revertable.
@@ -609,3 +785,4 @@ sequenceDiagram
 | 2026-04-13 14:00 | PRD created — initial draft |
 | 2026-04-13 14:20 | Renamed `industry_scores` → `customer_industry_scores` for scope clarity; strengthened docstring requirements to include explicit peers-vs-industry distinction |
 | 2026-04-13 14:30 | Phase 5 pinned E2E test to `staging.sbops.com` via dedicated fixture (endpoint not yet deployed on pentest01); added corresponding risk entry |
+| 2026-04-13 14:45 | Restructured to TDD: merged standalone Phase 4 unit tests into Phases 1–3 (Red-Green-Refactor per phase); renumbered E2E → Phase 4 and Docs → Phase 5; rewrote Testing Strategy to describe the TDD flow and allocate test cases per phase |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/prd.md
@@ -20,9 +20,9 @@
 | Field | Value |
 |---|---|
 | **PRD Status** | In Progress |
-| **Last Updated** | 2026-04-13 16:10 |
+| **Last Updated** | 2026-04-13 16:35 |
 | **Owner** | Yossi Attas (with AI assistance) |
-| **Current Phase** | Phase 3 of 5 complete |
+| **Current Phase** | Phase 4 of 5 complete |
 
 ---
 
@@ -298,7 +298,7 @@ sequenceDiagram
 
 **Quality Gates**
 - [ ] Unit tests cover all cases listed in Section 8 and pass with `uv run pytest safebreach_mcp_data/tests/ -v -m "not e2e"`.
-- [ ] One E2E test (`@pytest.mark.e2e`) passes against a real console with benchmark data.
+- [x] One E2E test (`@pytest.mark.e2e`) passes against a real console with benchmark data (verified against `staging.sbops.com`: customer_score 0.80 vs all_peers 0.53).
 - [ ] Full cross-server test suite green: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m "not e2e"`.
 - [ ] No secrets committed; pre-commit hooks pass.
 - [ ] `CLAUDE.md` updated (Data Server tools list + Caching Strategy) so reviewers see the new tool and its cache.
@@ -361,7 +361,7 @@ tests belong to which Red-Green-Refactor cycle.
 | Phase 1: Rename mapping + transform helper (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 tests green; 376-test Data MCP suite still green |
 | Phase 2: Business logic + cache (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 16 tests green; 392-test Data MCP suite green |
 | Phase 3: MCP tool registration (TDD) | ✅ Complete | 2026-04-13 | (pending commit) | 10 wrapper tests green; 402-test Data MCP suite green |
-| Phase 4: E2E test (pinned to staging) | ⏳ Pending | - | - | |
+| Phase 4: E2E test (pinned to staging) | ✅ Complete | 2026-04-13 | (pending commit) | Smoke test added with `peer_benchmark_e2e_console` fixture; verified green against real `staging.sbops.com` |
 | Phase 5: Docs (CLAUDE.md) | ⏳ Pending | - | - | |
 
 Phases 1–3 each follow a Red-Green-Refactor cycle: tests first, then implementation, then cleanup.
@@ -789,3 +789,4 @@ Re-run wrapper tests → all green. Run the broader suite: `uv run pytest safebr
 | 2026-04-13 15:10 | Phase 1 complete — 10 TestPeerBenchmarkTransform tests green; peer_benchmark_rename_mapping + peer_benchmark_score_field_mapping + peer_benchmark_control_field_mapping dicts and get_reduced_peer_benchmark_response helper added to data_types.py; 376 Data MCP tests still pass |
 | 2026-04-13 15:40 | Phase 2 complete — 16 TestPeerBenchmarkFunction tests green; sb_get_peer_benchmark_score function and peer_benchmark_cache (maxsize=3, ttl=600) added to data_functions.py; convert_epoch_to_datetime + get_reduced_peer_benchmark_response wired in; HTTP 204 / null-score hint composition / mutual-exclusivity / ISO conversion / token-leak protection all verified; 392 Data MCP tests pass |
 | 2026-04-13 16:10 | Phase 3 complete — 10 TestPeerBenchmarkToolWrapper tests green; get_peer_benchmark_score MCP tool registered on SafeBreachDataServer with full peers-vs-industry docstring (drives LLM tool selection); wrapper normalizes dates via normalize_timestamp, validates required dates, and delegates to sb_get_peer_benchmark_score by kwargs; new test_data_server.py uses asyncio.run + direct _tool_manager access; 402 Data MCP tests pass |
+| 2026-04-13 16:35 | Phase 4 complete — peer_benchmark_e2e_console fixture added to test_e2e.py (defaults to `staging`, override via PEER_BENCHMARK_E2E_CONSOLE; skips with explanatory message when staging creds missing); TestPeerBenchmarkScoreE2E.test_peer_benchmark_score_e2e smoke test added; verified green against real staging.sbops.com (customer_score 0.80 vs all_peers 0.53, 30-day window); non-e2e suite still 402 green; TODO comment notes follow-up to retire the dedicated fixture once /score lands on pentest01 |

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
@@ -1,0 +1,229 @@
+# Ticket Summary: SAF-29415
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: safebreach-mcp
+
+---
+
+## Current State
+
+**Original Summary**: Add the new Peer Benchmark Score API to the DATA MCP
+
+**Issues Identified in the original ticket**:
+- Parameter names in the description don't align with the Data MCP convention. Existing tools use `start_date`/`end_date` for date windows (`get_tests_history`) and `_filter`-suffixed Optional[str] comma-separated strings for multi-value filters (`playbook_attack_id_filter`, `mitre_technique_filter`). The ticket should spell out the tool's snake_case contract explicitly and how it maps to the API's camelCase.
+- Datetime format is under-specified (API needs ISO 8601 UTC `Z`; Data MCP tools accept epoch **or** ISO and normalize to epoch ms — this tool must additionally convert back to ISO for the body).
+- No mention of the established Data-server layering (`data_types.py` → `data_functions.py` → `data_server.py` → `tests/`) or the `x-apitoken` auth header used by Data APIs.
+- Caching strategy unstated; the project already has a `SafeBreachCache` pattern gated by `SB_MCP_CACHE_DATA` (size convention `maxsize=3, ttl=600` for data tools) that should be reused.
+- No acceptance criteria beyond DOD bullets — missing concrete, testable checks.
+- No note about staging/private-dev frozen peer snapshots or the semantics of `snapshotMonth` / `dataThroughDate` / `customAttackIdsFiltered` (documented in ticket comments but not in the description).
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- **Data server layering confirmed**: `data_types.py` (transforms) → `data_functions.py` (`sb_*` logic + caching + HTTP) → `data_server.py` (`@self.mcp.tool` registration, timestamp normalization) → `tests/`.
+- **HTTP pattern** (confirmed at `safebreach_mcp_data/data_functions.py:658-687`):
+  - URL: `f"{get_api_base_url(console, 'data')}/api/data/v1/accounts/{get_api_account_id(console)}/<endpoint>"`
+  - Header: `{"Content-Type": "application/json", "x-apitoken": apitoken}` (NOT Bearer)
+  - `requests.post(..., timeout=120)` → `response.raise_for_status()`
+- **Caching**: `SafeBreachCache` thread-safe TTLCache; convention for Data tools is `maxsize=3, ttl=600`; gate with `is_caching_enabled("data")`.
+- **Datetime mismatch**: `normalize_timestamp()` produces epoch ms (matches most SafeBreach APIs). Peer Benchmark API takes ISO 8601; use `convert_epoch_to_datetime(ms)["iso_datetime"]` to render back before POSTing.
+- **Tool-registration template**: `get_test_simulations_tool` (`data_server.py:100-137`) — typed Optional params + normalization + delegate.
+- **Test patterns** in `safebreach_mcp_data/tests/` — unit mocks `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; E2E uses `@pytest.mark.e2e` + `e2e_console` fixture.
+- **Relevant files**:
+  - `safebreach_mcp_data/data_server.py`
+  - `safebreach_mcp_data/data_functions.py`
+  - `safebreach_mcp_data/data_types.py`
+  - `safebreach_mcp_data/tests/test_data_functions.py`
+  - `safebreach_mcp_data/tests/test_e2e.py`
+  - `safebreach_mcp_core/datetime_utils.py`
+  - `safebreach_mcp_core/safebreach_cache.py`
+  - `CLAUDE.md`
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The SafeBreach Peer Benchmark Score API (`POST /api/data/v1/accounts/{account_id}/score`, delivered by SAF-27621) returns customer/peer/industry posture scores and security-control-category breakdowns. It is currently only reachable from the UI or directly via HTTP. SAF-29415 adds a Data-server MCP tool that wraps this endpoint so MCP clients (including the console AI chat) can answer natural-language questions like "How does my posture compare to peers last month?".
+
+The task is integration-focused — not a new capability. The tool must slot into the existing Data server patterns (auth, caching, parameter style, error handling) and faithfully surface the API's output, including the metadata fields that explain data freshness (`snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`).
+
+### Impact Assessment
+- **MCP Data server**: new tool, new cache instance, ~+1 API integration. No changes to existing tools.
+- **Docs**: `CLAUDE.md` needs updates to the Data Server tools list and Caching section.
+- **User experience**: unlocks NL queries about benchmark posture; aligns with DOD goal of console AI-chat parity.
+
+### Risks & Edge Cases
+- **Frozen snapshots**: staging / private-dev use a frozen production peer snapshot. Tool must expose `snapshotMonth`/`dataThroughDate` untouched and emit a `hint_to_agent` when peer/industry scores are absent.
+- **Datetime format divergence**: peer benchmark API expects ISO 8601 `Z`-suffixed UTC; normalize input to epoch ms (for cache keys) then re-render to ISO 8601 for the body.
+- **RBAC / permissions**: handle 403s without leaking auth context; standard `raise_for_status()` with logging.
+- **Cache correctness**: key must include console + both dates + sorted `includeTestIds` + sorted `excludeTestIds`.
+- **Response shape quirks**: `totalSimulations` only on `customerScore`; `industryScores` may be empty; per-category `securityControlCategory[]` shape is identical across customer/peer/industry but with different fields populated.
+- **Custom attack filtering**: `customAttackIdsFiltered` is API-side behavior — surface the count in the response and document the reason in the tool docstring.
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+Add `get_peer_benchmark_score` MCP tool to the Data Server wrapping the Peer Benchmark Score API
+
+### Description
+
+**Background**
+SafeBreach's Peer Benchmark Score API (delivered in SAF-27621) exposes `POST /api/data/v1/accounts/{account_id}/score`, returning customer/peer/industry posture scores with security-control-category breakdowns. MCP clients (including the console AI chat) currently cannot query it, forcing users back to the UI. This ticket adds an MCP tool so natural-language posture-comparison queries become possible.
+
+**Technical Context**
+- Target server: **Data Server** (port 8001, `safebreach_mcp_data/`).
+- Existing layering to mirror: `data_types.py` → `data_functions.py` → `data_server.py` → `tests/`.
+- Auth pattern (Data module): `x-apitoken` header (not Bearer); account-scoped URL built from `get_api_base_url(console, 'data')` + `get_api_account_id(console)`.
+- Caching pattern: `SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` gated by `is_caching_enabled("data")`.
+- Datetime handling: accept `str | int` at the MCP boundary; normalize via `normalize_timestamp()` → epoch ms (for validation + cache keys); convert back to ISO 8601 `Z` via `convert_epoch_to_datetime()` before POSTing (API expects ISO).
+
+**API Contract** (upstream SAF-27621)
+- Request: `POST /api/data/v1/accounts/{account_id}/score`
+  - Body: `{startDate, endDate, includeTestIds?, excludeTestIds?}` (ISO 8601 UTC strings; test-ID arrays optional)
+- Response: `{startDate, endDate, snapshotMonth, dataThroughDate, attackIds[], attackIdsQueried, customAttackIdsFiltered, customerScore, peerScore, industryScores[]}`
+  - Each score object has `score`, `scoreBlocked`, `scoreDetected`, `scoreUnblocked`, + `securityControlCategory[]` (customer also has `totalSimulations`)
+  - Score formula: `score = 1.0 * blocked + 0.5 * detected`
+
+**Tool Contract** (MCP-facing — follows Data MCP conventions precisely)
+- Tool name: `get_peer_benchmark_score` (matches `get_*` convention).
+- Parameters (snake_case at MCP boundary, same style/vocabulary as other Data tools):
+  - `console: str = "default"` — SafeBreach console name (identical to all other Data tools)
+  - `start_date: Optional[str | int]` (required) — "epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'" (same docstring phrase as `get_tests_history`). Maps to API `startDate`.
+  - `end_date: Optional[str | int]` (required) — same format. Maps to API `endDate`.
+  - `include_test_ids_filter: Optional[str] = None` — comma-separated planRun IDs to include (mirrors `playbook_attack_id_filter` style). Maps to API `includeTestIds[]`.
+  - `exclude_test_ids_filter: Optional[str] = None` — comma-separated planRun IDs to exclude. Maps to API `excludeTestIds[]`.
+- Internal normalization: `start_date`/`end_date` via `normalize_timestamp()` → epoch ms (for validation + cache keys) → back to ISO 8601 UTC `Z` via `convert_epoch_to_datetime()` for the POST body. Comma-separated ID filters split via `[v.strip() for v in s.split(",") if v.strip()]`.
+- Returns: the full API response, pass-through. Includes a `hint_to_agent` field when peer/industry data is empty (same field name used elsewhere in Data MCP responses for agent guidance).
+- Docstring must explain `snapshotMonth` (peer comparison month), `dataThroughDate` (ETL freshness), `customAttackIdsFiltered` (auto-filtered custom attacks), and the score formula — following the "Detailed parameter docs" format used by existing Data tools.
+
+**Function contract** (business logic):
+- `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None, exclude_test_ids_filter=None)` — mirrors `sb_get_tests_history` style (console first-positional default, Optional filters after).
+- Cache instance: `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` — declared alongside other caches at `data_functions.py` module top.
+- Cache key: `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"` — consistent with existing cache-key patterns.
+- Error handling: `try/except` around `requests.post(..., timeout=120)` + `response.raise_for_status()` + `logger.error(...)` — identical to other Data tools.
+
+**Problem Description**
+- No MCP access to peer benchmark today.
+- API uses camelCase + ISO datetimes, while MCP tools use snake_case + epoch-friendly inputs — the wrapper handles the translation.
+- Staging/private-dev uses a frozen peer snapshot; responses must surface this transparently via `snapshotMonth` / `dataThroughDate`.
+
+**Affected Areas**
+- `safebreach_mcp_data/data_functions.py` — add `sb_get_peer_benchmark_score` + `peer_benchmark_cache`
+- `safebreach_mcp_data/data_server.py` — register `get_peer_benchmark_score` MCP tool
+- `safebreach_mcp_data/data_types.py` — optional shaping helpers (if needed)
+- `safebreach_mcp_data/tests/test_data_functions.py` — unit tests
+- `safebreach_mcp_data/tests/test_e2e.py` — smoke E2E (`@pytest.mark.e2e`)
+- `CLAUDE.md` — Data Server tools list (add item 15, renumber) + Caching Strategy (add `peer_benchmark` cache line)
+
+### Acceptance Criteria
+
+- [ ] New MCP tool `get_peer_benchmark_score` is registered on the Data Server (port 8001) via `@self.mcp.tool(...)` in `data_server.py` — following the exact pattern used by `get_tests_history_tool`.
+- [ ] Tool parameters (snake_case, consistent with existing Data MCP tools): `console: str = "default"`, `start_date: Optional[str | int]` (required), `end_date: Optional[str | int]` (required), `include_test_ids_filter: Optional[str] = None` (comma-separated), `exclude_test_ids_filter: Optional[str] = None` (comma-separated).
+- [ ] `start_date` / `end_date` accept "epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'" — using the identical docstring phrasing as `get_tests_history`.
+- [ ] Wrapper normalizes both dates via `normalize_timestamp()` → epoch ms; business logic converts epoch ms back to ISO 8601 UTC `Z` via `convert_epoch_to_datetime()` before building the POST body.
+- [ ] Business logic calls `POST {get_api_base_url(console, 'data')}/api/data/v1/accounts/{get_api_account_id(console)}/score` with `x-apitoken` header and `timeout=120` — matching the pattern at `data_functions.py:658-687`.
+- [ ] POST body uses camelCase keys: `{startDate, endDate, includeTestIds?, excludeTestIds?}`. Test ID filters split via `[v.strip() for v in s.split(",") if v.strip()]` and only included in the body when non-empty.
+- [ ] Response contains customer/peer/industry scores with `securityControlCategory[]` breakdowns, plus `snapshotMonth`, `dataThroughDate`, `attackIds[]`, `attackIdsQueried`, `customAttackIdsFiltered` (pass-through).
+- [ ] When peer or industry scores are empty, response includes a `hint_to_agent` field explaining the likely cause (frozen snapshot on staging/private-dev, or insufficient data) — same field name used elsewhere in Data MCP.
+- [ ] Response matches the UI/API output exactly (verified via E2E on a console with benchmark data).
+- [ ] New cache `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside existing caches in `data_functions.py`. Cache gated by `is_caching_enabled("data")`. Cache key format: `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"`.
+- [ ] Errors handled with the existing convention: `response.raise_for_status()` inside `try/except`, `logger.error(...)` on failure, no token leakage in logs.
+- [ ] Tool docstring documents all parameters (stock phrasing where possible), `snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`, score formula (`1.0*blocked + 0.5*detected`), and the ISO-datetime contract.
+- [ ] Unit tests in `test_data_functions.py` cover: happy path, include-only filter, exclude-only filter, epoch-input normalization, ISO-input normalization, empty peer/industry → `hint_to_agent`, 403 error, 400 error. Mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`.
+- [ ] One E2E test in `test_e2e.py` (`@pytest.mark.e2e` + `e2e_console` fixture) validates the tool against a real console.
+- [ ] `CLAUDE.md` updated: Data Server tools list gains the new tool; Caching Strategy bullet list gains a `peer_benchmark — maxsize=3, ttl=600s` line.
+- [ ] Tool is accessible from the console AI chat (per DOD).
+
+### Suggested Labels/Components
+- Component: `data-mcp`, `peer-benchmark` (if labels exist)
+- Labels: none required beyond existing ticket labels
+
+---
+
+## Proposed Ticket Content — JIRA Markdown
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+
+SafeBreach's Peer Benchmark Score API (delivered in SAF-27621) exposes `POST /api/data/v1/accounts/{account_id}/score`, returning customer/peer/industry posture scores with security-control-category breakdowns. MCP clients (including the console AI chat) currently cannot query it, forcing users back to the UI. This ticket adds an MCP tool so natural-language posture-comparison queries become possible.
+
+### Technical Context
+
+* Target server: **Data Server** (port 8001, `safebreach_mcp_data/`)
+* Layering to mirror: `data_types.py` → `data_functions.py` → `data_server.py` → `tests/`
+* Auth pattern: `x-apitoken` header (not Bearer); URL built from `get_api_base_url(console, 'data')` + `get_api_account_id(console)`
+* Caching: `SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` gated by `is_caching_enabled("data")`
+* Datetime: accept ISO 8601 or epoch at MCP boundary; normalize via `normalize_timestamp()` → epoch ms (validation + cache keys); convert back to ISO 8601 `Z` via `convert_epoch_to_datetime()` before POSTing (API expects ISO)
+
+### API Contract (upstream SAF-27621)
+
+* Request: `POST /api/data/v1/accounts/{account_id}/score`
+* Request body: `{startDate, endDate, includeTestIds?, excludeTestIds?}` — ISO 8601 UTC strings
+* Response: `{startDate, endDate, snapshotMonth, dataThroughDate, attackIds[], attackIdsQueried, customAttackIdsFiltered, customerScore, peerScore, industryScores[]}`
+* Score fields: `score`, `scoreBlocked`, `scoreDetected`, `scoreUnblocked`, + `securityControlCategory[]` (customer also has `totalSimulations`)
+* Score formula: `score = 1.0 * blocked + 0.5 * detected`
+
+### Tool Contract (MCP-facing — follows Data MCP conventions)
+
+* Tool name: `get_peer_benchmark_score`
+* Parameters (snake_case, consistent with existing Data MCP tools):
+** `console: str = "default"`
+** `start_date: Optional[str | int]` (required) — epoch ms/seconds or ISO 8601 string, e.g. `'2026-03-01T00:00:00Z'`. Maps to API `startDate`
+** `end_date: Optional[str | int]` (required) — same format. Maps to API `endDate`
+** `include_test_ids_filter: Optional[str] = None` — comma-separated planRun IDs. Maps to API `includeTestIds[]` (mirrors `playbook_attack_id_filter` style)
+** `exclude_test_ids_filter: Optional[str] = None` — comma-separated planRun IDs. Maps to API `excludeTestIds[]`
+* Wrapper normalizes dates via `normalize_timestamp()` → epoch ms; business logic converts back to ISO 8601 UTC `Z` via `convert_epoch_to_datetime()` before POSTing
+* Returns: full API response pass-through, plus `hint_to_agent` when peer/industry is empty
+* Docstring explains `snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`, score formula, and ISO-datetime contract
+
+### Function Contract (business logic)
+
+* `sb_get_peer_benchmark_score(console, start_date, end_date, include_test_ids_filter=None, exclude_test_ids_filter=None)` — mirrors `sb_get_tests_history` style
+* New cache: `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` gated by `is_caching_enabled("data")`
+* Cache key: `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"`
+* HTTP: `requests.post(...)` with `x-apitoken` header and `timeout=120` (matches existing Data MCP pattern)
+* Errors: `response.raise_for_status()` + `logger.error(...)` — same convention as other Data tools
+
+### Problem Description
+
+* No MCP access to peer benchmark today
+* API uses camelCase + ISO datetimes; MCP tools use snake_case + epoch-friendly inputs — wrapper handles translation
+* Staging/private-dev uses a frozen peer snapshot; response must surface this via `snapshotMonth` / `dataThroughDate`
+
+### Affected Areas
+
+* `safebreach_mcp_data/data_functions.py` — `sb_get_peer_benchmark_score` + `peer_benchmark_cache`
+* `safebreach_mcp_data/data_server.py` — register `get_peer_benchmark_score` MCP tool
+* `safebreach_mcp_data/data_types.py` — optional shaping helpers
+* `safebreach_mcp_data/tests/test_data_functions.py` — unit tests
+* `safebreach_mcp_data/tests/test_e2e.py` — smoke E2E
+* `CLAUDE.md` — Data Server tools list + Caching section
+```
+
+**Acceptance Criteria:**
+```markdown
+* MCP tool `get_peer_benchmark_score` is registered on the Data Server (port 8001) via `@self.mcp.tool(...)` — following the `get_tests_history_tool` pattern
+* Tool parameters (snake_case, consistent with existing Data MCP tools): `console: str = "default"`, `start_date: Optional[str | int]` (required), `end_date: Optional[str | int]` (required), `include_test_ids_filter: Optional[str] = None` (comma-separated), `exclude_test_ids_filter: Optional[str] = None` (comma-separated)
+* `start_date` / `end_date` accept "epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'" — identical docstring phrasing as `get_tests_history`
+* Wrapper normalizes dates via `normalize_timestamp()` → epoch ms; business logic converts back to ISO 8601 UTC `Z` via `convert_epoch_to_datetime()` before POSTing
+* Business logic calls `POST {base_url}/api/data/v1/accounts/{account_id}/score` with `x-apitoken` header and `timeout=120` (matches `data_functions.py:658-687`)
+* POST body uses camelCase: `{startDate, endDate, includeTestIds?, excludeTestIds?}`; filters split via `[v.strip() for v in s.split(",") if v.strip()]` and only included when non-empty
+* Response contains customer/peer/industry scores with `securityControlCategory[]` breakdowns, plus `snapshotMonth`, `dataThroughDate`, `attackIds[]`, `attackIdsQueried`, `customAttackIdsFiltered` (pass-through)
+* Empty peer/industry scores → response includes `hint_to_agent` explaining the cause (frozen snapshot or insufficient data)
+* Response matches UI/API output exactly (verified via E2E on a console with benchmark data)
+* New cache `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside existing caches; gated by `is_caching_enabled("data")`; key `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"`
+* RBAC (403) and API errors handled via `response.raise_for_status()` inside `try/except` with `logger.error(...)`; no token leakage
+* Tool docstring documents all params, `snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`, score formula (`1.0*blocked + 0.5*detected`), ISO-datetime contract
+* Unit tests in `test_data_functions.py` cover: happy path, include-only, exclude-only, epoch input, ISO input, empty peer/industry hint, 403, 400 — mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; `setup_method` clears `peer_benchmark_cache`
+* One E2E test (`@pytest.mark.e2e` + `e2e_console` fixture) in `test_e2e.py` validates against a real console
+* `CLAUDE.md` updated: Data Server tools list + Caching Strategy adds `peer_benchmark — maxsize=3, ttl=600s` line
+* Tool accessible from console AI chat (per DOD)
+```

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
@@ -136,7 +136,7 @@ SafeBreach's Peer Benchmark Score API (delivered in SAF-27621) exposes `POST /ap
 - [ ] New cache `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside existing caches in `data_functions.py`. Cache gated by `is_caching_enabled("data")`. Cache key format: `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"`.
 - [ ] Errors handled with the existing convention: `response.raise_for_status()` inside `try/except`, `logger.error(...)` on failure, no token leakage in logs.
 - [ ] Tool docstring documents all parameters (stock phrasing where possible), `snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`, score formula (`1.0*blocked + 0.5*detected`), and the ISO-datetime contract.
-- [ ] Unit tests in `test_data_functions.py` cover: happy path, include-only filter, exclude-only filter, epoch-input normalization, ISO-input normalization, empty peer/industry → `hint_to_agent`, 403 error, 400 error. Mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`.
+- [ ] Unit tests in `test_data_functions.py` cover: happy path, include-only filter, exclude-only filter, epoch-input normalization, ISO-input normalization, empty peer/industry → `hint_to_agent`, 403 error, 400 error. Mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`. `setup_method` clears `peer_benchmark_cache`. <!-- pragma: allowlist secret -->
 - [ ] One E2E test in `test_e2e.py` (`@pytest.mark.e2e` + `e2e_console` fixture) validates the tool against a real console.
 - [ ] `CLAUDE.md` updated: Data Server tools list gains the new tool; Caching Strategy bullet list gains a `peer_benchmark — maxsize=3, ttl=600s` line.
 - [ ] Tool is accessible from the console AI chat (per DOD).
@@ -222,7 +222,7 @@ SafeBreach's Peer Benchmark Score API (delivered in SAF-27621) exposes `POST /ap
 * New cache `peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)` declared alongside existing caches; gated by `is_caching_enabled("data")`; key `f"peer_benchmark_{console}_{start_ms}_{end_ms}_{sorted_includes}_{sorted_excludes}"`
 * RBAC (403) and API errors handled via `response.raise_for_status()` inside `try/except` with `logger.error(...)`; no token leakage
 * Tool docstring documents all params, `snapshotMonth`, `dataThroughDate`, `customAttackIdsFiltered`, score formula (`1.0*blocked + 0.5*detected`), ISO-datetime contract
-* Unit tests in `test_data_functions.py` cover: happy path, include-only, exclude-only, epoch input, ISO input, empty peer/industry hint, 403, 400 — mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; `setup_method` clears `peer_benchmark_cache`
+* Unit tests in `test_data_functions.py` cover: happy path, include-only, exclude-only, epoch input, ISO input, empty peer/industry hint, 403, 400 — mocks: `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; `setup_method` clears `peer_benchmark_cache` <!-- pragma: allowlist secret -->
 * One E2E test (`@pytest.mark.e2e` + `e2e_console` fixture) in `test_e2e.py` validates against a real console
 * `CLAUDE.md` updated: Data Server tools list + Caching Strategy adds `peer_benchmark — maxsize=3, ttl=600s` line
 * Tool accessible from console AI chat (per DOD)

--- a/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
+++ b/prds/saf-29415-add-peer-benchmark-to-data-mcp/summary.md
@@ -32,7 +32,7 @@
 - **Caching**: `SafeBreachCache` thread-safe TTLCache; convention for Data tools is `maxsize=3, ttl=600`; gate with `is_caching_enabled("data")`.
 - **Datetime mismatch**: `normalize_timestamp()` produces epoch ms (matches most SafeBreach APIs). Peer Benchmark API takes ISO 8601; use `convert_epoch_to_datetime(ms)["iso_datetime"]` to render back before POSTing.
 - **Tool-registration template**: `get_test_simulations_tool` (`data_server.py:100-137`) — typed Optional params + normalization + delegate.
-- **Test patterns** in `safebreach_mcp_data/tests/` — unit mocks `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; E2E uses `@pytest.mark.e2e` + `e2e_console` fixture.
+- **Test patterns** in `safebreach_mcp_data/tests/` — unit mocks `requests.post`, `get_secret_for_console`, `get_api_base_url`, `get_api_account_id`; E2E uses `@pytest.mark.e2e` + `e2e_console` fixture. <!-- pragma: allowlist secret -->
 - **Relevant files**:
   - `safebreach_mcp_data/data_server.py`
   - `safebreach_mcp_data/data_functions.py`

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -2783,20 +2783,23 @@ def sb_get_simulation_lineage(
 # Peer benchmark score (SAF-29415) — POST /api/data/v1/accounts/{id}/score
 # ------------------------------------------------------------------
 # Hint fragments composed when the backend response indicates partial or
-# missing data. Strings are tuned for natural-language reasoning by the
-# LLM consumer and to the substring assertions in the unit tests.
+# missing data. These strings reach end-users verbatim through the LLM,
+# so they must remain free of internal infra terms (no env names, no
+# implementation constants). They are deliberately phrased for an
+# end-user audience.
 _PEER_BENCHMARK_204_HINT = (
-    "No executions in the requested window, or all matched attacks were "
-    "custom (peer benchmark excludes custom attack IDs >= 10,000,000)."
+    "No comparable executions in the requested window. This may happen when no "
+    "tests ran during the window, or when all matched attacks were "
+    "customer-defined (peer benchmark only compares standard SafeBreach attacks)."
 )
-_PEER_BENCHMARK_NULL_CUSTOMER_HINT = "No customer executions in this window."
+_PEER_BENCHMARK_NULL_CUSTOMER_HINT = (
+    "No customer executions matched the requested window."
+)
 _PEER_BENCHMARK_NULL_PEER_HINT = (
-    "No all-peers data for this window "
-    "(possibly frozen snapshot on staging/private-dev)."
+    "Peer benchmark data is not available for the requested window."
 )
 _PEER_BENCHMARK_EMPTY_INDUSTRY_HINT = (
-    "No customer-industry data for this window "
-    "(possibly frozen snapshot on staging/private-dev)."
+    "Industry benchmark data is not available for the requested window."
 )
 
 
@@ -2893,14 +2896,20 @@ def sb_get_peer_benchmark_score(
     response = requests.post(api_url, headers=headers, json=body, timeout=120)
 
     if response.status_code == 204:
-        result = {
-            "start_date": iso_start,
-            "end_date": iso_end,
-            "customer_score": None,
-            "all_peers_score": None,
-            "customer_industry_scores": [],
-            "hint_to_agent": _PEER_BENCHMARK_204_HINT,
+        # Route the empty-shape response through the transform helper so
+        # always-on metadata (scoring_formula, scope_note) appears uniformly
+        # on both 204 and 200 paths — no duplicated copy of the response
+        # envelope here.
+        empty_payload = {
+            "startDate": iso_start,
+            "endDate": iso_end,
+            "customerScore": None,
+            "peerScore": None,
+            "industryScores": [],
         }
+        result = get_reduced_peer_benchmark_response(
+            empty_payload, hint=_PEER_BENCHMARK_204_HINT,
+        )
         if is_caching_enabled("data"):
             peer_benchmark_cache.set(cache_key, result)
         return result

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -16,6 +16,7 @@ from safebreach_mcp_core.safebreach_cache import SafeBreachCache
 from safebreach_mcp_core.secret_utils import get_secret_for_console
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from safebreach_mcp_core.suggestions import get_suggestions_for_collection
+from safebreach_mcp_core.datetime_utils import convert_epoch_to_datetime
 from .data_types import (
     get_reduced_test_summary_mapping,
     get_reduced_simulation_result_entity,
@@ -23,6 +24,7 @@ from .data_types import (
     get_reduced_security_control_events_mapping,
     get_full_security_control_events_mapping,
     group_and_enrich_drift_records,
+    get_reduced_peer_benchmark_response,
 )
 from .drifts_metadata import drift_types_mapping
 
@@ -33,6 +35,7 @@ tests_cache = SafeBreachCache(name="tests", maxsize=5, ttl=1800)
 simulations_cache = SafeBreachCache(name="simulations", maxsize=3, ttl=600)
 security_control_events_cache = SafeBreachCache(name="security_control_events", maxsize=3, ttl=600)
 simulation_drifts_cache = SafeBreachCache(name="simulation_drifts", maxsize=3, ttl=600)
+peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600)
 
 # Configuration constants
 PAGE_SIZE = 10
@@ -2774,3 +2777,159 @@ def sb_get_simulation_lineage(
         "simulations": page_sims,
         "hint_to_agent": hint,
     }
+
+
+# ------------------------------------------------------------------
+# Peer benchmark score (SAF-29415) — POST /api/data/v1/accounts/{id}/score
+# ------------------------------------------------------------------
+# Hint fragments composed when the backend response indicates partial or
+# missing data. Strings are tuned for natural-language reasoning by the
+# LLM consumer and to the substring assertions in the unit tests.
+_PEER_BENCHMARK_204_HINT = (
+    "No executions in the requested window, or all matched attacks were "
+    "custom (peer benchmark excludes custom attack IDs >= 10,000,000)."
+)
+_PEER_BENCHMARK_NULL_CUSTOMER_HINT = "No customer executions in this window."
+_PEER_BENCHMARK_NULL_PEER_HINT = (
+    "No all-peers data for this window "
+    "(possibly frozen snapshot on staging/private-dev)."
+)
+_PEER_BENCHMARK_EMPTY_INDUSTRY_HINT = (
+    "No customer-industry data for this window "
+    "(possibly frozen snapshot on staging/private-dev)."
+)
+
+
+def sb_get_peer_benchmark_score(
+    console: str,
+    start_date: int,
+    end_date: int,
+    include_test_ids_filter: Optional[str] = None,
+    exclude_test_ids_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fetch the peer benchmark score for the given window via the SafeBreach
+    Data API and return the MCP-shaped response.
+
+    Wraps ``POST /api/data/v1/accounts/{account_id}/score`` (delivered in
+    SAF-27621). Validates inputs at the MCP boundary, caches per-(console,
+    window, sorted filters), converts epoch dates to ISO 8601 UTC for the
+    request body, handles HTTP 204 explicitly, composes a ``hint_to_agent``
+    when scores are null/empty, and runs the response through the Phase 1
+    transform helper.
+
+    Args:
+        console: SafeBreach console name (resolved via environments_metadata).
+        start_date: Epoch milliseconds for the start of the window.
+        end_date: Epoch milliseconds for the end of the window.
+        include_test_ids_filter: Comma-separated planRunIds to restrict
+            scoring to. Mutually exclusive with ``exclude_test_ids_filter``.
+        exclude_test_ids_filter: Comma-separated planRunIds to exclude.
+
+    Returns:
+        Dict with snake_case keys per ``peer_benchmark_rename_mapping``.
+        ``customer_score`` and ``all_peers_score`` may be None;
+        ``customer_industry_scores`` may be []. ``hint_to_agent`` is
+        included when any of those conditions hold or when the backend
+        returns HTTP 204.
+
+    Raises:
+        ValueError: When both filters are non-empty, or when
+            ``start_date >= end_date``.
+        requests.HTTPError: Propagated from the backend on non-2xx
+            responses other than 204.
+    """
+    inc = (
+        [v.strip() for v in include_test_ids_filter.split(",") if v.strip()]
+        if include_test_ids_filter else []
+    )
+    exc = (
+        [v.strip() for v in exclude_test_ids_filter.split(",") if v.strip()]
+        if exclude_test_ids_filter else []
+    )
+
+    if inc and exc:
+        raise ValueError(
+            "Cannot provide both include_test_ids_filter and "
+            "exclude_test_ids_filter. Omit both to include all tests."
+        )
+
+    if start_date >= end_date:
+        raise ValueError("start_date must be before end_date.")
+
+    cache_key = (
+        f"peer_benchmark_{console}_{start_date}_{end_date}_"
+        f"{','.join(sorted(inc))}_{','.join(sorted(exc))}"
+    )
+    if is_caching_enabled("data"):
+        cached = peer_benchmark_cache.get(cache_key)
+        if cached is not None:
+            logger.info(
+                "Retrieved peer benchmark score from cache for console '%s'",
+                console,
+            )
+            return cached
+
+    apitoken = get_secret_for_console(console)
+    base_url = get_api_base_url(console, 'data')
+    account_id = get_api_account_id(console)
+    api_url = f"{base_url}/api/data/v1/accounts/{account_id}/score"
+
+    iso_start = convert_epoch_to_datetime(start_date)["iso_datetime"]
+    iso_end = convert_epoch_to_datetime(end_date)["iso_datetime"]
+
+    body: Dict[str, Any] = {"startDate": iso_start, "endDate": iso_end}
+    if inc:
+        body["includeTestIds"] = inc
+    if exc:
+        body["excludeTestIds"] = exc
+
+    headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+
+    logger.info(
+        "Fetching peer benchmark score for console '%s' "
+        "(start=%s, end=%s, include=%d, exclude=%d)",
+        console, iso_start, iso_end, len(inc), len(exc),
+    )
+    response = requests.post(api_url, headers=headers, json=body, timeout=120)
+
+    if response.status_code == 204:
+        result = {
+            "start_date": iso_start,
+            "end_date": iso_end,
+            "customer_score": None,
+            "all_peers_score": None,
+            "customer_industry_scores": [],
+            "hint_to_agent": _PEER_BENCHMARK_204_HINT,
+        }
+        if is_caching_enabled("data"):
+            peer_benchmark_cache.set(cache_key, result)
+        return result
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        # Log without the API token — only console, URL, and status code.
+        logger.error(
+            "Peer benchmark API request failed for console '%s' "
+            "(URL: %s, status: %s)",
+            console, api_url, response.status_code,
+        )
+        raise
+
+    backend_json = response.json()
+
+    hint_fragments = []
+    if backend_json.get("customerScore") is None:
+        hint_fragments.append(_PEER_BENCHMARK_NULL_CUSTOMER_HINT)
+    if backend_json.get("peerScore") is None:
+        hint_fragments.append(_PEER_BENCHMARK_NULL_PEER_HINT)
+    if not backend_json.get("industryScores"):
+        hint_fragments.append(_PEER_BENCHMARK_EMPTY_INDUSTRY_HINT)
+    hint = "; ".join(hint_fragments) if hint_fragments else None
+
+    result = get_reduced_peer_benchmark_response(backend_json, hint=hint)
+
+    if is_caching_enabled("data"):
+        peer_benchmark_cache.set(cache_key, result)
+
+    return result

--- a/safebreach_mcp_data/data_server.py
+++ b/safebreach_mcp_data/data_server.py
@@ -29,6 +29,7 @@ from .data_functions import (
     sb_get_simulation_status_drifts,
     sb_get_security_control_drifts,
     sb_get_simulation_lineage,
+    sb_get_peer_benchmark_score,
 )
 
 logger = logging.getLogger(__name__)
@@ -652,6 +653,57 @@ Parameters:
                 console=console,
                 tracking_code=tracking_code,
                 page_number=page_number,
+            )
+
+        @self.mcp.tool(
+            name="get_peer_benchmark_score",
+            description="""Returns the customer's security posture score compared to SafeBreach peers for a given time window.
+Wraps POST /api/data/v1/accounts/{account_id}/score (SAF-27621).
+
+Parameters:
+  console (default 'default'): SafeBreach console name.
+  start_date (required): epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'. Start of the scoring window.
+  end_date (required): epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'. End of the scoring window.
+  include_test_ids_filter: comma-separated planRunIds to restrict scoring to. \
+Mutually exclusive with exclude_test_ids_filter.
+  exclude_test_ids_filter: comma-separated planRunIds to exclude from scoring. \
+Mutually exclusive with include_test_ids_filter.
+
+Peers vs industry distinction: all_peers_score reflects the average across ALL SafeBreach customers regardless of \
+industry (sourced from the backend's all_industries bucket). customer_industry_scores is an array scoped to the \
+customer's OWN industry only — determined server-side from a Salesforce industry mapping and not overridable by the \
+caller. In practice the array has 0 or 1 elements.
+
+Response fields:
+  peer_snapshot_month — the full-month peer snapshot used for comparison; peer and industry aggregation is always \
+full-month even when the query window is shorter.
+  peer_data_through_date — ETL freshness date; may be null when the gateway has no snapshot.
+  custom_attacks_filtered_count — count of custom attacks (moveId >= 10_000_000) auto-excluded from the peer comparison.
+  hint_to_agent — present when data is missing (e.g., no executions, no peer snapshot); guides the LLM's next step.
+
+Score formula: score = 1.0 * blocked + 0.5 * detected.
+
+HTTP 204 behavior: when the backend returns no-content (no executions in the window or all matched attacks are \
+custom), this tool returns the empty-shape response with a hint_to_agent — the caller does NOT need to handle an \
+exception."""
+        )
+        async def get_peer_benchmark_score_tool(
+            console: str = "default",
+            start_date: Optional[str | int] = None,
+            end_date: Optional[str | int] = None,
+            include_test_ids_filter: Optional[str] = None,
+            exclude_test_ids_filter: Optional[str] = None,
+        ) -> dict:
+            start_date = normalize_timestamp(start_date) if start_date is not None else None
+            end_date = normalize_timestamp(end_date) if end_date is not None else None
+            if start_date is None or end_date is None:
+                raise ValueError("start_date and end_date are required")
+            return sb_get_peer_benchmark_score(
+                console=console,
+                start_date=start_date,
+                end_date=end_date,
+                include_test_ids_filter=include_test_ids_filter,
+                exclude_test_ids_filter=exclude_test_ids_filter,
             )
 
 def parse_external_config(server_type: str) -> bool:

--- a/safebreach_mcp_data/data_types.py
+++ b/safebreach_mcp_data/data_types.py
@@ -5,9 +5,12 @@ This module provides data type mappings and transformations for SafeBreach data,
 specifically for test and simulation entities.
 """
 
+import logging
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 from safebreach_mcp_data.drifts_metadata import drift_types_mapping
+
+logger = logging.getLogger(__name__)
 
 # Test summary mapping
 reduced_test_summary_mapping = {
@@ -956,4 +959,146 @@ def group_sc_drift_records(
         })
 
     result.sort(key=lambda g: g["count"], reverse=True)
+    return result
+
+
+# ------------------------------------------------------------------
+# Peer benchmark score (SAF-29415) — rename mappings + transform
+# ------------------------------------------------------------------
+# The SafeBreach data backend exposes POST /api/data/v1/accounts/{id}/score.
+# These mappings translate the backend's camelCase response into the
+# MCP-facing snake_case shape described in the SAF-29415 PRD. Values are
+# preserved verbatim; only key names and empty/None handling are adjusted.
+
+peer_benchmark_rename_mapping = {
+    'start_date': 'startDate',
+    'end_date': 'endDate',
+    'peer_snapshot_month': 'snapshotMonth',
+    'peer_data_through_date': 'dataThroughDate',
+    'attack_ids': 'attackIds',
+    'attack_ids_count': 'attackIdsQueried',
+    'custom_attacks_filtered_count': 'customAttackIdsFiltered',
+    'customer_score': 'customerScore',
+    'all_peers_score': 'peerScore',
+    'customer_industry_scores': 'industryScores',
+}
+
+# ScoreBreakdown mapping — applied to customerScore, peerScore, and each
+# industryScores[] element. `total_simulations` is populated by the
+# backend for customerScore only, and `industry` is handled separately
+# (industryScores elements only) via the `include_industry_name` flag
+# on `_rename_score_breakdown`.
+peer_benchmark_score_field_mapping = {
+    'score': 'score',
+    'score_blocked': 'scoreBlocked',
+    'score_detected': 'scoreDetected',
+    'score_unblocked': 'scoreUnblocked',
+    'total_simulations': 'totalSimulations',
+    'security_control_breakdown': 'securityControlCategory',
+}
+
+# ControlScore mapping — applied to each entry within a
+# security_control_breakdown[] list. `score_unblocked` is preserved
+# when present in the source; the backend omits it for peer/industry
+# control entries, so `map_reduced_entity` naturally drops it there.
+peer_benchmark_control_field_mapping = {
+    'control_category_name': 'name',
+    'score': 'score',
+    'score_blocked': 'scoreBlocked',
+    'score_detected': 'scoreDetected',
+    'score_unblocked': 'scoreUnblocked',
+}
+
+
+def _rename_control_entry(control_entity: Dict[str, Any]) -> Dict[str, Any]:
+    """Rename a single ControlScore dict from backend shape to MCP shape.
+
+    `score_unblocked` is only emitted when the source dict already contains
+    `scoreUnblocked` — peer/industry control entries omit it upstream, so
+    the key is naturally dropped for those without special-casing here.
+    """
+    return map_reduced_entity(control_entity, peer_benchmark_control_field_mapping)
+
+
+def _rename_score_breakdown(
+    score_entity: Dict[str, Any],
+    include_industry_name: bool = False,
+) -> Dict[str, Any]:
+    """Rename a ScoreBreakdown dict (customerScore / peerScore / industry entry).
+
+    Recursively transforms the nested `securityControlCategory` list into
+    `security_control_breakdown`. When `include_industry_name` is True, the
+    source `industry` field is renamed to `industry_name` — this applies to
+    entries in `industryScores[]` only.
+    """
+    result = map_reduced_entity(score_entity, peer_benchmark_score_field_mapping)
+
+    controls = result.get('security_control_breakdown')
+    if controls is not None:
+        result['security_control_breakdown'] = [
+            _rename_control_entry(ctrl) for ctrl in controls
+        ]
+
+    if include_industry_name and 'industry' in score_entity:
+        result['industry_name'] = score_entity['industry']
+
+    return result
+
+
+def get_reduced_peer_benchmark_response(
+    backend_json: Dict[str, Any],
+    hint: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Transform a backend peer benchmark /score response into MCP shape.
+
+    Renames camelCase keys to self-explanatory snake_case keys per the
+    peer_benchmark_rename_mapping tables, recursively transforming nested
+    ScoreBreakdown and ControlScore structures. Semantic values are
+    preserved verbatim (no score re-computation, no field drops beyond
+    unknown top-level keys which are warned and skipped defensively).
+
+    Args:
+        backend_json: Raw dict parsed from the backend response body.
+        hint: Optional hint string. When truthy, attached to the output
+            as ``hint_to_agent`` at the top level; otherwise omitted.
+
+    Returns:
+        A dict with renamed top-level keys. `customer_score` /
+        `all_peers_score` pass ``None`` through unchanged.
+        `customer_industry_scores` is always a list (possibly empty).
+    """
+    result: Dict[str, Any] = {}
+    known_backend_keys = set(peer_benchmark_rename_mapping.values())
+
+    # Warn and drop any unknown top-level keys (defensive fallthrough —
+    # the helper should not crash when the backend introduces new fields).
+    for backend_key in backend_json:
+        if backend_key not in known_backend_keys:
+            logger.warning(
+                "Unknown top-level key '%s' in peer benchmark response; skipping.",
+                backend_key,
+            )
+
+    for mcp_key, backend_key in peer_benchmark_rename_mapping.items():
+        if backend_key not in backend_json:
+            continue
+
+        value = backend_json[backend_key]
+
+        if backend_key in ('customerScore', 'peerScore'):
+            result[mcp_key] = (
+                _rename_score_breakdown(value) if value is not None else None
+            )
+        elif backend_key == 'industryScores':
+            result[mcp_key] = (
+                [_rename_score_breakdown(entry, include_industry_name=True)
+                 for entry in value]
+                if value is not None else None
+            )
+        else:
+            result[mcp_key] = value
+
+    if hint:
+        result['hint_to_agent'] = hint
+
     return result

--- a/safebreach_mcp_data/data_types.py
+++ b/safebreach_mcp_data/data_types.py
@@ -988,32 +988,49 @@ peer_benchmark_rename_mapping = {
 # backend for customerScore only, and `industry` is handled separately
 # (industryScores elements only) via the `include_industry_name` flag
 # on `_rename_score_breakdown`.
+#
+# Note: backend `scoreUnblocked` is renamed to `score_missed` (not
+# `score_unblocked`) — "missed" is the unambiguous term for the
+# fully-evaded portion (`1 - blocked - detected`) and aligns with the
+# `missed` simulation status used elsewhere in the data MCP.
 peer_benchmark_score_field_mapping = {
     'score': 'score',
     'score_blocked': 'scoreBlocked',
     'score_detected': 'scoreDetected',
-    'score_unblocked': 'scoreUnblocked',
+    'score_missed': 'scoreUnblocked',
     'total_simulations': 'totalSimulations',
     'security_control_breakdown': 'securityControlCategory',
 }
 
 # ControlScore mapping — applied to each entry within a
-# security_control_breakdown[] list. `score_unblocked` is preserved
-# when present in the source; the backend omits it for peer/industry
-# control entries, so `map_reduced_entity` naturally drops it there.
+# security_control_breakdown[] list. `score_missed` is preserved when
+# present in the source; the backend omits it for peer/industry control
+# entries, so `map_reduced_entity` naturally drops it there.
 peer_benchmark_control_field_mapping = {
     'control_category_name': 'name',
     'score': 'score',
     'score_blocked': 'scoreBlocked',
     'score_detected': 'scoreDetected',
-    'score_unblocked': 'scoreUnblocked',
+    'score_missed': 'scoreUnblocked',
 }
+
+# Always-on metadata appended to every transformed peer-benchmark
+# response. These make the response self-contained for the LLM consumer
+# (per Claude Desktop UX feedback): the agent can synthesize without
+# having to carry the formula or the scope asymmetry in-context.
+PEER_BENCHMARK_SCORING_FORMULA = "score = 1.0 * blocked + 0.5 * detected"
+PEER_BENCHMARK_SCOPE_NOTE = (
+    "Customer score reflects the exact requested window. "
+    "All-peers and customer-industry scores are always full-month aggregates "
+    "of the snapshot identified by peer_snapshot_month, even when the requested "
+    "window is shorter — keep this asymmetry in mind for narrow windows."
+)
 
 
 def _rename_control_entry(control_entity: Dict[str, Any]) -> Dict[str, Any]:
     """Rename a single ControlScore dict from backend shape to MCP shape.
 
-    `score_unblocked` is only emitted when the source dict already contains
+    `score_missed` is only emitted when the source dict already contains
     `scoreUnblocked` — peer/industry control entries omit it upstream, so
     the key is naturally dropped for those without special-casing here.
     """
@@ -1027,17 +1044,21 @@ def _rename_score_breakdown(
     """Rename a ScoreBreakdown dict (customerScore / peerScore / industry entry).
 
     Recursively transforms the nested `securityControlCategory` list into
-    `security_control_breakdown`. When `include_industry_name` is True, the
-    source `industry` field is renamed to `industry_name` — this applies to
-    entries in `industryScores[]` only.
+    `security_control_breakdown`, and sorts that list alphabetically by
+    `control_category_name` so customer / peer / industry breakdowns share
+    a stable order an agent can iterate position-wise.
+
+    When `include_industry_name` is True, the source `industry` field is
+    renamed to `industry_name` — this applies to entries in
+    `industryScores[]` only.
     """
     result = map_reduced_entity(score_entity, peer_benchmark_score_field_mapping)
 
     controls = result.get('security_control_breakdown')
     if controls is not None:
-        result['security_control_breakdown'] = [
-            _rename_control_entry(ctrl) for ctrl in controls
-        ]
+        renamed = [_rename_control_entry(ctrl) for ctrl in controls]
+        renamed.sort(key=lambda c: c.get('control_category_name', ''))
+        result['security_control_breakdown'] = renamed
 
     if include_industry_name and 'industry' in score_entity:
         result['industry_name'] = score_entity['industry']
@@ -1097,6 +1118,10 @@ def get_reduced_peer_benchmark_response(
             )
         else:
             result[mcp_key] = value
+
+    # Always-on metadata so the response is self-contained for the agent.
+    result['scoring_formula'] = PEER_BENCHMARK_SCORING_FORMULA
+    result['scope_note'] = PEER_BENCHMARK_SCOPE_NOTE
 
     if hint:
         result['hint_to_agent'] = hint

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4,8 +4,12 @@ Tests for SafeBreach Data Functions
 This module tests the data functions that handle test and simulation operations.
 """
 
+import copy
+import logging
+
 import pytest
 import json
+from requests.exceptions import HTTPError
 from unittest.mock import Mock, patch, MagicMock
 from safebreach_mcp_data.data_functions import (
     sb_get_tests_history,
@@ -18,6 +22,7 @@ from safebreach_mcp_data.data_functions import (
     sb_get_test_findings_details,
     sb_get_test_drifts,
     sb_get_full_simulation_logs,
+    sb_get_peer_benchmark_score,
     _get_all_tests_from_cache_or_api,
     _apply_filters,
     _apply_ordering,
@@ -36,6 +41,7 @@ from safebreach_mcp_data.data_functions import (
     security_control_events_cache,
     findings_cache,
     full_simulation_logs_cache,
+    peer_benchmark_cache,
     PAGE_SIZE
 )
 
@@ -3002,3 +3008,463 @@ class TestDataFunctions:
         assert result['attacker']['os_version'] == 'Ubuntu 22.04'
         assert result['attacker']['error'] == 'connection refused'
         assert result['attacker']['simulation_steps'] == [{'message': 'attacker step'}]
+
+
+# Standardized epoch-ms test values (real values, NOT mocked — real
+# convert_epoch_to_datetime will produce deterministic ISO strings).
+_START_MS = 1709251200000  # 2024-03-01T00:00:00Z
+_END_MS = 1711929600000    # 2024-04-01T00:00:00Z
+
+
+class TestPeerBenchmarkFunction:
+    """Test suite for sb_get_peer_benchmark_score (SAF-29415 Phase 2)."""
+
+    def setup_method(self):
+        """Clear the peer benchmark cache before each test."""
+        peer_benchmark_cache.clear()
+
+    @pytest.fixture
+    def happy_backend_response(self):
+        """Full happy-path backend /score response payload."""
+        return {
+            "startDate": "2024-03-01T00:00:00.000Z",
+            "endDate": "2024-04-01T00:00:00.000Z",
+            "snapshotMonth": "2024-03",
+            "dataThroughDate": "2024-03-31",
+            "attackIds": ["7001", "7002"],
+            "attackIdsQueried": 2,
+            "customAttackIdsFiltered": 0,
+            "customerScore": {
+                "score": 0.68,
+                "scoreBlocked": 0.40,
+                "scoreDetected": 0.18,
+                "scoreUnblocked": 0.10,
+                "totalSimulations": 500,
+                "securityControlCategory": [
+                    {"name": "Network Inspection", "score": 0.50,
+                     "scoreBlocked": 0.30, "scoreDetected": 0.10,
+                     "scoreUnblocked": 0.10},
+                ],
+            },
+            "peerScore": {
+                "score": 0.75,
+                "scoreBlocked": 0.50,
+                "scoreDetected": 0.20,
+                "scoreUnblocked": 0.05,
+                "securityControlCategory": [
+                    {"name": "Network Inspection", "score": 0.75,
+                     "scoreBlocked": 0.50, "scoreDetected": 0.20},
+                ],
+            },
+            "industryScores": [
+                {
+                    "industry": "Information Technology",
+                    "score": 0.69,
+                    "scoreBlocked": 0.45,
+                    "scoreDetected": 0.19,
+                    "scoreUnblocked": 0.05,
+                    "securityControlCategory": [
+                        {"name": "Network Inspection", "score": 0.70,
+                         "scoreBlocked": 0.45, "scoreDetected": 0.20},
+                    ],
+                },
+            ],
+        }
+
+    @pytest.fixture
+    def make_post_response(self):
+        """Factory fixture: build a MagicMock POST response."""
+        def _factory(status_code=200, json_data=None, raise_for_status_effect=None):
+            resp = Mock()
+            resp.status_code = status_code
+            resp.json.return_value = json_data
+            if raise_for_status_effect is not None:
+                resp.raise_for_status.side_effect = raise_for_status_effect
+            else:
+                resp.raise_for_status.return_value = None
+            return resp
+        return _factory
+
+    # ---- Test 1 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_happy_path_no_filters(self, mock_post, mock_secret, mock_base_url,
+                                   mock_account_id, happy_backend_response,
+                                   make_post_response):
+        """Happy path: no filters -> correct URL, headers, body, timeout, shape."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+
+        # URL pattern
+        called_url = args[0] if args else kwargs.get('url')
+        assert "/accounts/123/score" in called_url
+
+        # Headers: x-apitoken (not Bearer) + Content-Type
+        headers = kwargs['headers']
+        assert headers.get('x-apitoken') == "test-token"
+        assert headers.get('Content-Type') == "application/json"
+        assert 'Authorization' not in headers  # NO Bearer
+
+        # Body: ISO-Z dates, no filter keys
+        body = kwargs['json']
+        assert body['startDate'].endswith('Z')
+        assert body['endDate'].endswith('Z')
+        assert 'includeTestIds' not in body
+        assert 'excludeTestIds' not in body
+
+        # Timeout
+        assert kwargs['timeout'] == 120
+
+        # Return value has renamed keys
+        assert 'customer_score' in result
+        assert 'all_peers_score' in result
+        assert 'customer_industry_scores' in result
+
+    # ---- Test 2 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_include_only_filter(self, mock_post, mock_secret, mock_base_url,
+                                 mock_account_id, happy_backend_response,
+                                 make_post_response):
+        """Include filter is trimmed, split, sent as includeTestIds."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+            include_test_ids_filter="a, b , c",
+        )
+
+        body = mock_post.call_args.kwargs['json']
+        assert body.get('includeTestIds') == ["a", "b", "c"]
+        assert 'excludeTestIds' not in body
+
+    # ---- Test 3 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_exclude_only_filter(self, mock_post, mock_secret, mock_base_url,
+                                 mock_account_id, happy_backend_response,
+                                 make_post_response):
+        """Exclude filter is trimmed, split, sent as excludeTestIds."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+            exclude_test_ids_filter="x, y",
+        )
+
+        body = mock_post.call_args.kwargs['json']
+        assert body.get('excludeTestIds') == ["x", "y"]
+        assert 'includeTestIds' not in body
+
+    # ---- Test 4 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_mutual_exclusivity_raises_value_error(self, mock_post, mock_secret,
+                                                   mock_base_url, mock_account_id):
+        """Both filters non-empty -> ValueError; requests.post never called."""
+        mock_secret.return_value = "test-token"
+
+        with pytest.raises(ValueError) as excinfo:
+            sb_get_peer_benchmark_score(
+                "test-console", start_date=_START_MS, end_date=_END_MS,
+                include_test_ids_filter="a",
+                exclude_test_ids_filter="b",
+            )
+
+        assert "Cannot provide both" in str(excinfo.value)
+        mock_post.assert_not_called()
+
+    # ---- Test 5 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_empty_filter_strings_treated_as_absent(
+        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        happy_backend_response, make_post_response,
+    ):
+        """Empty string and None for filters -> no filter keys in body."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+            include_test_ids_filter="",
+            exclude_test_ids_filter=None,
+        )
+
+        body = mock_post.call_args.kwargs['json']
+        assert 'includeTestIds' not in body
+        assert 'excludeTestIds' not in body
+
+    # ---- Test 6 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_date_ordering_validation(self, mock_post, mock_secret,
+                                      mock_base_url, mock_account_id):
+        """start_date >= end_date -> ValueError; requests.post never called."""
+        mock_secret.return_value = "test-token"
+
+        # start > end
+        with pytest.raises(ValueError) as excinfo:
+            sb_get_peer_benchmark_score(
+                "test-console", start_date=_END_MS, end_date=_START_MS,
+            )
+        assert "start_date must be before end_date" in str(excinfo.value)
+
+        # start == end
+        with pytest.raises(ValueError):
+            sb_get_peer_benchmark_score(
+                "test-console", start_date=_START_MS, end_date=_START_MS,
+            )
+
+        mock_post.assert_not_called()
+
+    # ---- Test 7 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_epoch_to_iso_conversion(self, mock_post, mock_secret, mock_base_url,
+                                     mock_account_id, happy_backend_response,
+                                     make_post_response):
+        """Epoch ms -> ISO 8601 UTC Z strings in body."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        body = mock_post.call_args.kwargs['json']
+        assert body['startDate'].endswith('Z')
+        assert body['endDate'].endswith('Z')
+
+    # ---- Test 8 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_http_204_handling(self, mock_post, mock_secret, mock_base_url,
+                               mock_account_id, make_post_response):
+        """HTTP 204 -> empty-shape result + hint mentioning no executions/custom."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(status_code=204, json_data=None)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert result['customer_score'] is None
+        assert result['all_peers_score'] is None
+        assert result['customer_industry_scores'] == []
+        assert 'hint_to_agent' in result
+        hint_lower = result['hint_to_agent'].lower()
+        assert ('no executions' in hint_lower) or ('custom' in hint_lower)
+
+    # ---- Test 9 -----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_null_customer_score_hint(self, mock_post, mock_secret, mock_base_url,
+                                      mock_account_id, happy_backend_response,
+                                      make_post_response):
+        """200 with customerScore: None -> hint explains no customer executions."""
+        mock_secret.return_value = "test-token"
+        payload = copy.deepcopy(happy_backend_response)
+        payload["customerScore"] = None
+        mock_post.return_value = make_post_response(200, payload)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert 'hint_to_agent' in result
+        hint_lower = result['hint_to_agent'].lower()
+        assert ('no executions' in hint_lower) or ('customer' in hint_lower)
+
+    # ---- Test 10 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_null_peer_score_hint(self, mock_post, mock_secret, mock_base_url,
+                                  mock_account_id, happy_backend_response,
+                                  make_post_response):
+        """200 with peerScore: None -> hint mentions all-peers missing."""
+        mock_secret.return_value = "test-token"
+        payload = copy.deepcopy(happy_backend_response)
+        payload["peerScore"] = None
+        mock_post.return_value = make_post_response(200, payload)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert 'hint_to_agent' in result
+        hint_lower = result['hint_to_agent'].lower()
+        assert 'peer' in hint_lower
+
+    # ---- Test 11 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_empty_industry_scores_hint(self, mock_post, mock_secret, mock_base_url,
+                                        mock_account_id, happy_backend_response,
+                                        make_post_response):
+        """200 with industryScores: [] -> hint mentions customer-industry missing."""
+        mock_secret.return_value = "test-token"
+        payload = copy.deepcopy(happy_backend_response)
+        payload["industryScores"] = []
+        mock_post.return_value = make_post_response(200, payload)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert 'hint_to_agent' in result
+        hint_lower = result['hint_to_agent'].lower()
+        assert 'industry' in hint_lower
+
+    # ---- Test 12 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_composed_hint_multiple_nulls(self, mock_post, mock_secret, mock_base_url,
+                                          mock_account_id, happy_backend_response,
+                                          make_post_response):
+        """peerScore null AND industryScores empty -> hint joins fragments with '; '."""
+        mock_secret.return_value = "test-token"
+        payload = copy.deepcopy(happy_backend_response)
+        payload["peerScore"] = None
+        payload["industryScores"] = []
+        mock_post.return_value = make_post_response(200, payload)
+
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert 'hint_to_agent' in result
+        hint = result['hint_to_agent']
+        hint_lower = hint.lower()
+        assert 'peer' in hint_lower
+        assert 'industry' in hint_lower
+        assert '; ' in hint  # fragments joined with "; "
+
+    # ---- Test 13 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_500_backend_error_logging(self, mock_post, mock_secret, mock_base_url,
+                                       mock_account_id, make_post_response, caplog):
+        """500 -> logger.error called, HTTPError re-raised, no token in log."""
+        mock_secret.return_value = "test-token-secret-value"
+        mock_post.return_value = make_post_response(
+            status_code=500,
+            raise_for_status_effect=HTTPError("500 Server Error"),
+        )
+
+        with caplog.at_level(logging.ERROR, logger="safebreach_mcp_data.data_functions"):
+            with pytest.raises(HTTPError):
+                sb_get_peer_benchmark_score(
+                    "test-console", start_date=_START_MS, end_date=_END_MS,
+                )
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) >= 1, "expected at least one ERROR-level log record"
+
+        # Security regression: token must never appear in log messages
+        for record in caplog.records:
+            assert "test-token-secret-value" not in record.getMessage(), (
+                f"API token leaked in log: {record.getMessage()!r}"
+            )
+
+    # ---- Test 14 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_cache_hit(self, mock_post, mock_secret, mock_base_url, mock_account_id,
+                       mock_cache_enabled, happy_backend_response, make_post_response):
+        """Cache enabled + identical calls -> requests.post called once."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        first = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        second = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert mock_post.call_count == 1
+        assert first == second
+
+    # ---- Test 15 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=False)
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_cache_disabled(self, mock_post, mock_secret, mock_base_url, mock_account_id,
+                            mock_cache_disabled, happy_backend_response, make_post_response):
+        """Cache disabled -> identical calls hit backend each time."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+
+        assert mock_post.call_count == 2
+
+    # ---- Test 16 ----------------------------------------------------
+    @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_cache_key_order_independence(self, mock_post, mock_secret, mock_base_url,
+                                          mock_account_id, mock_cache_enabled,
+                                          happy_backend_response, make_post_response):
+        """Same IDs in different order -> second call hits cache (key uses sorted list)."""
+        mock_secret.return_value = "test-token"
+        mock_post.return_value = make_post_response(200, happy_backend_response)
+
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+            include_test_ids_filter="b,a",
+        )
+        sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+            include_test_ids_filter="a,b",
+        )
+
+        assert mock_post.call_count == 1

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -3280,6 +3280,10 @@ class TestPeerBenchmarkFunction:
         assert 'hint_to_agent' in result
         hint_lower = result['hint_to_agent'].lower()
         assert ('no executions' in hint_lower) or ('custom' in hint_lower)
+        # The 204 path must also surface the always-on metadata so the agent
+        # can synthesize a useful response without re-fetching context.
+        assert result['scoring_formula'] == "score = 1.0 * blocked + 0.5 * detected"
+        assert 'scope_note' in result and isinstance(result['scope_note'], str)
 
     # ---- Test 9 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
@@ -3468,3 +3472,66 @@ class TestPeerBenchmarkFunction:
         )
 
         assert mock_post.call_count == 1
+
+    # ---- Test 17 (hint sanitization) -------------------------------
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
+    @patch('safebreach_mcp_data.data_functions.requests.post')
+    def test_hints_do_not_leak_internal_details(
+        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        happy_backend_response, make_post_response,
+    ):
+        """All hint paths must avoid leaking internal infra terms.
+
+        Per Claude Desktop UX feedback: hint_to_agent text reaches end-users
+        verbatim through the LLM. It must not mention internal environment
+        names ("staging", "private-dev", "frozen snapshot") or implementation
+        constants (the `>= 10_000_000` custom-attack threshold).
+        """
+        mock_secret.return_value = "test-token"
+        forbidden = ["staging", "private-dev", "frozen snapshot", "10_000_000", "10000000"]
+
+        def _assert_clean(hint, scenario):
+            lower = hint.lower()
+            for term in forbidden:
+                assert term.lower() not in lower, (
+                    f"{scenario!r} hint leaked '{term}': {hint!r}"
+                )
+
+        # Scenario A: HTTP 204
+        mock_post.return_value = make_post_response(status_code=204, json_data=None)
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        _assert_clean(result["hint_to_agent"], "204")
+
+        # Scenario B: 200 with customerScore=None
+        peer_benchmark_cache.clear()
+        payload = copy.deepcopy(happy_backend_response)
+        payload["customerScore"] = None
+        mock_post.return_value = make_post_response(200, payload)
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        _assert_clean(result["hint_to_agent"], "null customerScore")
+
+        # Scenario C: 200 with peerScore=None
+        peer_benchmark_cache.clear()
+        payload = copy.deepcopy(happy_backend_response)
+        payload["peerScore"] = None
+        mock_post.return_value = make_post_response(200, payload)
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        _assert_clean(result["hint_to_agent"], "null peerScore")
+
+        # Scenario D: 200 with empty industryScores
+        peer_benchmark_cache.clear()
+        payload = copy.deepcopy(happy_backend_response)
+        payload["industryScores"] = []
+        mock_post.return_value = make_post_response(200, payload)
+        result = sb_get_peer_benchmark_score(
+            "test-console", start_date=_START_MS, end_date=_END_MS,
+        )
+        _assert_clean(result["hint_to_agent"], "empty industryScores")

--- a/safebreach_mcp_data/tests/test_data_server.py
+++ b/safebreach_mcp_data/tests/test_data_server.py
@@ -1,0 +1,183 @@
+"""
+Tests for SafeBreach Data Server tool wrappers (SAF-29415 Phase 3).
+
+This file targets the thin MCP-tool wrappers registered on
+``SafeBreachDataServer``. Wrappers are tested by reaching into FastMCP's
+``_tool_manager._tools`` registry and invoking the underlying async
+function directly via ``asyncio.run`` — this preserves the wrapper's
+real exception types and dict return values, which the public
+``call_tool`` API would otherwise wrap in ``ToolError`` / serialize to
+``TextContent``.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+
+def _get_tool_fn(tool_name: str):
+    """Return the underlying async function for a registered MCP tool."""
+    # Deferred import to avoid module-level coupling and to ensure the
+    # singleton ``data_server`` is fully constructed before lookup.
+    from safebreach_mcp_data.data_server import data_server
+    return data_server.mcp._tool_manager._tools[tool_name].fn
+
+
+class TestPeerBenchmarkToolWrapper:
+    """Wrapper-contract tests for the ``get_peer_benchmark_score`` MCP tool."""
+
+    # ---- Test 1: registration --------------------------------------
+    def test_tool_registered(self):
+        """get_peer_benchmark_score appears in the registered tool list."""
+        from safebreach_mcp_data.data_server import data_server
+        tools = asyncio.run(data_server.mcp.list_tools())
+        names = [tool.name for tool in tools]
+        assert "get_peer_benchmark_score" in names
+
+    # ---- Test 2: epoch input normalization -------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_epoch_input_normalization(self, mock_fn):
+        """Epoch-seconds inputs are converted to epoch-ms before delegation."""
+        mock_fn.return_value = {"score": 42}
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        asyncio.run(fn(
+            console="c",
+            start_date=1700000000,
+            end_date=1702592000,
+        ))
+
+        mock_fn.assert_called_once()
+        kwargs = mock_fn.call_args.kwargs
+        assert kwargs['start_date'] == 1700000000000
+        assert kwargs['end_date'] == 1702592000000
+
+    # ---- Test 3: ISO input normalization ---------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_iso_input_normalization(self, mock_fn):
+        """ISO 8601 strings are normalized to epoch-ms before delegation."""
+        mock_fn.return_value = {"score": 42}
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        asyncio.run(fn(
+            console="c",
+            start_date="2026-03-01T00:00:00Z",
+            end_date="2026-03-31T23:59:59Z",
+        ))
+
+        mock_fn.assert_called_once()
+        kwargs = mock_fn.call_args.kwargs
+        assert kwargs['start_date'] == 1772323200000
+        assert kwargs['end_date'] == 1775001599000
+
+    # ---- Test 4: missing start_date raises -------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_missing_start_date_raises(self, mock_fn):
+        """start_date=None -> ValueError; business function never called."""
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        with pytest.raises(ValueError, match="start_date and end_date are required"):
+            asyncio.run(fn(
+                console="c",
+                start_date=None,
+                end_date=1702592000,
+            ))
+
+        mock_fn.assert_not_called()
+
+    # ---- Test 5: missing end_date raises ---------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_missing_end_date_raises(self, mock_fn):
+        """end_date=None -> ValueError; business function never called."""
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        with pytest.raises(ValueError, match="start_date and end_date are required"):
+            asyncio.run(fn(
+                console="c",
+                start_date=1700000000,
+                end_date=None,
+            ))
+
+        mock_fn.assert_not_called()
+
+    # ---- Test 6: invalid start_date string raises ------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_invalid_start_date_string_raises(self, mock_fn):
+        """Non-parseable date string -> ValueError; business fn never called."""
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        with pytest.raises(ValueError, match="start_date and end_date are required"):
+            asyncio.run(fn(
+                console="c",
+                start_date="not-a-date",
+                end_date=1702592000,
+            ))
+
+        mock_fn.assert_not_called()
+
+    # ---- Test 7: filters pass through unchanged --------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_filters_pass_through(self, mock_fn):
+        """Filter strings are forwarded to the business function unchanged."""
+        mock_fn.return_value = {}
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        asyncio.run(fn(
+            console="c",
+            start_date=1700000000000,
+            end_date=1702592000000,
+            include_test_ids_filter="a,b",
+            exclude_test_ids_filter=None,
+        ))
+
+        kwargs = mock_fn.call_args.kwargs
+        assert kwargs['include_test_ids_filter'] == "a,b"
+        assert kwargs['exclude_test_ids_filter'] is None
+
+    # ---- Test 8: console default -----------------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_console_default(self, mock_fn):
+        """Omitting console -> business function called with console='default'."""
+        mock_fn.return_value = {}
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        asyncio.run(fn(
+            start_date=1700000000000,
+            end_date=1702592000000,
+        ))
+
+        kwargs = mock_fn.call_args.kwargs
+        assert kwargs['console'] == "default"
+
+    # ---- Test 9: return value pass-through -------------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_return_value_pass_through(self, mock_fn):
+        """Wrapper returns the business function's exact dict (identity)."""
+        sentinel = {"customer_score": 85, "_sentinel": True}
+        mock_fn.return_value = sentinel
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        result = asyncio.run(fn(
+            console="c",
+            start_date=1700000000000,
+            end_date=1702592000000,
+        ))
+
+        assert result is sentinel  # identity check, not equality
+
+    # ---- Test 10: business ValueError propagates -------------------
+    @patch('safebreach_mcp_data.data_server.sb_get_peer_benchmark_score')
+    def test_business_function_valueerror_propagates(self, mock_fn):
+        """ValueError from the business function propagates unchanged."""
+        mock_fn.side_effect = ValueError("both filters cannot be used together")
+        fn = _get_tool_fn("get_peer_benchmark_score")
+
+        with pytest.raises(ValueError, match="both filters cannot be used together"):
+            asyncio.run(fn(
+                console="c",
+                start_date=1700000000000,
+                end_date=1702592000000,
+                include_test_ids_filter="a",
+                exclude_test_ids_filter="b",
+            ))

--- a/safebreach_mcp_data/tests/test_data_types.py
+++ b/safebreach_mcp_data/tests/test_data_types.py
@@ -803,12 +803,20 @@ class TestPeerBenchmarkTransform:
                 "scoreDetected": 0.20,
                 "scoreUnblocked": 0.05,
                 "securityControlCategory": [
+                    # Order intentionally differs from customer's order (Endpoint
+                    # Protection / Network Inspection) so sort tests have signal.
                     {
                         "name": "Network Inspection",
                         "score": 0.75,
                         "scoreBlocked": 0.50,
                         "scoreDetected": 0.20,
                         # NOTE: no scoreUnblocked for peer control entries
+                    },
+                    {
+                        "name": "Endpoint Protection",
+                        "score": 0.78,
+                        "scoreBlocked": 0.55,
+                        "scoreDetected": 0.18,
                     },
                 ],
             },
@@ -820,12 +828,19 @@ class TestPeerBenchmarkTransform:
                     "scoreDetected": 0.19,
                     "scoreUnblocked": 0.05,
                     "securityControlCategory": [
+                        # Same here — peer-style ordering; sort test will verify.
                         {
                             "name": "Network Inspection",
                             "score": 0.70,
                             "scoreBlocked": 0.45,
                             "scoreDetected": 0.20,
                             # NOTE: no scoreUnblocked for industry control entries
+                        },
+                        {
+                            "name": "Endpoint Protection",
+                            "score": 0.72,
+                            "scoreBlocked": 0.50,
+                            "scoreDetected": 0.20,
                         },
                     ],
                 },
@@ -862,28 +877,40 @@ class TestPeerBenchmarkTransform:
         assert result["attack_ids_count"] == 3
         assert result["custom_attacks_filtered_count"] == 1
 
-        # customer_score shape
+        # Always-on metadata fields (response is self-contained for the agent)
+        assert result["scoring_formula"] == "score = 1.0 * blocked + 0.5 * detected"
+        assert "scope_note" in result
+        assert "customer score" in result["scope_note"].lower()
+        assert "full" in result["scope_note"].lower() and "month" in result["scope_note"].lower()
+
+        # customer_score shape (note: score_missed replaces score_unblocked)
         customer = result["customer_score"]
         assert isinstance(customer, dict)
-        for key in ("score", "score_blocked", "score_detected", "score_unblocked",
+        for key in ("score", "score_blocked", "score_detected", "score_missed",
                     "total_simulations", "security_control_breakdown"):
             assert key in customer, f"customer_score missing {key}"
+        # legacy name must be gone
+        assert "score_unblocked" not in customer
         assert customer["score"] == 0.68
         assert customer["total_simulations"] == 500
         assert isinstance(customer["security_control_breakdown"], list)
         assert len(customer["security_control_breakdown"]) == 2
         for ctrl in customer["security_control_breakdown"]:
             for key in ("control_category_name", "score", "score_blocked",
-                        "score_detected", "score_unblocked"):
+                        "score_detected", "score_missed"):
                 assert key in ctrl, f"customer control entry missing {key}"
-        assert customer["security_control_breakdown"][0]["control_category_name"] == "Network Inspection"
+            assert "score_unblocked" not in ctrl
+        # security_control_breakdown is alphabetically sorted by control_category_name
+        assert customer["security_control_breakdown"][0]["control_category_name"] == "Endpoint Protection"
+        assert customer["security_control_breakdown"][1]["control_category_name"] == "Network Inspection"
 
         # all_peers_score shape (no total_simulations)
         peers = result["all_peers_score"]
         assert isinstance(peers, dict)
-        for key in ("score", "score_blocked", "score_detected", "score_unblocked",
+        for key in ("score", "score_blocked", "score_detected", "score_missed",
                     "security_control_breakdown"):
             assert key in peers, f"all_peers_score missing {key}"
+        assert "score_unblocked" not in peers
         assert peers["score"] == 0.75
 
         # customer_industry_scores shape
@@ -892,28 +919,42 @@ class TestPeerBenchmarkTransform:
         assert len(industries) == 1
         industry = industries[0]
         for key in ("industry_name", "score", "score_blocked", "score_detected",
-                    "score_unblocked", "security_control_breakdown"):
+                    "score_missed", "security_control_breakdown"):
             assert key in industry, f"industry entry missing {key}"
+        assert "score_unblocked" not in industry
 
         # No hint_to_agent when no hint passed
         assert "hint_to_agent" not in result
 
     # Test 2
-    def test_customer_only_score_unblocked_in_controls(self, full_backend_response):
-        """score_unblocked present in customer control entries, absent in peer/industry control entries."""
+    def test_customer_only_score_missed_in_controls(self, full_backend_response):
+        """score_missed present in customer control entries, absent in peer/industry control entries.
+
+        score_missed replaced the misleading score_unblocked name (per Claude Desktop UX
+        feedback): "missed" means neither blocked nor detected, aligning with the `missed`
+        simulation status used elsewhere in the data MCP.
+        """
         result = get_reduced_peer_benchmark_response(full_backend_response)
 
-        # Customer controls: score_unblocked present and renamed
-        customer_ctrls = result["customer_score"]["security_control_breakdown"]
-        assert customer_ctrls[0]["score_unblocked"] == 0.10
-        assert customer_ctrls[1]["score_unblocked"] == 0.05
+        # Customer controls: score_missed present and renamed (key by name to be sort-independent)
+        customer_ctrls_by_name = {
+            c["control_category_name"]: c
+            for c in result["customer_score"]["security_control_breakdown"]
+        }
+        assert customer_ctrls_by_name["Network Inspection"]["score_missed"] == 0.10
+        assert customer_ctrls_by_name["Endpoint Protection"]["score_missed"] == 0.05
+        # Legacy key must be gone everywhere
+        for ctrl in customer_ctrls_by_name.values():
+            assert "score_unblocked" not in ctrl
 
-        # Peer controls: no score_unblocked key injected
+        # Peer controls: no score_missed (and no score_unblocked) key injected
         peer_ctrl = result["all_peers_score"]["security_control_breakdown"][0]
+        assert "score_missed" not in peer_ctrl
         assert "score_unblocked" not in peer_ctrl
 
-        # Industry controls: no score_unblocked key injected
+        # Industry controls: no score_missed (and no score_unblocked) key injected
         industry_ctrl = result["customer_industry_scores"][0]["security_control_breakdown"][0]
+        assert "score_missed" not in industry_ctrl
         assert "score_unblocked" not in industry_ctrl
 
     # Test 3
@@ -1013,3 +1054,38 @@ class TestPeerBenchmarkTransform:
         industry_entry = result["customer_industry_scores"][0]
         assert industry_entry["industry_name"] == "Information Technology"
         assert "industry" not in industry_entry
+
+    # Test 11
+    def test_security_control_breakdown_sorted_alphabetically(self, full_backend_response):
+        """Each security_control_breakdown[] is sorted alphabetically by control_category_name.
+
+        The backend returns customer / peer / industry breakdowns in inconsistent orders
+        (e.g., Endpoint first in customer, Network Inspection first in peers). Without sort,
+        agents merging the lists must key by name. We sort uniformly to remove that fragility
+        (per Claude Desktop UX feedback).
+        """
+        result = get_reduced_peer_benchmark_response(full_backend_response)
+
+        def _names(breakdown):
+            return [c["control_category_name"] for c in breakdown]
+
+        # Customer
+        customer_names = _names(result["customer_score"]["security_control_breakdown"])
+        assert customer_names == sorted(customer_names)
+        assert customer_names == ["Endpoint Protection", "Network Inspection"]
+
+        # All-peers — fixture has them reverse-alphabetical; expect alphabetical out
+        peer_names = _names(result["all_peers_score"]["security_control_breakdown"])
+        assert peer_names == sorted(peer_names)
+        assert peer_names == ["Endpoint Protection", "Network Inspection"]
+
+        # Industry — same expectation
+        industry_names = _names(
+            result["customer_industry_scores"][0]["security_control_breakdown"]
+        )
+        assert industry_names == sorted(industry_names)
+        assert industry_names == ["Endpoint Protection", "Network Inspection"]
+
+        # Customer order matches peer order (this is the comparison-friendliness property
+        # the agent relies on).
+        assert customer_names == peer_names == industry_names

--- a/safebreach_mcp_data/tests/test_data_types.py
+++ b/safebreach_mcp_data/tests/test_data_types.py
@@ -4,6 +4,9 @@ Tests for SafeBreach Data Types
 This module tests the data type mappings and transformations for security control events.
 """
 
+import copy
+import logging
+
 import pytest
 from safebreach_mcp_data.data_types import (
     get_nested_value,
@@ -15,6 +18,7 @@ from safebreach_mcp_data.data_types import (
     get_full_simulation_logs_mapping,
     get_reduced_test_summary_mapping,
     _build_node_data,
+    get_reduced_peer_benchmark_response,
 )
 
 
@@ -750,3 +754,262 @@ class TestTestSummaryMapping:
         result = get_reduced_test_summary_mapping(entity)
         assert result["findings_count"] == 0
         assert result["compromised_hosts"] == 0
+
+
+class TestPeerBenchmarkTransform:
+    """Test suite for the peer benchmark score rename mapping and transform helper (SAF-29415)."""
+
+    @pytest.fixture
+    def full_backend_response(self):
+        """Full backend /score payload with all fields populated.
+
+        Customer control entries include ``scoreUnblocked``; peer and industry control
+        entries deliberately omit it (proving the conditional logic in tests 1, 2).
+        """
+        return {
+            "startDate": "2026-03-01T00:00:00.000Z",
+            "endDate": "2026-04-01T00:00:00.000Z",
+            "snapshotMonth": "2026-03",
+            "dataThroughDate": "2026-03-15",
+            "attackIds": ["7001", "7002", "7003"],
+            "attackIdsQueried": 3,
+            "customAttackIdsFiltered": 1,
+            "customerScore": {
+                "score": 0.68,
+                "scoreBlocked": 0.40,
+                "scoreDetected": 0.18,
+                "scoreUnblocked": 0.10,
+                "totalSimulations": 500,
+                "securityControlCategory": [
+                    {
+                        "name": "Network Inspection",
+                        "score": 0.50,
+                        "scoreBlocked": 0.30,
+                        "scoreDetected": 0.10,
+                        "scoreUnblocked": 0.10,
+                    },
+                    {
+                        "name": "Endpoint Protection",
+                        "score": 0.80,
+                        "scoreBlocked": 0.60,
+                        "scoreDetected": 0.15,
+                        "scoreUnblocked": 0.05,
+                    },
+                ],
+            },
+            "peerScore": {
+                "score": 0.75,
+                "scoreBlocked": 0.50,
+                "scoreDetected": 0.20,
+                "scoreUnblocked": 0.05,
+                "securityControlCategory": [
+                    {
+                        "name": "Network Inspection",
+                        "score": 0.75,
+                        "scoreBlocked": 0.50,
+                        "scoreDetected": 0.20,
+                        # NOTE: no scoreUnblocked for peer control entries
+                    },
+                ],
+            },
+            "industryScores": [
+                {
+                    "industry": "Information Technology",
+                    "score": 0.69,
+                    "scoreBlocked": 0.45,
+                    "scoreDetected": 0.19,
+                    "scoreUnblocked": 0.05,
+                    "securityControlCategory": [
+                        {
+                            "name": "Network Inspection",
+                            "score": 0.70,
+                            "scoreBlocked": 0.45,
+                            "scoreDetected": 0.20,
+                            # NOTE: no scoreUnblocked for industry control entries
+                        },
+                    ],
+                },
+            ],
+        }
+
+    # Test 1
+    def test_full_shape_happy_path(self, full_backend_response):
+        """Full payload -> every top-level + nested field renamed per the mapping tables."""
+        result = get_reduced_peer_benchmark_response(full_backend_response)
+
+        # Top-level renamed keys present
+        expected_top = {
+            "start_date", "end_date", "peer_snapshot_month", "peer_data_through_date",
+            "attack_ids", "attack_ids_count", "custom_attacks_filtered_count",
+            "customer_score", "all_peers_score", "customer_industry_scores",
+        }
+        assert expected_top.issubset(set(result.keys()))
+
+        # No camelCase backend keys remain at the top level
+        legacy_camel = {
+            "startDate", "endDate", "snapshotMonth", "dataThroughDate", "attackIds",
+            "attackIdsQueried", "customAttackIdsFiltered", "customerScore", "peerScore",
+            "industryScores",
+        }
+        assert legacy_camel.isdisjoint(set(result.keys()))
+
+        # Top-level values
+        assert result["start_date"] == "2026-03-01T00:00:00.000Z"
+        assert result["end_date"] == "2026-04-01T00:00:00.000Z"
+        assert result["peer_snapshot_month"] == "2026-03"
+        assert result["peer_data_through_date"] == "2026-03-15"
+        assert result["attack_ids"] == ["7001", "7002", "7003"]
+        assert result["attack_ids_count"] == 3
+        assert result["custom_attacks_filtered_count"] == 1
+
+        # customer_score shape
+        customer = result["customer_score"]
+        assert isinstance(customer, dict)
+        for key in ("score", "score_blocked", "score_detected", "score_unblocked",
+                    "total_simulations", "security_control_breakdown"):
+            assert key in customer, f"customer_score missing {key}"
+        assert customer["score"] == 0.68
+        assert customer["total_simulations"] == 500
+        assert isinstance(customer["security_control_breakdown"], list)
+        assert len(customer["security_control_breakdown"]) == 2
+        for ctrl in customer["security_control_breakdown"]:
+            for key in ("control_category_name", "score", "score_blocked",
+                        "score_detected", "score_unblocked"):
+                assert key in ctrl, f"customer control entry missing {key}"
+        assert customer["security_control_breakdown"][0]["control_category_name"] == "Network Inspection"
+
+        # all_peers_score shape (no total_simulations)
+        peers = result["all_peers_score"]
+        assert isinstance(peers, dict)
+        for key in ("score", "score_blocked", "score_detected", "score_unblocked",
+                    "security_control_breakdown"):
+            assert key in peers, f"all_peers_score missing {key}"
+        assert peers["score"] == 0.75
+
+        # customer_industry_scores shape
+        industries = result["customer_industry_scores"]
+        assert isinstance(industries, list)
+        assert len(industries) == 1
+        industry = industries[0]
+        for key in ("industry_name", "score", "score_blocked", "score_detected",
+                    "score_unblocked", "security_control_breakdown"):
+            assert key in industry, f"industry entry missing {key}"
+
+        # No hint_to_agent when no hint passed
+        assert "hint_to_agent" not in result
+
+    # Test 2
+    def test_customer_only_score_unblocked_in_controls(self, full_backend_response):
+        """score_unblocked present in customer control entries, absent in peer/industry control entries."""
+        result = get_reduced_peer_benchmark_response(full_backend_response)
+
+        # Customer controls: score_unblocked present and renamed
+        customer_ctrls = result["customer_score"]["security_control_breakdown"]
+        assert customer_ctrls[0]["score_unblocked"] == 0.10
+        assert customer_ctrls[1]["score_unblocked"] == 0.05
+
+        # Peer controls: no score_unblocked key injected
+        peer_ctrl = result["all_peers_score"]["security_control_breakdown"][0]
+        assert "score_unblocked" not in peer_ctrl
+
+        # Industry controls: no score_unblocked key injected
+        industry_ctrl = result["customer_industry_scores"][0]["security_control_breakdown"][0]
+        assert "score_unblocked" not in industry_ctrl
+
+    # Test 3
+    def test_customer_score_null_passthrough(self, full_backend_response):
+        """customerScore == None -> customer_score is None (not empty dict, not missing)."""
+        payload = copy.deepcopy(full_backend_response)
+        payload["customerScore"] = None
+
+        result = get_reduced_peer_benchmark_response(payload)
+
+        assert "customer_score" in result
+        assert result["customer_score"] is None
+
+    # Test 4
+    def test_peer_score_null_passthrough(self, full_backend_response):
+        """peerScore == None -> all_peers_score is None."""
+        payload = copy.deepcopy(full_backend_response)
+        payload["peerScore"] = None
+
+        result = get_reduced_peer_benchmark_response(payload)
+
+        assert "all_peers_score" in result
+        assert result["all_peers_score"] is None
+
+    # Test 5
+    def test_industry_scores_empty_passthrough(self, full_backend_response):
+        """industryScores == [] -> customer_industry_scores is []."""
+        payload = copy.deepcopy(full_backend_response)
+        payload["industryScores"] = []
+
+        result = get_reduced_peer_benchmark_response(payload)
+
+        assert "customer_industry_scores" in result
+        assert result["customer_industry_scores"] == []
+
+    # Test 6
+    def test_data_through_date_null_passthrough(self, full_backend_response):
+        """dataThroughDate == None -> peer_data_through_date is None."""
+        payload = copy.deepcopy(full_backend_response)
+        payload["dataThroughDate"] = None
+
+        result = get_reduced_peer_benchmark_response(payload)
+
+        assert "peer_data_through_date" in result
+        assert result["peer_data_through_date"] is None
+
+    # Test 7
+    def test_hint_attached(self, full_backend_response):
+        """hint='x' -> result has hint_to_agent='x' at the top level."""
+        result = get_reduced_peer_benchmark_response(
+            full_backend_response, hint="Some helpful hint for the agent"
+        )
+
+        assert "hint_to_agent" in result
+        assert result["hint_to_agent"] == "Some helpful hint for the agent"
+
+    # Test 8
+    def test_hint_omitted_or_empty(self, full_backend_response):
+        """hint is None or '' -> no hint_to_agent key in output."""
+        result_none = get_reduced_peer_benchmark_response(full_backend_response, hint=None)
+        assert "hint_to_agent" not in result_none
+
+        result_empty = get_reduced_peer_benchmark_response(full_backend_response, hint="")
+        assert "hint_to_agent" not in result_empty
+
+    # Test 9
+    def test_unknown_top_level_key_defensive_fallthrough(self, full_backend_response, caplog):
+        """Unknown top-level key -> WARNING log + known fields preserved + unknown key dropped."""
+        payload = copy.deepcopy(full_backend_response)
+        payload["unexpectedNewField"] = "some_value"
+
+        with caplog.at_level(logging.WARNING, logger="safebreach_mcp_data.data_types"):
+            result = get_reduced_peer_benchmark_response(payload)
+
+        # Known fields still work
+        assert result["start_date"] == "2026-03-01T00:00:00.000Z"
+        assert result["customer_score"] is not None
+        assert result["customer_score"]["score"] == 0.68
+
+        # Unknown key is NOT passed through
+        assert "unexpectedNewField" not in result
+
+        # At least one WARNING record mentioning the unknown key
+        warning_messages = [
+            record.message for record in caplog.records
+            if record.levelno == logging.WARNING
+        ]
+        assert any("unexpectedNewField" in message for message in warning_messages), (
+            f"expected a WARNING mentioning 'unexpectedNewField'; got: {warning_messages}"
+        )
+
+    # Test 10
+    def test_industry_name_inside_industry_scores(self, full_backend_response):
+        """industry field inside industryScores[] becomes industry_name in output."""
+        result = get_reduced_peer_benchmark_response(full_backend_response)
+
+        industry_entry = result["customer_industry_scores"][0]
+        assert industry_entry["industry_name"] == "Information Technology"
+        assert "industry" not in industry_entry

--- a/safebreach_mcp_data/tests/test_e2e.py
+++ b/safebreach_mcp_data/tests/test_e2e.py
@@ -17,7 +17,7 @@ from typing import Dict, Any
 
 from safebreach_mcp_data.data_functions import (
     sb_get_tests_history,
-    sb_get_test_details, 
+    sb_get_test_details,
     sb_get_test_simulations,
     sb_get_simulation_details,
     sb_get_security_controls_events,
@@ -25,7 +25,8 @@ from safebreach_mcp_data.data_functions import (
     sb_get_test_findings_counts,
     sb_get_test_findings_details,
     sb_get_test_drifts,
-    sb_get_full_simulation_logs
+    sb_get_full_simulation_logs,
+    sb_get_peer_benchmark_score,
 )
 
 
@@ -689,3 +690,112 @@ class TestDataServerE2E:
         
         print(f"  ✅ Error handling validation completed successfully")
         print(f"==================================\n")
+
+
+# ---------------------------------------------------------------------
+# Peer benchmark score E2E (SAF-29415 Phase 4)
+# ---------------------------------------------------------------------
+# This test is pinned to the `staging` console because the backend
+# /api/data/v1/accounts/{id}/score endpoint (SAF-27621) is deployed on
+# staging.sbops.com but NOT yet on pentest01.safebreach.com (the default
+# E2E_CONSOLE for this repo as of 2026-04-13). Reusing the shared
+# `e2e_console` fixture would point at pentest01 and cause a 404.
+#
+# TODO (SAF-29415 follow-up): once /score lands on pentest01, retire the
+# `peer_benchmark_e2e_console` fixture and switch this test to use the
+# shared `e2e_console` fixture.
+
+@pytest.fixture(scope="class")
+def peer_benchmark_e2e_console():
+    """Resolve the console for the peer benchmark E2E test.
+
+    Defaults to `staging` (where the backend /score endpoint lives).
+    Override via PEER_BENCHMARK_E2E_CONSOLE. Skips (does not fail) when
+    the resolved console isn't configured locally — neither environments
+    metadata nor a credential is set.
+    """
+    console = os.environ.get('PEER_BENCHMARK_E2E_CONSOLE', 'staging')
+    skip_msg = (
+        "Peer Benchmark E2E skipped: endpoint not yet deployed on the "
+        "default E2E console; set PEER_BENCHMARK_E2E_CONSOLE to a console "
+        "that has POST /api/data/v1/accounts/{id}/score live, or configure "
+        "credentials for the 'staging' console."
+    )
+
+    # Defer imports so collection-time failures here don't affect other tests.
+    from safebreach_mcp_core.environments_metadata import get_environment_by_name
+    from safebreach_mcp_core.secret_utils import get_secret_for_console
+
+    try:
+        get_environment_by_name(console)
+    except Exception:
+        pytest.skip(skip_msg)
+
+    try:
+        token = get_secret_for_console(console)
+        if not token:
+            pytest.skip(skip_msg)
+    except Exception:
+        pytest.skip(skip_msg)
+
+    return console
+
+
+class TestPeerBenchmarkScoreE2E:
+    """End-to-end smoke test for sb_get_peer_benchmark_score (SAF-29415)."""
+
+    @pytest.mark.e2e
+    def test_peer_benchmark_score_e2e(self, peer_benchmark_e2e_console):
+        """Smoke: 30-day window against staging; assert renamed top-level shape."""
+        import time
+
+        end_ms = int(time.time() * 1000)
+        start_ms = end_ms - (30 * 24 * 60 * 60 * 1000)  # 30 days back
+
+        print(f"\n=== Peer Benchmark E2E ===")
+        print(f"  Console: {peer_benchmark_e2e_console}")
+        print(f"  Window: {start_ms} -> {end_ms} (30 days)")
+
+        result = sb_get_peer_benchmark_score(
+            console=peer_benchmark_e2e_console,
+            start_date=start_ms,
+            end_date=end_ms,
+        )
+
+        # Top-level renamed keys must always be present (even on 204 path).
+        assert isinstance(result, dict)
+        for required_key in (
+            "start_date", "end_date",
+            "customer_score", "all_peers_score", "customer_industry_scores",
+        ):
+            assert required_key in result, f"missing required key: {required_key}"
+
+        # Scores: each is either None or a dict with the expected sub-keys.
+        for score_key in ("customer_score", "all_peers_score"):
+            value = result[score_key]
+            assert value is None or isinstance(value, dict), (
+                f"{score_key} must be None or dict, got {type(value).__name__}"
+            )
+            if isinstance(value, dict):
+                for sub_key in ("score", "score_blocked", "score_detected"):
+                    assert sub_key in value, f"{score_key} missing {sub_key}"
+
+        # customer_industry_scores must be a list (possibly empty);
+        # each element (if any) must be a dict carrying industry_name.
+        industries = result["customer_industry_scores"]
+        assert isinstance(industries, list)
+        for entry in industries:
+            assert isinstance(entry, dict)
+            assert "industry_name" in entry
+            assert "score" in entry
+
+        # Surface useful operational signal — if the staging snapshot is
+        # frozen or the window has no data, the hint explains it. The
+        # test still passes because the structured empty shape is valid.
+        if "hint_to_agent" in result:
+            print(f"  hint_to_agent: {result['hint_to_agent']}")
+        else:
+            print(f"  customer_score.score: {result['customer_score'].get('score') if result['customer_score'] else None}")
+            print(f"  all_peers_score.score: {result['all_peers_score'].get('score') if result['all_peers_score'] else None}")
+        print(f"  ✅ Peer benchmark E2E shape verified")
+        print(f"==========================\n")


### PR DESCRIPTION
## Summary

- New MCP tool **`get_peer_benchmark_score`** on the Data Server (port 8001) wraps `POST /api/data/v1/accounts/{id}/score` (delivered upstream in SAF-27621). Lets MCP clients (Claude Desktop, console AI chat) answer natural-language posture-comparison queries without users opening the UI.
- Built via TDD across 3 implementation phases (transform helper → business logic + cache → MCP wrapper) plus 1 staging-pinned E2E smoke and CLAUDE.md docs.
- Final round: response-shape polish driven by Claude Desktop UX testing — neutralized hint strings (no internal env names leaking to end-users), renamed `score_unblocked` → `score_missed`, added always-on `scoring_formula` + `scope_note` fields, and sorted `security_control_breakdown[]` alphabetically.

JIRA: [SAF-29415](https://safebreach.atlassian.net/browse/SAF-29415)

## What changed

- **`safebreach_mcp_data/data_types.py`**: `peer_benchmark_rename_mapping` + nested score/control field mappings; `get_reduced_peer_benchmark_response()` transform helper that renames camelCase to snake_case, sorts control breakdowns alphabetically, and emits always-on `scoring_formula` / `scope_note` metadata.
- **`safebreach_mcp_data/data_functions.py`**: `peer_benchmark_cache` (`maxsize=3`, `ttl=600s`, gated by `SB_MCP_CACHE_DATA`); `sb_get_peer_benchmark_score()` with input validation (mutual-exclusivity + date ordering) at the MCP boundary, ISO 8601 conversion for the request body, HTTP 204 handling, and end-user-safe hint composition.
- **`safebreach_mcp_data/data_server.py`**: `@self.mcp.tool(name=\"get_peer_benchmark_score\")` registration with full peers-vs-industry docstring (drives LLM tool-selection); thin wrapper does `normalize_timestamp` + required-field validation, then delegates by kwargs.
- **`safebreach_mcp_data/tests/`**: 37 unit tests (11 transform + 17 business logic + 10 wrapper, including hint sanitization + alphabetical sort) and 1 E2E smoke pinned to a dedicated `peer_benchmark_e2e_console` fixture (defaults to \`staging\` because `/score` isn't on `pentest01` yet).
- **`CLAUDE.md`**: tools-list entry at item 15 with the full peers-vs-industry explainer; cache strategy line gains `peer_benchmark (3/600s)`.
- **`prds/saf-29415-add-peer-benchmark-to-data-mcp/`**: full PRD, context, summary, and manual test plan.

## Key design decisions

- **Pass-through with rename mapping** (not strict verbatim, not aggressive reduction). Field names are snake_case and self-explanatory: `customer_score`, `all_peers_score`, `customer_industry_scores`, `score_missed`, `peer_snapshot_month`, `peer_data_through_date`, `custom_attacks_filtered_count`.
- **Peers-vs-industry disambiguation in the field names themselves**: `all_peers_score` is across all SafeBreach customers regardless of industry; `customer_industry_scores` is server-side scoped to the customer's own industry only (Salesforce mapping; not overridable; typically 0 or 1 element).
- **Self-contained response**: `scoring_formula` and `scope_note` are always present so the agent doesn't need to carry the formula or the customer-vs-peer scope asymmetry across turns.
- **Hint sanitization**: hints reach end-users verbatim through the LLM, so they're free of internal terms (no \"staging\", \"private-dev\", \"frozen snapshot\", or the `>= 10_000_000` custom-attack threshold). Test 17 enforces this with a forbidden-term list.
- **MCP-boundary validation** for include/exclude mutual exclusivity gives the agent a clean error before hitting the backend.

## Test plan

- [x] Unit tests: 37 new tests, all green (`uv run pytest safebreach_mcp_data/tests/ -m \"not e2e\"` → 404 passed)
- [x] Cross-server suite: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/ safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ -m \"not e2e\"` → 604 passed, no regressions
- [x] Live E2E vs `staging.sbops.com`: PASS (customer 0.80 vs all-peers 0.53, 30-day window, ~1.3s)
- [x] **Manual** — see `prds/saf-29415-add-peer-benchmark-to-data-mcp/manual-tests.md` for the 8-test plan covering Claude Desktop tool surface, console AI chat (ticket DOD), LLM peers-vs-industry disambiguation, cross-tool composition, frozen-snapshot hint UX, cache visibility, token-leak audit on real server logs, and pentest01 (endpoint-not-deployed) error UX.

## Follow-up

- E2E test is pinned to \`staging\` via a dedicated `peer_benchmark_e2e_console` fixture because `/score` isn't yet deployed on `pentest01`. Once it lands on pentest01, retire the fixture and switch to the shared `e2e_console`.
- One DoD item still open per the original ticket: validate end-to-end from Claude Desktop / console AI chat (manual user task — covered by manual-tests.md T1.1/T1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)