### PR TITLE
SAF-29966: Add scenario listing and detail tools to Config Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,8 @@ This is a Model Context Protocol (MCP) server that bridges AI agents with SafeBr
 
 **Caching Strategy**: All caches use bounded `SafeBreachCache` (wraps `cachetools.TTLCache`) with
 per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to bound memory:
-- **Config Server**: `simulators` (5/3600s), `scenarios` (5/1800s), `scenario_categories` (5/3600s)
+- **Config Server**: `simulators` (5/3600s), `scenarios` (5/1800s), `scenario_categories` (5/3600s),
+  `plans` (5/1800s)
 - **Data Server**: `tests` (5/1800s), `simulations` (3/600s), `security_control_events` (3/600s),
   `findings` (3/600s), `full_simulation_logs` (2/300s), `peer_benchmark` (3/600s)
 - **Playbook Server**: `playbook_attacks` — maxsize=5, TTL=1800s
@@ -275,13 +276,16 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 1. `get_console_simulators` ✨ **Enhanced** - Filtered simulator retrieval with status, name, label, OS type,
   and criticality filtering plus customizable ordering
 2. `get_simulator_details` - Get detailed simulator information
-3. `get_scenarios` ✨ **NEW** - Filtered and paginated scenario listing with name, creator (OOB/custom),
-  category, recommended, tag, and ready-to-run filtering. Categories resolved from separate endpoint.
+3. `get_scenarios` ✨ **NEW** - Filtered and paginated listing of BOTH OOB (SafeBreach-published)
+  scenarios AND custom (user-created) plans. Each item has `source_type='oob'|'custom'`. By default
+  returns both sources merged; `creator_filter='safebreach'` returns OOB only, `creator_filter='custom'`
+  returns plans only. Other filters: name, category (OOB only), recommended (OOB only), tag, ready-to-run.
   Ready-to-run = all steps have both targetFilter AND attackerFilter with non-empty criteria values.
   Supports ordering by name, step_count, createdAt, updatedAt (asc/desc). PAGE_SIZE=10 with hint_to_agent.
-4. `get_scenario_details` ✨ **NEW** - Full scenario payload by UUID including all steps with attack
-  filters, system filters, target/attacker filters, phases, actions, edges, and resolved category names.
-  Full payload preserved for future queue API integration.
+4. `get_scenario_details` ✨ **NEW** - Full scenario/plan payload by ID. Accepts UUID string (OOB) or
+  integer-as-string (custom plan). Returns complete payload including all steps with attack filters,
+  system/target/attacker filters, phases, actions, edges, plus `source_type` and resolved category names
+  (empty for custom). Full payload preserved for future queue API integration.
 
 **Data Server (Port 8001):**
 3. `get_tests_history` ✨ **Enhanced** - Filtered and paginated test execution history with advanced filtering options (test type, time windows, status, name patterns) and customizable ordering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ This is a Model Context Protocol (MCP) server that bridges AI agents with SafeBr
 
 **Caching Strategy**: All caches use bounded `SafeBreachCache` (wraps `cachetools.TTLCache`) with
 per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to bound memory:
-- **Config Server**: `simulators` — maxsize=5, TTL=3600s
+- **Config Server**: `simulators` (5/3600s), `scenarios` (5/1800s), `scenario_categories` (5/3600s)
 - **Data Server**: `tests` (5/1800s), `simulations` (3/600s), `security_control_events` (3/600s),
   `findings` (3/600s), `full_simulation_logs` (2/300s), `peer_benchmark` (3/600s)
 - **Playbook Server**: `playbook_attacks` — maxsize=5, TTL=1800s
@@ -272,8 +272,16 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 ### Multi-Server Distribution
 
 **Config Server (Port 8000):**
-1. `get_console_simulators` ✨ **Enhanced** - Filtered simulator retrieval with status, name, label, OS type, and criticality filtering plus customizable ordering
-2. `get_simulator_details` - Get detailed simulator information  
+1. `get_console_simulators` ✨ **Enhanced** - Filtered simulator retrieval with status, name, label, OS type,
+  and criticality filtering plus customizable ordering
+2. `get_simulator_details` - Get detailed simulator information
+3. `get_scenarios` ✨ **NEW** - Filtered and paginated scenario listing with name, creator (OOB/custom),
+  category, recommended, tag, and ready-to-run filtering. Categories resolved from separate endpoint.
+  Ready-to-run = all steps have both targetFilter AND attackerFilter with non-empty criteria values.
+  Supports ordering by name, step_count, createdAt, updatedAt (asc/desc). PAGE_SIZE=10 with hint_to_agent.
+4. `get_scenario_details` ✨ **NEW** - Full scenario payload by UUID including all steps with attack
+  filters, system filters, target/attacker filters, phases, actions, edges, and resolved category names.
+  Full payload preserved for future queue API integration.
 
 **Data Server (Port 8001):**
 3. `get_tests_history` ✨ **Enhanced** - Filtered and paginated test execution history with advanced filtering options (test type, time windows, status, name patterns) and customizable ordering

--- a/prds/SAF-29966-create-tool-to-list-scenarios/context.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/context.md
@@ -42,7 +42,7 @@ Scenario APIs use `/api/content-manager/vLatest/` — similar content domain as 
 - **types.py**: Transform API dicts → reduced/full output dicts, client-side filtering, pagination (PAGE_SIZE=10)
 - **functions.py**: `requests.get()` with `x-apitoken` header, 120s timeout, optional `SafeBreachCache` (TTLCache)
 - **server.py**: `@self.mcp.tool()` decorator, returns `str` (formatted text, not JSON), error wrapping
-- **tests/**: `@patch()` mocking of `requests.get`, `get_secret_for_console`, `get_api_base_url`;
+- **tests/**: `@patch()` mocking of `requests.get`, credential helpers, `get_api_base_url`;
   `@pytest.fixture` for test data; class-based grouping with `setup_method`/`teardown_method`
 
 ### Auth Pattern

--- a/prds/SAF-29966-create-tool-to-list-scenarios/context.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29966
 
 ## Status
-Phase 3: Create Working Branch and PRD Context
+Phase 6: PRD Created
 
 ## Mode
 Improving
@@ -140,3 +140,60 @@ Each step has: `name`, `draft` (bool), `systemFilter`, `targetFilter`, `attacker
 
 ### Ordering Options
 name (default), step_count, created_at, updated_at — asc/desc
+
+## Implementation Pattern Details (Phase 4 Deep Dive)
+
+### Config Server Tool Pattern
+- Tools return `-> dict` (not str like Playbook)
+- Functions are `async def`
+- Single-tenant auto-resolve: check `if not safebreach_envs:` then override console name
+- Import: `from safebreach_mcp_core.environments_metadata import get_console_name, safebreach_envs`
+
+### Pagination Pattern (from playbook_types.py:561-600)
+- 0-based page numbering, PAGE_SIZE=10
+- Ceiling division: `total_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE`
+- Slice: `start = page * PAGE_SIZE`, `end = min(start + PAGE_SIZE, total)`
+- Response keys: `page_number`, `total_pages`, `total_scenarios`, `scenarios_in_page`, `hint_to_agent`
+- `hint_to_agent` = None on last page
+- Invalid page returns `error` key with empty list
+
+### Filtering Pattern (from playbook_types.py:369-497)
+- Copy input list, chain sequential filters (AND logic)
+- Case-insensitive partial match: `filter.lower() in item['name'].lower()`
+- Use `.get()` for safe access
+- `applied_filters` dict tracks only provided (non-default) filters
+
+### Cache Pattern
+- `scenarios_cache = SafeBreachCache(name="scenarios", maxsize=5, ttl=1800)`
+- `categories_cache = SafeBreachCache(name="scenario_categories", maxsize=5, ttl=3600)`
+- Check `is_caching_enabled("config")` before get/set
+- Cache key: `f"scenarios_{console}"`, `f"categories_{console}"`
+
+### Test Pattern (from config tests)
+- `setup_method()`: clear caches
+- `@pytest.fixture` for mock data matching API response structure
+- `@patch()` decorators for `requests.get`, `get_secret_for_console`, `get_api_base_url`
+- Config does NOT need `get_api_account_id` for scenarios (no account_id in path)
+- Assert dict structure and pagination metadata
+
+### Naming Convention (confirmed with user)
+- **Tool input params**: snake_case (`name_filter`, `page_number`)
+- **Pagination/metadata keys**: snake_case (`total_pages`, `hint_to_agent`, `applied_filters`)
+- **Entity fields from API**: Preserve API names (`createdBy`, `createdAt`, `updatedAt`)
+- **New computed fields**: snake_case (`step_count`, `is_ready_to_run`, `category_names`)
+
+## Brainstorming Results
+
+### Chosen Approach: Single API Call + Client-Side Everything (Approach A)
+- Fetch all scenarios in one `/scenarios` call, cache full objects
+- Categories fetched separately with dedicated cache (TTL=3600s)
+- Filter, compute ready-to-run, join categories, paginate — all client-side
+- `get_scenario_details` looks up by ID from cached list (free, no extra API call)
+- Matches proven playbook server pattern exactly
+
+### Key Design Decisions
+1. **get_scenario_details returns full raw payload** (for future queue API use)
+2. **get_scenarios list view is minimal**: step_count only, no step names
+3. **Categories**: Separate cache, lazy-loaded, TTL=3600s
+4. **Scenarios**: Cache full objects, TTL=1800s, maxsize=5
+5. **is_ready_to_run computed from steps** during transform (not stored in API)

--- a/prds/SAF-29966-create-tool-to-list-scenarios/context.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29966
 
 ## Status
-Phase 6: Summary Created
+Phase 3: Create Working Branch and PRD Context
 
 ## Mode
 Improving
@@ -48,7 +48,7 @@ Scenario APIs use `/api/content-manager/vLatest/` — similar content domain as 
 ### Auth Pattern
 - Token: `get_secret_for_console(console)` → header `{"x-apitoken": token}`
 - Base URL: `get_api_base_url(console, endpoint_type)` → e.g., `https://console.safebreach.com`
-- Note: Scenario API uses `x-token` header (JWT), which differs from existing `x-apitoken` pattern
+- Confirmed: `x-apitoken` works with `/api/content-manager/vLatest/` endpoints (tested live)
 
 ### Caching
 - `SafeBreachCache(name=..., maxsize=..., ttl=...)` wrapper around `cachetools.TTLCache`
@@ -93,11 +93,50 @@ Two new MCP tools needed in the Config Server to expose SafeBreach scenario mana
 5. **Pagination**: Follow existing PAGE_SIZE=10 pattern if scenario list is large
 
 ### Risks & Edge Cases
-- **API response structure unknown**: Need actual API response to design transforms accurately
-- **Category join**: If categories are separate, need to fetch both and join client-side
-- **No account_id in path**: Scenario API may use different URL structure than config API
-- **Large scenario lists**: May need pagination if response is large
-- **OOB vs custom distinction**: Need to identify which field in API response indicates this
+- **Category join**: Categories are separate endpoint, need client-side join by integer ID
+- **No account_id in path**: Scenario API uses `/api/content-manager/vLatest/scenarios` (no account_id)
+- **Large scenario lists**: 443 scenarios on pentest01 — pagination essential
+- **Null-safe handling**: `tags` and `description` can be null
 
-## Proposed Improvements
-(Phase 6)
+## Real API Response Analysis (from pentest01 console)
+
+### Scenario Object Fields
+`id` (UUID), `name`, `description` (nullable), `createdBy`, `recommended` (bool),
+`categories` (int[]), `tags` (str[] or null), `createdAt`, `updatedAt`,
+`steps` (step objects), `order`, `actions`, `edges`, `phases`, `minApiVer`, `maxApiVer`
+
+### Category Object Fields
+`id` (int), `name`, `description`, `icon`, `scenarioIcon`, `cardBackGround`, `order`, `minApiVer`
+
+### Data Volume
+- 443 scenarios total (all `createdBy: "SafeBreach"` on this console, but field supports custom)
+- 15 categories (static reference data)
+- 6 recommended scenarios
+- 206 scenarios with tags
+- Steps per scenario: 0-16, avg 6.3
+- 1 scenario has no steps
+
+### Ready-to-Run Definition (confirmed with user)
+A scenario is "ready to run" when ALL steps have BOTH `targetFilter` AND `attackerFilter`
+with at least one key containing non-empty `values` arrays (e.g., `os`, `role`, `simulators`
+with actual IDs). Empty `simulators.values: []` does NOT qualify.
+- 4 of 443 are ready on pentest01
+- targetFilter keys found: `os`, `simulators`
+- attackerFilter keys found: `os`, `role`, `simulators`
+
+### Step Structure
+Each step has: `name`, `draft` (bool), `systemFilter`, `targetFilter`, `attackerFilter`,
+`attacksFilter` (references attacks by `playbook` IDs or `tags` criteria)
+
+### Proposed Filters
+| Filter | Type | Field Source |
+|--------|------|-------------|
+| `name_filter` | Partial match (case-insensitive) | `name` |
+| `creator_filter` | "safebreach"/"custom" | `createdBy` |
+| `category_filter` | Category name partial match | `categories[]` → join |
+| `recommended_filter` | Boolean | `recommended` |
+| `tag_filter` | Partial match (case-insensitive) | `tags[]` |
+| `ready_to_run_filter` | Boolean | computed from steps |
+
+### Ordering Options
+name (default), step_count, created_at, updated_at — asc/desc

--- a/prds/SAF-29966-create-tool-to-list-scenarios/context.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/context.md
@@ -1,0 +1,103 @@
+# Ticket Context: SAF-29966
+
+## Status
+Phase 6: Summary Created
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: [safebreach-mcp] Create tools to allow listing of all available scenarios and drilling in into a specific one
+- **Description**: List of scenarios should indicate which are OOB vs custom, which are ready to run, how many attacks are included, and what category is each one in. A second tool should accept the scenario id as input and return a full payload of a scenario.
+- **Status**: In Progress
+- **Assignee**: Yossi Attas
+- **Priority**: Medium
+
+## Task Scope
+Full investigation of codebase architecture and existing patterns to prepare for implementing two new MCP tools:
+1. `get_scenarios` — List all available scenarios with OOB/custom indicator, ready-to-run status, attack count, and category
+2. `get_scenario_details` — Get full scenario payload by ID
+
+## API Endpoints
+- `GET /api/content-manager/vLatest/scenarios` — Lists all scenarios
+- `GET /api/content-manager/vLatest/scenarioCategories` — Lists scenario categories
+- Authentication: `x-token` header (JWT)
+- Base path: `/api/content-manager/vLatest/`
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+
+## Investigation Findings
+
+### Server Architecture & API Paths
+Each server handles specific API base paths:
+- **Config (8000)**: `/api/config/v1/` — Simulators
+- **Data (8001)**: `/api/data/v1/` and `/api/siem/v1/` — Tests/simulations
+- **Playbook (8003)**: `/api/kb/vLatest/` — Attack moves
+- **Studio (8004)**: `/api/content/v1/` — Custom attack code
+
+Scenario APIs use `/api/content-manager/vLatest/` — similar content domain as Studio.
+
+### Implementation Patterns (from Playbook server reference)
+- **types.py**: Transform API dicts → reduced/full output dicts, client-side filtering, pagination (PAGE_SIZE=10)
+- **functions.py**: `requests.get()` with `x-apitoken` header, 120s timeout, optional `SafeBreachCache` (TTLCache)
+- **server.py**: `@self.mcp.tool()` decorator, returns `str` (formatted text, not JSON), error wrapping
+- **tests/**: `@patch()` mocking of `requests.get`, `get_secret_for_console`, `get_api_base_url`;
+  `@pytest.fixture` for test data; class-based grouping with `setup_method`/`teardown_method`
+
+### Auth Pattern
+- Token: `get_secret_for_console(console)` → header `{"x-apitoken": token}`
+- Base URL: `get_api_base_url(console, endpoint_type)` → e.g., `https://console.safebreach.com`
+- Note: Scenario API uses `x-token` header (JWT), which differs from existing `x-apitoken` pattern
+
+### Caching
+- `SafeBreachCache(name=..., maxsize=..., ttl=...)` wrapper around `cachetools.TTLCache`
+- Opt-in via env vars: `SB_MCP_CACHE_<SERVER>=true`
+- Key format: `f"{type}_{console}"`, e.g., `"scenarios_demo"`
+
+### Existing Scenario Code
+- **None found** — this is a greenfield feature
+
+### Server Placement Options
+1. **Studio Server (8004)**: Closest domain (content), avoids new server complexity
+2. **New Content-Manager Server (8005)**: Clean separation, new port
+
+## Problem Analysis
+
+### Problem Scope
+Two new MCP tools needed in the Config Server to expose SafeBreach scenario management:
+1. **`get_scenarios`** — List all scenarios with metadata (OOB/custom, ready-to-run, attack count, category)
+2. **`get_scenario_details`** — Full scenario payload by ID
+
+### API Integration
+- **List endpoint**: `GET /api/content-manager/vLatest/scenarios`
+- **Categories endpoint**: `GET /api/content-manager/vLatest/scenarioCategories`
+- **Detail endpoint**: Likely `GET /api/content-manager/vLatest/scenarios/{id}` (TBD — may be in list payload)
+- **Auth**: `x-apitoken` header (standard pattern, per user decision)
+- **URL resolution**: `get_api_base_url(console, 'content-manager')` — no `account_id` in path
+
+### Affected Areas
+- `safebreach_mcp_config/config_types.py` — Add scenario transform functions
+- `safebreach_mcp_config/config_functions.py` — Add scenario business logic, cache, API calls
+- `safebreach_mcp_config/config_server.py` — Register two new MCP tools
+- `safebreach_mcp_config/tests/` — Unit tests for all new code
+- `safebreach_mcp_core/environments_metadata.py` — Add 'content-manager' to endpoint docs
+- `CLAUDE.md` — Update tool documentation
+
+### Key Design Decisions
+1. **Server placement**: Config Server (8000) — user decision
+2. **Auth method**: `x-apitoken` — matches existing pattern
+3. **Caching**: Use existing `SB_MCP_CACHE_CONFIG` env var, new SafeBreachCache for scenarios
+4. **Categories**: May need to join scenarios with categories endpoint, or categories may already
+   be embedded in scenario response (need API response analysis)
+5. **Pagination**: Follow existing PAGE_SIZE=10 pattern if scenario list is large
+
+### Risks & Edge Cases
+- **API response structure unknown**: Need actual API response to design transforms accurately
+- **Category join**: If categories are separate, need to fetch both and join client-side
+- **No account_id in path**: Scenario API may use different URL structure than config API
+- **Large scenario lists**: May need pagination if response is large
+- **OOB vs custom distinction**: Need to identify which field in API response indicates this
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
@@ -1,0 +1,619 @@
+# Scenario Listing and Detail Tools for Config Server — SAF-29966
+
+## 1. Overview
+
+| Field | Value |
+|-------|-------|
+| **Task Type** | Feature |
+| **Purpose** | Enable AI agents to discover and inspect SafeBreach scenarios via MCP tools |
+| **Target Consumer** | AI agents (Claude, etc.) interacting with SafeBreach via MCP protocol |
+| **Key Benefits** | 1) Scenario discovery with filtering and pagination 2) Full scenario payload for inspection and future queue API integration 3) Ready-to-run status visibility |
+| **Business Alignment** | Extends SafeBreach MCP coverage to scenario management, completing the AI-driven workflow |
+| **Originating Request** | [SAF-29966](https://safebreach.atlassian.net/browse/SAF-29966) |
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-04-14 18:30 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+## 2. Solution Description
+
+### Chosen Solution
+Single API call with client-side filtering, pagination, and category join.
+Fetch all scenarios from `GET /api/content-manager/vLatest/scenarios` in one call,
+cache full objects, and perform all filtering, ordering, and pagination client-side.
+Categories are fetched from a separate endpoint and cached independently.
+`get_scenario_details` performs a lookup by ID from the cached scenario list.
+
+This approach mirrors the proven Playbook Server pattern, keeping implementation
+simple, consistent, and maintainable.
+
+### Alternatives Considered
+
+**Approach B: Reduced Cache + API Details on Demand**
+- Cache only transformed reduced objects for the list view
+- Hit the API for every `get_scenario_details` call
+- Pros: Lower memory footprint (~500KB vs ~3MB per console)
+- Cons: Extra API call per detail request; `is_ready_to_run` must be precomputed during
+  initial transform since step data is discarded; inconsistent with existing patterns
+
+**Approach C: Dual Cache (Reduced + Full)**
+- Maintain separate caches for reduced list and full objects
+- Pros: Both tools served from cache; fastest responses
+- Cons: Higher memory; more complex cache management; no real benefit over
+  Approach A since full objects are needed for `is_ready_to_run` computation anyway
+
+### Decision Rationale
+Approach A wins because `is_ready_to_run` requires step data regardless, making memory
+savings from Approach B illusory. Memory is trivial (443 scenarios ~3MB vs Playbook's
+4600+ attacks already cached similarly). Approach A also enables `get_scenario_details`
+for free from the cached list, and the full payload stays cached for future queue API use.
+
+## 3. Core Feature Components
+
+### Component A: Scenario Data Transforms (`config_types.py`)
+
+**Purpose**: Transform raw API scenario objects into reduced list view and compute derived fields.
+New functions added to the existing `config_types.py`.
+
+**Key Features**:
+- `get_reduced_scenario_mapping(scenario, categories_map)` — Transforms a full scenario object
+  into a reduced representation for list view. Includes: `id`, `name`, `description` (truncated
+  to 200 chars), `createdBy`, `recommended`, `category_names` (resolved from categories_map),
+  `tags`, `step_count`, `is_ready_to_run`, `createdAt`, `updatedAt`
+- `compute_is_ready_to_run(scenario)` — Evaluates whether ALL steps have BOTH `targetFilter`
+  AND `attackerFilter` with at least one key containing non-empty `values` arrays. Returns bool.
+- `filter_scenarios_by_criteria(scenarios, ...)` — Applies all 6 filters using AND logic:
+  name (partial), creator (safebreach/custom), category (partial on resolved names),
+  recommended (bool), tag (partial), ready_to_run (bool)
+- `apply_scenario_ordering(scenarios, order_by, order_direction)` — Sorts by name, step_count,
+  createdAt, or updatedAt in asc/desc order
+- `paginate_scenarios(scenarios, page_number, page_size)` — Returns paginated dict with
+  `page_number`, `total_pages`, `total_scenarios`, `scenarios_in_page`, `hint_to_agent`
+
+### Component B: Scenario Business Logic (`config_functions.py`)
+
+**Purpose**: API integration, caching, and orchestration for scenario operations.
+New functions added to the existing `config_functions.py`.
+
+**Key Features**:
+- `scenarios_cache` — `SafeBreachCache(name="scenarios", maxsize=5, ttl=1800)` for full
+  scenario objects per console
+- `categories_cache` — `SafeBreachCache(name="scenario_categories", maxsize=5, ttl=3600)`
+  for category reference data per console
+- `_get_all_scenarios_from_cache_or_api(console)` — Fetches all scenarios from
+  `GET {base_url}/api/content-manager/vLatest/scenarios` with `x-apitoken` header.
+  Caches full response list. Returns `List[Dict]`.
+- `_get_categories_map_from_cache_or_api(console)` — Fetches categories from
+  `GET {base_url}/api/content-manager/vLatest/scenarioCategories` with `x-apitoken` header.
+  Returns `Dict[int, str]` mapping category ID to name. Cached separately with longer TTL.
+- `sb_get_scenarios(console, page_number, name_filter, creator_filter, category_filter,
+  recommended_filter, tag_filter, ready_to_run_filter, order_by, order_direction)` —
+  Main orchestration: fetch scenarios + categories, transform to reduced view, apply filters,
+  order, paginate, return result dict with `applied_filters` and `hint_to_agent`.
+- `sb_get_scenario_details(scenario_id, console)` — Lookup scenario by UUID from cached list.
+  Returns full raw scenario object with `category_names` resolved. Raises `ValueError` if not found.
+- `clear_scenarios_cache()` / `clear_categories_cache()` — Cache clearing for tests.
+
+### Component C: MCP Tool Registration (`config_server.py`)
+
+**Purpose**: Register `get_scenarios` and `get_scenario_details` as MCP tools.
+New tool registrations added to the existing `_register_tools()` method.
+
+**Key Features**:
+- `get_scenarios` tool — `async def` returning `-> dict`. Includes single-tenant console
+  auto-resolve. Rich description documenting all parameters for Claude.
+- `get_scenario_details` tool — `async def` returning `-> dict`. Accepts `scenario_id` (UUID
+  string) and `console`. Single-tenant auto-resolve.
+
+### Component D: Unit Tests
+
+**Purpose**: Comprehensive test coverage for all new scenario functionality.
+
+**Key Features**:
+- `test_config_types.py` — Tests for `get_reduced_scenario_mapping`, `compute_is_ready_to_run`,
+  `filter_scenarios_by_criteria`, `apply_scenario_ordering`, `paginate_scenarios`
+- `test_config_functions.py` — Tests for `_get_all_scenarios_from_cache_or_api`,
+  `_get_categories_map_from_cache_or_api`, `sb_get_scenarios`, `sb_get_scenario_details`
+  with mocked API responses, cache behavior, error handling
+
+## 4. API Endpoints and Integration
+
+### Existing APIs to Consume
+
+**Scenarios List API**:
+- **URL**: `GET /api/content-manager/vLatest/scenarios`
+- **Headers**: `x-apitoken: {token}`, `Content-Type: application/json`
+- **Response**: JSON array of scenario objects. Each object contains:
+  `id` (UUID string), `name`, `description` (nullable), `createdBy`,
+  `recommended` (bool), `categories` (int[]), `tags` (string[] or null),
+  `createdAt`, `updatedAt`, `steps` (array of step objects with
+  `name`, `draft`, `systemFilter`, `targetFilter`, `attackerFilter`, `attacksFilter`),
+  `order`, `actions`, `edges`, `phases`, `minApiVer`, `maxApiVer`
+
+**Scenario Categories API**:
+- **URL**: `GET /api/content-manager/vLatest/scenarioCategories`
+- **Headers**: `x-apitoken: {token}`, `Content-Type: application/json`
+- **Response**: JSON array of category objects. Each object contains:
+  `id` (int), `name`, `description`, `icon`, `scenarioIcon`,
+  `cardBackGround`, `order`, `minApiVer`
+
+**Base URL Resolution**:
+- Multi-tenant: `get_api_base_url(console, 'content-manager')` resolves to console URL
+- Single-tenant: Falls back to `CONTENT_MANAGER_URL` env var or console config URL
+- No `account_id` in the URL path (unlike Config's simulator API)
+
+## 5. Example Customer Flow
+
+_Omitted — backend-only MCP tool changes, no UI workflow._
+
+## 6. Non-Functional Requirements
+
+### Technical Constraints
+- **Integration**: Config Server (port 8000) — extends existing `SafeBreachConfigServer` class
+- **Technology Stack**: Python 3.12+, `requests` library, `SafeBreachCache` (cachetools)
+- **Backward Compatibility**: No breaking changes — additive only (two new tools)
+- **Caching**: Controlled by existing `SB_MCP_CACHE_CONFIG` env var
+
+### Performance Requirements
+- **Response Times**: List endpoint under 2s (cached), under 10s (cold API call for 443 scenarios)
+- **Memory**: ~3MB per cached console (full scenario objects), max 5 consoles = ~15MB
+- **Category Cache**: ~10KB per console (15 categories), negligible
+
+## 7. Definition of Done
+
+**Core Functionality**:
+- [ ] `get_scenarios` returns paginated, filtered scenario list
+- [ ] `get_scenario_details` returns full raw scenario payload by UUID
+- [ ] Category names resolved from separate API endpoint
+- [ ] `is_ready_to_run` computed correctly per the agreed definition
+- [ ] All 6 filters work correctly in combination (AND logic)
+- [ ] Ordering works for all 4 fields in both directions
+- [ ] Pagination with `hint_to_agent` works correctly
+- [ ] Single-tenant mode auto-resolve works for both tools
+- [ ] Caching controlled by `SB_MCP_CACHE_CONFIG` env var
+
+**Quality Gates**:
+- [ ] Unit tests cover: transforms, filtering, pagination, ready-to-run, category join, caching, errors
+- [ ] All existing Config Server tests still pass
+- [ ] No regressions in other servers' test suites
+
+**Documentation**:
+- [ ] `CLAUDE.md` updated with new tool documentation
+
+## 8. Testing Strategy
+
+### Unit Testing
+- **Framework**: pytest with `unittest.mock`
+- **Scope**:
+  - `config_types.py`: Transform functions, `compute_is_ready_to_run` (edge cases: no steps,
+    empty filters, mixed filter types), filtering (each filter individually + combinations),
+    ordering (each field + direction), pagination (first/middle/last/invalid pages)
+  - `config_functions.py`: API call mocking (success, HTTP errors, malformed responses),
+    cache hit/miss behavior, category fetching and map building,
+    `sb_get_scenarios` full orchestration, `sb_get_scenario_details` found/not-found
+- **Mocking**: `@patch()` for `requests.get`, `get_secret_for_console`, `get_api_base_url`
+- **Fixtures**: Mock scenario data matching real API response structure,
+  mock category data, pre-built categories map
+
+### Integration Testing
+- E2E tests (marked `@pytest.mark.e2e`) that call real SafeBreach API
+  on pentest01 console — deferred to separate E2E test pass
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: RED — Types Tests | ⏳ Pending | - | - | Write tests first (all fail) |
+| Phase 2: GREEN — Types Implementation | ⏳ Pending | - | - | Implement to make tests pass |
+| Phase 3: RED — Functions Tests | ⏳ Pending | - | - | Write tests first (all fail) |
+| Phase 4: GREEN — Functions Implementation | ⏳ Pending | - | - | Implement to make tests pass |
+| Phase 5: MCP Tool Registration | ⏳ Pending | - | - | |
+| Phase 6: RED/GREEN — E2E Tests | ⏳ Pending | - | - | Against pentest01 console |
+| Phase 7: Documentation | ⏳ Pending | - | - | |
+
+### Phase 1: RED — Types Tests
+
+**Semantic Change**: Write all unit tests for scenario transform, filter, ordering, and
+pagination functions. All tests will fail (RED) because the functions don't exist yet.
+
+**Deliverables**: Complete test suite for `config_types.py` scenario functions.
+
+**Implementation Details**:
+
+1. **Test `compute_is_ready_to_run`** — `TestComputeIsReadyToRun` class
+   - Scenario with all steps having real OS/role criteria → `True`
+   - Scenario with steps having empty `simulators.values: []` only → `False`
+   - Scenario with no steps → `False`
+   - Scenario with mixed steps (some ready, some not) → `False`
+   - Scenario with one step having targetFilter but no attackerFilter → `False`
+
+2. **Test `get_reduced_scenario_mapping`** — `TestGetReducedScenarioMapping` class
+   - Verify all expected keys are present in output
+   - Verify `description` truncation at 200 chars
+   - Verify `category_names` resolved correctly from map
+   - Verify `step_count` computed correctly
+   - Verify `is_ready_to_run` computed correctly
+   - Verify null `tags` and `description` handled safely
+
+3. **Test `filter_scenarios_by_criteria`** — `TestFilterScenariosByCriteria` class
+   - Each filter individually with matching and non-matching data
+   - Combined filters (AND logic)
+   - `creator_filter`: "safebreach" matches "SafeBreach" (case-insensitive)
+   - `creator_filter`: "custom" excludes "SafeBreach"
+   - `tag_filter` with null tags scenarios
+   - `category_filter` partial matching on resolved names
+   - Empty filter set returns all scenarios
+
+4. **Test `apply_scenario_ordering`** — `TestApplyScenarioOrdering` class
+   - Each order_by field in asc and desc
+   - Case-insensitive name ordering
+
+5. **Test `paginate_scenarios`** — `TestPaginateScenarios` class
+   - First page, middle page, last page
+   - Invalid page number (negative, beyond total)
+   - `hint_to_agent` present on non-last pages, None on last page
+   - Empty input list
+   - Single-page result
+
+**Fixtures**: Mock scenario data matching real API response structure (full scenario objects
+with steps, targetFilter, attackerFilter), mock categories map `Dict[int, str]`,
+pre-transformed reduced scenario dicts for filter/ordering/pagination tests.
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/tests/test_config_types.py` | Modify | Add scenario test classes (all RED) |
+
+**Git Commit**: `test(config): add RED unit tests for scenario types and transforms`
+
+---
+
+### Phase 2: GREEN — Types Implementation
+
+**Semantic Change**: Implement scenario transform, filter, ordering, and pagination functions
+to make all Phase 1 tests pass.
+
+**Deliverables**: All pure functions passing their tests.
+
+**Implementation Details**:
+
+1. **`compute_is_ready_to_run(scenario)`**
+   - Accept a full scenario dict
+   - Return `False` if scenario has no steps (empty list)
+   - For each step, check that `targetFilter` is a non-empty dict AND `attackerFilter`
+     is a non-empty dict
+   - For each non-empty filter dict, verify at least one key has a `values` list that is
+     non-empty. A key like `"simulators"` with `"values": []` does NOT qualify.
+   - Return `True` only if ALL steps pass both checks
+
+2. **`get_reduced_scenario_mapping(scenario, categories_map)`**
+   - Accept a full scenario dict and a `Dict[int, str]` mapping category IDs to names
+   - Return a new dict with these keys:
+     - `id`, `name`, `createdBy`, `recommended`, `tags`, `createdAt`, `updatedAt`
+       — preserved directly from the scenario
+     - `description` — truncated to 200 characters with "..." suffix if longer; `None` if null
+     - `category_names` — list of resolved category name strings by looking up each int in
+       `scenario['categories']` against the categories_map; skip unknown IDs
+     - `step_count` — `len(scenario.get('steps', []))`
+     - `is_ready_to_run` — result of `compute_is_ready_to_run(scenario)`
+
+3. **`filter_scenarios_by_criteria(scenarios, name_filter, creator_filter, category_filter,
+   recommended_filter, tag_filter, ready_to_run_filter)`**
+   - Copy input list, then chain filters sequentially (AND logic)
+   - `name_filter`: case-insensitive partial match on `name`
+   - `creator_filter`: if `"safebreach"` → match `createdBy == "SafeBreach"` (case-insensitive);
+     if `"custom"` → match `createdBy != "SafeBreach"` (case-insensitive)
+   - `category_filter`: case-insensitive partial match on any string in `category_names` list
+   - `recommended_filter`: exact boolean match on `recommended`
+   - `tag_filter`: case-insensitive partial match on any string in `tags` list; scenarios with
+     `tags=None` or empty tags are excluded when this filter is active
+   - `ready_to_run_filter`: exact boolean match on `is_ready_to_run`
+
+4. **`apply_scenario_ordering(scenarios, order_by, order_direction)`**
+   - Valid `order_by`: `"name"` (default), `"step_count"`, `"createdAt"`, `"updatedAt"`
+   - Valid `order_direction`: `"asc"` (default), `"desc"`
+   - Sort using appropriate key function; for string fields use `.lower()` for
+     case-insensitive ordering
+
+5. **`paginate_scenarios(scenarios, page_number, page_size)`**
+   - Follow exact pattern from `playbook_types.py:paginate_attacks`
+   - Return dict: `page_number`, `total_pages`, `total_scenarios`,
+     `scenarios_in_page`, `hint_to_agent` (None on last page)
+   - On invalid page_number: return `error` key with empty `scenarios_in_page`
+
+**Verification**: Run `uv run pytest safebreach_mcp_config/tests/test_config_types.py -v`
+— all Phase 1 tests must pass (RED → GREEN).
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/config_types.py` | Modify | Add 5 new functions for scenario transforms |
+
+**Git Commit**: `feat(config): implement scenario transforms to pass types tests (GREEN)`
+
+---
+
+### Phase 3: RED — Functions Tests
+
+**Semantic Change**: Write all unit tests for scenario business logic functions.
+All tests will fail (RED) because the functions don't exist yet.
+
+**Deliverables**: Complete test suite for `config_functions.py` scenario functions.
+
+**Implementation Details**:
+
+1. **Test `_get_all_scenarios_from_cache_or_api`** — `TestGetAllScenariosFromCacheOrApi` class
+   - Successful API call: mock `requests.get` returning scenario list, verify return
+   - Cache hit: enable caching, pre-populate cache, verify no API call made
+   - Cache miss: enable caching, verify API called and result cached
+   - API error: mock `requests.get` raising exception, verify it propagates
+   - HTTP error: mock response with non-200 status, verify `raise_for_status()` triggers
+
+2. **Test `_get_categories_map_from_cache_or_api`** — `TestGetCategoriesMapFromCacheOrApi` class
+   - Successful API call: verify returns `Dict[int, str]` mapping
+   - Cache hit/miss behavior
+   - API error handling
+
+3. **Test `sb_get_scenarios`** — `TestSbGetScenarios` class
+   - Full orchestration: mock both API calls, verify paginated filtered result
+   - Invalid `order_by`: verify `ValueError`
+   - Invalid `creator_filter`: verify `ValueError`
+   - API failure: verify error dict returned (not exception raised)
+   - Pagination: create 25+ mock scenarios, verify page_number/total_pages
+
+4. **Test `sb_get_scenario_details`** — `TestSbGetScenarioDetails` class
+   - Found: mock scenarios list with target ID, verify full payload returned
+   - Not found: verify `ValueError` raised
+   - Empty scenario_id: verify `ValueError` raised
+   - Verify `category_names` added to returned scenario
+
+5. **Fixture setup**
+   - `setup_method`: clear both `scenarios_cache` and `categories_cache`
+   - `@pytest.fixture` for mock scenario data matching real API structure
+   - `@pytest.fixture` for mock categories API response (list of category objects)
+   - `@patch()` decorators for `requests.get`, `get_secret_for_console`, `get_api_base_url`
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/tests/test_config_functions.py` | Modify | Add scenario function test classes (all RED) |
+
+**Git Commit**: `test(config): add RED unit tests for scenario business logic functions`
+
+---
+
+### Phase 4: GREEN — Functions Implementation
+
+**Semantic Change**: Implement scenario business logic functions to make all Phase 3
+tests pass.
+
+**Deliverables**: API integration, caching, and orchestration functions.
+
+**Implementation Details**:
+
+1. **Module-level cache instances**
+   - `scenarios_cache = SafeBreachCache(name="scenarios", maxsize=5, ttl=1800)`
+   - `categories_cache = SafeBreachCache(name="scenario_categories", maxsize=5, ttl=3600)`
+   - `clear_scenarios_cache()` and `clear_categories_cache()` helper functions
+
+2. **`_get_all_scenarios_from_cache_or_api(console)`**
+   - Cache key: `f"scenarios_{console}"`
+   - If `is_caching_enabled("config")`, check `scenarios_cache.get(cache_key)`
+   - On cache miss: call `get_secret_for_console(console)` for token,
+     `get_api_base_url(console, 'content-manager')` for base URL
+   - Build URL: `f"{base_url}/api/content-manager/vLatest/scenarios"`
+   - Headers: `{"Content-Type": "application/json", "x-apitoken": apitoken}`
+   - `requests.get(url, headers=headers, timeout=120)`, call `response.raise_for_status()`
+   - Parse `response.json()` — the response IS the list (no `data` wrapper)
+   - Cache result if caching enabled
+   - Return `List[Dict]`
+
+3. **`_get_categories_map_from_cache_or_api(console)`**
+   - Cache key: `f"categories_{console}"`
+   - Same cache-check pattern with `is_caching_enabled("config")` and `categories_cache`
+   - Same API call pattern, URL: `f"{base_url}/api/content-manager/vLatest/scenarioCategories"`
+   - Parse response list and build `Dict[int, str]` mapping `category['id']` to
+     `category['name']`
+   - Cache the map if caching enabled
+   - Return `Dict[int, str]`
+
+4. **`sb_get_scenarios(console, page_number, name_filter, creator_filter, category_filter,
+   recommended_filter, tag_filter, ready_to_run_filter, order_by, order_direction)`**
+   - Validate `order_by` against valid list, raise `ValueError` if invalid
+   - Validate `order_direction` against `['asc', 'desc']`
+   - Validate `creator_filter` against `['safebreach', 'custom']` if provided
+   - Validate `page_number >= 0`
+   - Inside try/except:
+     - Fetch all scenarios: `_get_all_scenarios_from_cache_or_api(console)`
+     - Fetch categories map: `_get_categories_map_from_cache_or_api(console)`
+     - Transform each scenario to reduced view: `get_reduced_scenario_mapping(s, categories_map)`
+     - Apply filters: `filter_scenarios_by_criteria(reduced, ...)`
+     - Apply ordering: `apply_scenario_ordering(filtered, order_by, order_direction)`
+     - Paginate: `paginate_scenarios(ordered, page_number, PAGE_SIZE)`
+     - Build `applied_filters` dict (only non-default values)
+     - Add `applied_filters` to paginated result
+     - Return result dict
+   - On exception: return `{"error": f"Failed to get scenarios: {str(e)}", "console": console}`
+
+5. **`sb_get_scenario_details(scenario_id, console)`**
+   - Validate `scenario_id` is not empty
+   - Fetch all scenarios: `_get_all_scenarios_from_cache_or_api(console)`
+   - Fetch categories map: `_get_categories_map_from_cache_or_api(console)`
+   - Find scenario by matching `scenario['id'] == scenario_id`
+   - If not found: raise `ValueError(f"Scenario with ID '{scenario_id}' not found")`
+   - Return full scenario dict with added `category_names` field (resolved from categories_map)
+
+**Verification**: Run `uv run pytest safebreach_mcp_config/tests/ -v -m "not e2e"`
+— all Phase 1 + Phase 3 tests must pass (RED → GREEN).
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/config_functions.py` | Modify | Add cache instances, 5 new functions, 2 cache-clear helpers |
+
+**Git Commit**: `feat(config): implement scenario business logic to pass functions tests (GREEN)`
+
+---
+
+### Phase 5: MCP Tool Registration
+
+**Semantic Change**: Register `get_scenarios` and `get_scenario_details` as MCP tools in the
+Config Server.
+
+**Deliverables**: Two new MCP tools accessible to AI agents.
+
+**Implementation Details**:
+
+1. **Update imports** in `config_server.py` to include `sb_get_scenarios` and
+   `sb_get_scenario_details` from `.config_functions`
+
+2. **`get_scenarios` tool registration**
+   - Decorator: `@self.mcp.tool(name="get_scenarios", description="...")`
+   - Description must document all parameters for Claude (same style as `get_console_simulators`)
+   - Function signature: `async def get_scenarios_tool(console, page_number, name_filter,
+     creator_filter, category_filter, recommended_filter, tag_filter, ready_to_run_filter,
+     order_by, order_direction) -> dict`
+   - All filter parameters default to `None`, page_number defaults to `0`,
+     order_by defaults to `"name"`, order_direction defaults to `"asc"`
+   - Include single-tenant console auto-resolve pattern (same as `get_console_simulators`)
+   - Call `sb_get_scenarios(...)` and return result
+
+3. **`get_scenario_details` tool registration**
+   - Decorator: `@self.mcp.tool(name="get_scenario_details", description="...")`
+   - Function signature: `async def get_scenario_details_tool(scenario_id, console) -> dict`
+   - `scenario_id` is required (UUID string), `console` defaults to `"default"`
+   - Include single-tenant console auto-resolve
+   - Call `sb_get_scenario_details(scenario_id, console)` and return result
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/config_server.py` | Modify | Add 2 new tool registrations + import |
+
+**Git Commit**: `feat(config): register get_scenarios and get_scenario_details MCP tools`
+
+---
+
+### Phase 6: RED/GREEN — E2E Tests
+
+**Semantic Change**: Add end-to-end tests that call the real SafeBreach API on pentest01
+console to validate scenario tools work against real data.
+
+**Deliverables**: E2E test suite marked with `@pytest.mark.e2e` and `@skip_e2e`.
+
+**Implementation Details**:
+
+1. **Test `get_scenarios` E2E** — `TestScenarioE2E` class
+   - Fetch scenarios from pentest01 console with no filters, verify non-empty response
+   - Verify response structure: `page_number`, `total_pages`, `total_scenarios`,
+     `scenarios_in_page`, `hint_to_agent`
+   - Verify each scenario in page has expected keys: `id`, `name`, `createdBy`,
+     `category_names`, `step_count`, `is_ready_to_run`, `recommended`
+   - Test `name_filter` with a known scenario name substring
+   - Test `creator_filter="safebreach"` returns only SafeBreach-created scenarios
+   - Test `recommended_filter=True` returns only recommended scenarios
+   - Test `ready_to_run_filter=True` returns only ready scenarios (expect 4 on pentest01)
+   - Test pagination: verify page 0 returns PAGE_SIZE items, verify `hint_to_agent`
+     points to page 1
+
+2. **Test `get_scenario_details` E2E**
+   - Fetch scenario list, pick the first ID, call `sb_get_scenario_details` with that ID
+   - Verify full payload: `id`, `name`, `steps`, `categories`, `category_names`
+   - Verify `category_names` is a list of strings (resolved from categories endpoint)
+   - Test with non-existent ID: verify `ValueError` raised
+
+3. **Test infrastructure**
+   - Use `@pytest.mark.e2e` and `@skip_e2e` decorators (following existing E2E pattern)
+   - Console: `E2E_CONSOLE` env var or default to `"pentest01"`
+   - Requires `source .vscode/set_env.sh` before running
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_config/tests/test_e2e_scenarios.py` | Create | E2E tests for scenario tools against pentest01 |
+
+**Git Commit**: `test(config): add E2E tests for scenario tools against pentest01`
+
+---
+
+### Phase 7: Documentation
+
+**Semantic Change**: Update CLAUDE.md with new tool documentation.
+
+**Deliverables**: Updated documentation reflecting the two new Config Server tools.
+
+**Implementation Details**:
+
+1. **Update CLAUDE.md Config Server section**
+   - Add `get_scenarios` tool to the Config Server tools list with description of all
+     parameters and filtering capabilities
+   - Add `get_scenario_details` tool with description
+   - Update the tool count
+   - Add scenario-specific sections: ready-to-run definition, category resolution
+
+2. **Update cache configuration section**
+   - Document `scenarios` cache (maxsize=5, TTL=1800s)
+   - Document `scenario_categories` cache (maxsize=5, TTL=3600s)
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `CLAUDE.md` | Modify | Add scenario tool documentation, cache config |
+
+**Git Commit**: `docs: add scenario tools to CLAUDE.md documentation`
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Scenario API response structure changes | Medium | Transform functions isolate API changes from tool interface |
+| Large scenario counts on customer consoles | Low | Client-side pagination handles any count; cache bounds memory |
+| `x-apitoken` auth rejected by content-manager API | Low | Already tested live on pentest01; fallback to session token if needed |
+
+### Assumptions
+- The `/api/content-manager/vLatest/scenarios` endpoint returns ALL scenarios in a single
+  response (no server-side pagination). Confirmed on pentest01 (443 scenarios).
+- Category IDs in scenario objects always reference valid categories from the categories
+  endpoint. Unknown IDs are silently skipped in resolution.
+- The `createdBy` field will contain `"SafeBreach"` for OOB scenarios and a different
+  value (user name) for custom scenarios.
+
+## 11. Future Enhancements
+
+- **Run scenario via queue API**: Use the full cached scenario payload to submit scenarios
+  for execution via the SafeBreach queue API
+- **Scenario search by MITRE technique**: Cross-reference scenario step attack filters with
+  playbook MITRE data for technique-based discovery
+- **Scenario comparison**: Compare two scenarios' attack coverage
+
+## 12. Executive Summary
+
+- **Issue**: AI agents cannot discover or inspect SafeBreach scenarios via MCP tools
+- **What Was Built**: Two new MCP tools (`get_scenarios`, `get_scenario_details`) in the
+  Config Server with comprehensive filtering, pagination, and category resolution
+- **Key Technical Decisions**: Config Server placement; single API call with client-side
+  processing; separate category cache; ready-to-run computed from step filter analysis;
+  full raw payload for details (future queue API use)
+- **Business Value**: Completes the MCP tool coverage for scenario management, enabling AI
+  agents to assist users with scenario discovery, selection, and inspection
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-04-14 18:30 | PRD created — initial draft |
+| 2026-04-14 18:45 | Restructured to pure TDD phases (RED → GREEN), added E2E test phase against pentest01 |

--- a/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
@@ -15,10 +15,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Draft |
-| **Last Updated** | 2026-04-14 18:30 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-04-16 10:30 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | N/A |
+| **Current Phase** | Complete (9 of 9) |
 
 ## 2. Solution Description
 
@@ -208,13 +208,15 @@ _Omitted — backend-only MCP tool changes, no UI workflow._
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: RED — Types Tests | ⏳ Pending | - | - | Write tests first (all fail) |
-| Phase 2: GREEN — Types Implementation | ⏳ Pending | - | - | Implement to make tests pass |
-| Phase 3: RED — Functions Tests | ⏳ Pending | - | - | Write tests first (all fail) |
-| Phase 4: GREEN — Functions Implementation | ⏳ Pending | - | - | Implement to make tests pass |
-| Phase 5: MCP Tool Registration | ⏳ Pending | - | - | |
-| Phase 6: RED/GREEN — E2E Tests | ⏳ Pending | - | - | Against pentest01 console |
-| Phase 7: Documentation | ⏳ Pending | - | - | |
+| Phase 1: RED — Types Tests | ✅ Complete | 2026-04-14 | 1aeb1c6 | 29 test cases |
+| Phase 2: GREEN — Types Implementation | ✅ Complete | 2026-04-14 | 202d816 | 5 transform functions |
+| Phase 3: RED — Functions Tests | ✅ Complete | 2026-04-14 | ea9a82f | 16 test cases |
+| Phase 4: GREEN — Functions Implementation | ✅ Complete | 2026-04-14 | 0c56b15 | API calls, caching, orchestration |
+| Phase 5: MCP Tool Registration | ✅ Complete | 2026-04-14 | 740bc80 | 2 new MCP tools |
+| Phase 6: RED/GREEN — E2E Tests | ✅ Complete | 2026-04-14 | 19b5651 | 10 E2E tests against pentest01 |
+| Phase 7: Documentation | ✅ Complete | 2026-04-14 | da1686e | CLAUDE.md updated |
+| Phase 8: Custom Plans Integration | ✅ Complete | 2026-04-15 | ceee3c4 | Merged OOB + custom (plans API) |
+| Phase 9: Simplified Detail View | ✅ Complete | 2026-04-16 | 36e9b6c | Unified LLM-readable format |
 
 ### Phase 1: RED — Types Tests
 
@@ -617,4 +619,6 @@ console to validate scenario tools work against real data.
 |------|-------------------|
 | 2026-04-14 18:30 | PRD created — initial draft |
 | 2026-04-14 18:45 | Restructured to pure TDD phases (RED → GREEN), added E2E test phase against pentest01 |
-| 2026-04-15 12:00 | Added Phase 8 — integrate custom scenarios (plans API) discovered after initial impl. Added source_type field to unify OOB and custom. |
+| 2026-04-15 12:00 | Phase 8: Integrate custom scenarios (plans API). OOB + custom merged with source_type field. |
+| 2026-04-16 10:00 | Phase 9: Simplified get_scenario_details for LLM consumption. Raw payload replaced with unified step format. DAG traversal for custom plans. |
+| 2026-04-16 10:30 | All 9 phases complete. 82 unit + 13 E2E tests passing. PRD marked complete. |

--- a/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/prd.md
@@ -617,3 +617,4 @@ console to validate scenario tools work against real data.
 |------|-------------------|
 | 2026-04-14 18:30 | PRD created — initial draft |
 | 2026-04-14 18:45 | Restructured to pure TDD phases (RED → GREEN), added E2E test phase against pentest01 |
+| 2026-04-15 12:00 | Added Phase 8 — integrate custom scenarios (plans API) discovered after initial impl. Added source_type field to unify OOB and custom. |

--- a/prds/SAF-29966-create-tool-to-list-scenarios/summary.md
+++ b/prds/SAF-29966-create-tool-to-list-scenarios/summary.md
@@ -1,0 +1,164 @@
+# Ticket Summary: SAF-29966
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repository**: safebreach-mcp
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] Create tools to allow listing of all available scenarios and drilling in into a specific one
+**Issues Identified**: Ticket lacks API details, field mapping, filter specification, and readiness criteria
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- **API endpoints confirmed**: `GET /api/content-manager/vLatest/scenarios` (list) and
+  `GET /api/content-manager/vLatest/scenarioCategories` (category metadata)
+- **Auth**: `x-apitoken` header works (same as all other MCP servers)
+- **Data volume**: 443 scenarios on pentest01 console — **pagination required** (PAGE_SIZE=10)
+- **Categories**: 15 categories, referenced by integer ID in scenarios, need client-side join
+- **Ready-to-run definition**: ALL steps must have both `targetFilter` AND `attackerFilter` with
+  at least one key containing non-empty `values` (e.g., `os`, `role` criteria). Empty
+  `simulators.values` arrays do NOT qualify. Currently 4 of 443 are ready.
+- **OOB vs custom**: `createdBy` field — "SafeBreach" = OOB, anything else = custom
+- **Server placement**: Config Server (port 8000) per user decision
+- Relevant files: `config_types.py`, `config_functions.py`, `config_server.py`, tests/
+
+### Scenario Data Structure
+Top-level fields: `id` (UUID), `name`, `description`, `createdBy`, `recommended`, `categories`
+(int[]), `tags` (str[] or null), `createdAt`, `updatedAt`, `steps` (step objects with
+attacksFilter/targetFilter/attackerFilter/systemFilter), `order`, `actions`, `edges`, `phases`,
+`minApiVer`, `maxApiVer`
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The SafeBreach MCP platform lacks tools for AI agents to discover and inspect scenarios.
+Scenarios are a core SafeBreach concept — pre-built or custom multi-step attack workflows
+that chain multiple attacks. Without MCP tools, agents cannot list available scenarios,
+filter by category/readiness/type, or inspect scenario details.
+
+### Impact Assessment
+- AI agents cannot assist users with scenario selection or management
+- Users must use the web UI to browse scenarios, breaking the MCP-driven workflow
+- Scenario readiness (ready-to-run vs needs-configuration) is not exposed to AI agents
+
+### Risks & Edge Cases
+- **Category join**: Scenarios reference categories by integer ID; categories endpoint must
+  be fetched and joined client-side for human-readable names
+- **Large payloads**: Full scenario details include step structures with nested filters;
+  reduced view for list endpoint is essential
+- **Ready-to-run logic**: Complex — requires checking all steps for non-empty targetFilter AND
+  attackerFilter with real criteria values (not just empty simulators arrays)
+- **Tag filtering**: 206 of 443 scenarios have tags; tags can be null, need null-safe handling
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Add scenario listing and detail tools to Config Server with filtering and pagination
+
+### Description
+
+**Background**
+SafeBreach scenarios are multi-step attack workflows that chain attacks for comprehensive
+security testing. AI agents need MCP tools to list, filter, and inspect scenarios.
+
+**Technical Context**
+* Two API endpoints: `GET /api/content-manager/vLatest/scenarios` (all scenarios) and
+  `GET /api/content-manager/vLatest/scenarioCategories` (category metadata)
+* Authentication via `x-apitoken` header (same as all MCP servers)
+* Config Server (port 8000) hosts the new tools
+* 443 scenarios on pentest01 — pagination required (PAGE_SIZE=10)
+* Categories referenced by integer ID; need client-side join with categories endpoint
+
+**Problem Description**
+* No MCP tools exist for scenario discovery or inspection
+* Agents cannot filter by OOB/custom, category, readiness, or search by name/tag
+* "Ready to run" requires checking all steps have both targetFilter AND attackerFilter
+  with non-empty criteria values (os, role, etc.)
+
+**Affected Areas**
+* `safebreach_mcp_config/config_types.py` — Scenario transform functions (reduced/full mapping)
+* `safebreach_mcp_config/config_functions.py` — API calls, caching, filtering, pagination logic
+* `safebreach_mcp_config/config_server.py` — Two new MCP tool registrations
+* `safebreach_mcp_config/tests/` — Unit tests for types, functions, and server
+* `CLAUDE.md` — Tool documentation update
+
+### Acceptance Criteria
+
+- [ ] `get_scenarios` tool returns paginated scenario list (PAGE_SIZE=10, 0-based pages)
+- [ ] Each scenario in list includes: id, name, description (truncated), createdBy,
+  category names (resolved from categories endpoint), step_count, recommended, tags,
+  is_ready_to_run, createdAt, updatedAt
+- [ ] Supports `name_filter` (case-insensitive partial match)
+- [ ] Supports `creator_filter` ("safebreach" for OOB, "custom" for user-created)
+- [ ] Supports `category_filter` (case-insensitive partial match on category name)
+- [ ] Supports `recommended_filter` (boolean)
+- [ ] Supports `tag_filter` (case-insensitive partial match on tags)
+- [ ] Supports `ready_to_run_filter` (boolean — all steps have both targetFilter AND
+  attackerFilter with at least one key containing non-empty values)
+- [ ] Supports ordering by name, step_count, created_at, updated_at (asc/desc)
+- [ ] Returns `hint_to_agent` for pagination navigation
+- [ ] Returns `applied_filters` metadata
+- [ ] `get_scenario_details` tool returns full scenario payload by UUID
+- [ ] Scenario details include full step definitions with attack filters
+- [ ] Categories cached separately with appropriate TTL (shared cache)
+- [ ] Scenarios cached with `SB_MCP_CACHE_CONFIG` env var control
+- [ ] Unit tests cover: transform functions, API call mocking, filtering logic,
+  pagination, ready-to-run computation, category join, error handling
+- [ ] Single-tenant mode auto-resolve works for both new tools
+
+### Suggested Labels/Components
+- Component: safebreach_mcp_config
+- Labels: mcp, scenarios, enhancement
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+SafeBreach scenarios are multi-step attack workflows that chain attacks for comprehensive
+security testing. AI agents need MCP tools to list, filter, and inspect scenarios.
+
+### Technical Context
+* Two API endpoints: `GET /api/content-manager/vLatest/scenarios` and
+  `GET /api/content-manager/vLatest/scenarioCategories`
+* Authentication via `x-apitoken` header
+* Config Server (port 8000) hosts the new tools
+* 443+ scenarios — pagination required (PAGE_SIZE=10)
+* Categories referenced by integer ID; need client-side join
+
+### Problem Description
+* No MCP tools exist for scenario discovery or inspection
+* Agents cannot filter scenarios by OOB/custom, category, readiness, name, or tags
+* "Ready to run" = all steps have both targetFilter AND attackerFilter with non-empty
+  criteria values (os, role, etc.)
+
+### Affected Areas
+* `safebreach_mcp_config/` — types, functions, server, tests
+* `CLAUDE.md` — documentation update
+```
+
+**Acceptance Criteria:**
+```markdown
+* `get_scenarios` tool with pagination (PAGE_SIZE=10), filtering (name, creator,
+  category, recommended, tag, ready_to_run), and ordering
+* Each scenario includes: id, name, description, createdBy, category names, step_count,
+  recommended, tags, is_ready_to_run, createdAt, updatedAt
+* `get_scenario_details` tool returns full scenario payload by UUID
+* Caching via SB_MCP_CACHE_CONFIG env var with SafeBreachCache
+* Unit tests for transforms, filtering, pagination, ready-to-run logic, category join
+* Single-tenant mode auto-resolve for both tools
+```

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -12,12 +12,23 @@ from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
 from safebreach_mcp_core.secret_utils import get_secret_for_console
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
-from .config_types import get_minimal_simulator_mapping, get_full_simulator_mapping
+from .config_types import (
+    get_minimal_simulator_mapping,
+    get_full_simulator_mapping,
+    get_reduced_scenario_mapping,
+    filter_scenarios_by_criteria,
+    apply_scenario_ordering,
+    paginate_scenarios,
+)
 
 logger = logging.getLogger(__name__)
 
 # Bounded cache: max 5 consoles, 1-hour TTL
 simulators_cache = SafeBreachCache(name="simulators", maxsize=5, ttl=3600)
+
+# Scenario caches
+scenarios_cache = SafeBreachCache(name="scenarios", maxsize=5, ttl=1800)
+categories_cache = SafeBreachCache(name="scenario_categories", maxsize=5, ttl=3600)
 
 # Configuration constants
 PAGE_SIZE = 10
@@ -313,3 +324,214 @@ def sb_get_simulator_details(simulator_id: str, console: str = "default") -> Dic
     except Exception as e:
         logger.error(f"Error getting simulator details for ID '{simulator_id}' from console '{console}': {str(e)}")
         raise
+
+
+# --- Scenario Functions ---
+
+
+def clear_scenarios_cache():
+    """Clear the scenarios cache (for testing)."""
+    scenarios_cache.clear()
+
+
+def clear_categories_cache():
+    """Clear the categories cache (for testing)."""
+    categories_cache.clear()
+
+
+def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
+    """
+    Get all scenarios from cache or API.
+
+    Args:
+        console: SafeBreach console name
+
+    Returns:
+        List of full scenario dictionaries
+    """
+    cache_key = f"scenarios_{console}"
+
+    if is_caching_enabled("config"):
+        cached = scenarios_cache.get(cache_key)
+        if cached is not None:
+            logger.info(f"Retrieved {len(cached)} scenarios from cache for console '{console}'")
+            return cached
+
+    try:
+        apitoken = get_secret_for_console(console)
+        base_url = get_api_base_url(console, 'content-manager')
+
+        api_url = f"{base_url}/api/content-manager/vLatest/scenarios"
+        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+
+        logger.info(f"Fetching scenarios from API for console '{console}'")
+        response = requests.get(api_url, headers=headers, timeout=120)
+        response.raise_for_status()
+
+        scenarios = response.json()
+
+        if is_caching_enabled("config"):
+            scenarios_cache.set(cache_key, scenarios)
+
+        logger.info(f"Retrieved {len(scenarios)} scenarios from API for console '{console}'")
+        return scenarios
+
+    except Exception as e:
+        logger.error(f"Error fetching scenarios from API for console '{console}': {str(e)}")
+        raise
+
+
+def _get_categories_map_from_cache_or_api(console: str) -> Dict[int, str]:
+    """
+    Get category ID to name mapping from cache or API.
+
+    Args:
+        console: SafeBreach console name
+
+    Returns:
+        Dict mapping category ID (int) to category name (str)
+    """
+    cache_key = f"categories_{console}"
+
+    if is_caching_enabled("config"):
+        cached = categories_cache.get(cache_key)
+        if cached is not None:
+            logger.info(f"Retrieved categories from cache for console '{console}'")
+            return cached
+
+    try:
+        apitoken = get_secret_for_console(console)
+        base_url = get_api_base_url(console, 'content-manager')
+
+        api_url = f"{base_url}/api/content-manager/vLatest/scenarioCategories"
+        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+
+        logger.info(f"Fetching scenario categories from API for console '{console}'")
+        response = requests.get(api_url, headers=headers, timeout=120)
+        response.raise_for_status()
+
+        categories_list = response.json()
+        categories_map = {cat["id"]: cat["name"] for cat in categories_list}
+
+        if is_caching_enabled("config"):
+            categories_cache.set(cache_key, categories_map)
+
+        logger.info(f"Retrieved {len(categories_map)} categories from API for console '{console}'")
+        return categories_map
+
+    except Exception as e:
+        logger.error(f"Error fetching categories from API for console '{console}': {str(e)}")
+        raise
+
+
+def sb_get_scenarios(
+    console: str = "default",
+    page_number: int = 0,
+    name_filter: Optional[str] = None,
+    creator_filter: Optional[str] = None,
+    category_filter: Optional[str] = None,
+    recommended_filter: Optional[bool] = None,
+    tag_filter: Optional[str] = None,
+    ready_to_run_filter: Optional[bool] = None,
+    order_by: str = "name",
+    order_direction: str = "asc",
+) -> Dict[str, Any]:
+    """
+    Get filtered and paginated list of scenarios for a given console.
+    """
+    valid_order_by = ['name', 'step_count', 'createdAt', 'updatedAt']
+    if order_by not in valid_order_by:
+        raise ValueError(
+            f"Invalid order_by parameter '{order_by}'. "
+            f"Valid values are: {', '.join(valid_order_by)}"
+        )
+
+    valid_order_direction = ['asc', 'desc']
+    if order_direction not in valid_order_direction:
+        raise ValueError(
+            f"Invalid order_direction parameter '{order_direction}'. "
+            f"Valid values are: {', '.join(valid_order_direction)}"
+        )
+
+    if creator_filter is not None:
+        valid_creator_filters = ['safebreach', 'custom']
+        if creator_filter.lower() not in valid_creator_filters:
+            raise ValueError(
+                f"Invalid creator_filter parameter '{creator_filter}'. "
+                f"Valid values are: {', '.join(valid_creator_filters)}"
+            )
+
+    if page_number < 0:
+        raise ValueError(f"page_number must be >= 0, got {page_number}")
+
+    try:
+        all_scenarios = _get_all_scenarios_from_cache_or_api(console)
+        categories_map = _get_categories_map_from_cache_or_api(console)
+
+        reduced = [
+            get_reduced_scenario_mapping(s, categories_map) for s in all_scenarios
+        ]
+
+        filtered = filter_scenarios_by_criteria(
+            reduced,
+            name_filter=name_filter,
+            creator_filter=creator_filter,
+            category_filter=category_filter,
+            recommended_filter=recommended_filter,
+            tag_filter=tag_filter,
+            ready_to_run_filter=ready_to_run_filter,
+        )
+
+        ordered = apply_scenario_ordering(filtered, order_by=order_by, order_direction=order_direction)
+        paginated = paginate_scenarios(ordered, page_number=page_number, page_size=PAGE_SIZE)
+
+        applied_filters = {}
+        if name_filter:
+            applied_filters['name_filter'] = name_filter
+        if creator_filter:
+            applied_filters['creator_filter'] = creator_filter
+        if category_filter:
+            applied_filters['category_filter'] = category_filter
+        if recommended_filter is not None:
+            applied_filters['recommended_filter'] = recommended_filter
+        if tag_filter:
+            applied_filters['tag_filter'] = tag_filter
+        if ready_to_run_filter is not None:
+            applied_filters['ready_to_run_filter'] = ready_to_run_filter
+        if order_by != "name":
+            applied_filters['order_by'] = order_by
+        if order_direction != "asc":
+            applied_filters['order_direction'] = order_direction
+
+        paginated['applied_filters'] = applied_filters
+        return paginated
+
+    except Exception as e:
+        logger.error(f"Error getting scenarios for console '{console}': {str(e)}")
+        return {
+            "error": f"Failed to get scenarios: {str(e)}",
+            "console": console,
+        }
+
+
+def sb_get_scenario_details(scenario_id: str, console: str = "default") -> Dict[str, Any]:
+    """
+    Get full details of a specific scenario by ID.
+    """
+    if not scenario_id or not scenario_id.strip():
+        raise ValueError("scenario_id parameter is required and cannot be empty")
+
+    all_scenarios = _get_all_scenarios_from_cache_or_api(console)
+    categories_map = _get_categories_map_from_cache_or_api(console)
+
+    for scenario in all_scenarios:
+        if scenario.get("id") == scenario_id:
+            result = dict(scenario)
+            result["category_names"] = [
+                categories_map[cat_id]
+                for cat_id in scenario.get("categories", [])
+                if cat_id in categories_map
+            ]
+            return result
+
+    raise ValueError(f"Scenario with ID '{scenario_id}' not found")

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -16,6 +16,7 @@ from .config_types import (
     get_minimal_simulator_mapping,
     get_full_simulator_mapping,
     get_reduced_scenario_mapping,
+    get_reduced_plan_mapping,
     filter_scenarios_by_criteria,
     apply_scenario_ordering,
     paginate_scenarios,
@@ -29,6 +30,7 @@ simulators_cache = SafeBreachCache(name="simulators", maxsize=5, ttl=3600)
 # Scenario caches
 scenarios_cache = SafeBreachCache(name="scenarios", maxsize=5, ttl=1800)
 categories_cache = SafeBreachCache(name="scenario_categories", maxsize=5, ttl=3600)
+plans_cache = SafeBreachCache(name="plans", maxsize=5, ttl=1800)
 
 # Configuration constants
 PAGE_SIZE = 10
@@ -339,6 +341,59 @@ def clear_categories_cache():
     categories_cache.clear()
 
 
+def clear_plans_cache():
+    """Clear the plans cache (for testing)."""
+    plans_cache.clear()
+
+
+def _get_all_plans_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
+    """
+    Get all custom plans (user-created scenarios) from cache or API.
+
+    Plans live at /api/config/v2/accounts/{account_id}/plans?details=true and have
+    a different schema than OOB scenarios.
+
+    Args:
+        console: SafeBreach console name
+
+    Returns:
+        List of full plan dictionaries
+    """
+    cache_key = f"plans_{console}"
+
+    if is_caching_enabled("config"):
+        cached = plans_cache.get(cache_key)
+        if cached is not None:
+            logger.info(f"Retrieved {len(cached)} plans from cache for console '{console}'")
+            return cached
+
+    try:
+        apitoken = get_secret_for_console(console)
+        base_url = get_api_base_url(console, 'config')
+        account_id = get_api_account_id(console)
+
+        api_url = f"{base_url}/api/config/v2/accounts/{account_id}/plans?details=true"
+        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+
+        logger.info(f"Fetching custom plans from API for console '{console}'")
+        response = requests.get(api_url, headers=headers, timeout=120)
+        response.raise_for_status()
+
+        response_data = response.json()
+        # Plans API wraps the list in {"data": [...]}
+        plans = response_data.get("data", []) if isinstance(response_data, dict) else response_data
+
+        if is_caching_enabled("config"):
+            plans_cache.set(cache_key, plans)
+
+        logger.info(f"Retrieved {len(plans)} custom plans from API for console '{console}'")
+        return plans
+
+    except Exception as e:
+        logger.error(f"Error fetching plans from API for console '{console}': {str(e)}")
+        raise
+
+
 def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     """
     Get all scenarios from cache or API.
@@ -465,12 +520,22 @@ def sb_get_scenarios(
         raise ValueError(f"page_number must be >= 0, got {page_number}")
 
     try:
-        all_scenarios = _get_all_scenarios_from_cache_or_api(console)
-        categories_map = _get_categories_map_from_cache_or_api(console)
+        # Determine which sources to fetch based on creator_filter
+        fetch_oob = creator_filter is None or creator_filter.lower() == 'safebreach'
+        fetch_custom = creator_filter is None or creator_filter.lower() == 'custom'
 
-        reduced = [
-            get_reduced_scenario_mapping(s, categories_map) for s in all_scenarios
-        ]
+        reduced = []
+
+        if fetch_oob:
+            all_scenarios = _get_all_scenarios_from_cache_or_api(console)
+            categories_map = _get_categories_map_from_cache_or_api(console)
+            reduced.extend(
+                get_reduced_scenario_mapping(s, categories_map) for s in all_scenarios
+            )
+
+        if fetch_custom:
+            all_plans = _get_all_plans_from_cache_or_api(console)
+            reduced.extend(get_reduced_plan_mapping(p) for p in all_plans)
 
         filtered = filter_scenarios_by_criteria(
             reduced,
@@ -517,21 +582,39 @@ def sb_get_scenarios(
 def sb_get_scenario_details(scenario_id: str, console: str = "default") -> Dict[str, Any]:
     """
     Get full details of a specific scenario by ID.
+
+    Searches both OOB scenarios (UUID IDs) and custom plans (integer IDs).
+    Returns the full raw payload with source_type='oob'|'custom' added, plus
+    resolved category_names for OOB scenarios.
     """
-    if not scenario_id or not scenario_id.strip():
+    if scenario_id is None or (isinstance(scenario_id, str) and not scenario_id.strip()):
         raise ValueError("scenario_id parameter is required and cannot be empty")
 
+    # Normalize to string for unified comparison (UUIDs and integer plan IDs)
+    scenario_id = str(scenario_id).strip()
+
+    # Try OOB scenarios first (UUID string IDs)
     all_scenarios = _get_all_scenarios_from_cache_or_api(console)
     categories_map = _get_categories_map_from_cache_or_api(console)
 
     for scenario in all_scenarios:
-        if scenario.get("id") == scenario_id:
+        if str(scenario.get("id")) == scenario_id:
             result = dict(scenario)
+            result["source_type"] = "oob"
             result["category_names"] = [
                 categories_map[cat_id]
                 for cat_id in scenario.get("categories", [])
                 if cat_id in categories_map
             ]
+            return result
+
+    # Fall back to custom plans (integer IDs, stringified for comparison)
+    all_plans = _get_all_plans_from_cache_or_api(console)
+    for plan in all_plans:
+        if str(plan.get("id")) == scenario_id:
+            result = dict(plan)
+            result["source_type"] = "custom"
+            result["category_names"] = []  # Custom plans don't have categories
             return result
 
     raise ValueError(f"Scenario with ID '{scenario_id}' not found")

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -17,6 +17,7 @@ from .config_types import (
     get_full_simulator_mapping,
     get_reduced_scenario_mapping,
     get_reduced_plan_mapping,
+    get_scenario_detail_view,
     filter_scenarios_by_criteria,
     apply_scenario_ordering,
     paginate_scenarios,
@@ -599,22 +600,12 @@ def sb_get_scenario_details(scenario_id: str, console: str = "default") -> Dict[
 
     for scenario in all_scenarios:
         if str(scenario.get("id")) == scenario_id:
-            result = dict(scenario)
-            result["source_type"] = "oob"
-            result["category_names"] = [
-                categories_map[cat_id]
-                for cat_id in scenario.get("categories", [])
-                if cat_id in categories_map
-            ]
-            return result
+            return get_scenario_detail_view(scenario, categories_map, source_type="oob")
 
     # Fall back to custom plans (integer IDs, stringified for comparison)
     all_plans = _get_all_plans_from_cache_or_api(console)
     for plan in all_plans:
         if str(plan.get("id")) == scenario_id:
-            result = dict(plan)
-            result["source_type"] = "custom"
-            result["category_names"] = []  # Custom plans don't have categories
-            return result
+            return get_scenario_detail_view(plan, categories_map, source_type="custom")
 
     raise ValueError(f"Scenario with ID '{scenario_id}' not found")

--- a/safebreach_mcp_config/config_server.py
+++ b/safebreach_mcp_config/config_server.py
@@ -14,7 +14,12 @@ from typing import Optional
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from safebreach_mcp_core import SafeBreachMCPBase
-from .config_functions import sb_get_console_simulators, sb_get_simulator_details
+from .config_functions import (
+    sb_get_console_simulators,
+    sb_get_simulator_details,
+    sb_get_scenarios,
+    sb_get_scenario_details,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +84,63 @@ label_filter (partial label match), os_type_filter (OS type match), critical_onl
                 if console_name != 'default' and console not in safebreach_envs:
                     console = console_name
             return sb_get_simulator_details(simulator_id, console)
+
+        @self.mcp.tool(
+            name="get_scenarios",
+            description="""Returns a filtered and paginated list of SafeBreach scenarios for a given console.
+Scenarios are multi-step attack workflows. Each scenario includes metadata about its type (OOB/custom),
+category, readiness status, and step count. Results are paginated (10 per page) and ordered by name ascending by default.
+Parameters: console (required), page_number (0-based, default 0), name_filter (partial name match),
+creator_filter ('safebreach' for OOB or 'custom' for user-created), category_filter (partial category name match),
+recommended_filter (True/False), tag_filter (partial tag match), ready_to_run_filter (True/False - whether all steps
+have simulator selection criteria configured), order_by ('name'/'step_count'/'createdAt'/'updatedAt'),
+order_direction ('asc'/'desc')"""
+        )
+        async def get_scenarios_tool(
+            console: str = "default",
+            page_number: int = 0,
+            name_filter: Optional[str] = None,
+            creator_filter: Optional[str] = None,
+            category_filter: Optional[str] = None,
+            recommended_filter: Optional[bool] = None,
+            tag_filter: Optional[str] = None,
+            ready_to_run_filter: Optional[bool] = None,
+            order_by: str = "name",
+            order_direction: str = "asc"
+        ) -> dict:
+            from safebreach_mcp_core.environments_metadata import get_console_name, safebreach_envs
+            if not safebreach_envs:
+                console_name = get_console_name()
+                if console_name != 'default' and console not in safebreach_envs:
+                    console = console_name
+            return sb_get_scenarios(
+                console=console,
+                page_number=page_number,
+                name_filter=name_filter,
+                creator_filter=creator_filter,
+                category_filter=category_filter,
+                recommended_filter=recommended_filter,
+                tag_filter=tag_filter,
+                ready_to_run_filter=ready_to_run_filter,
+                order_by=order_by,
+                order_direction=order_direction,
+            )
+
+        @self.mcp.tool(
+            name="get_scenario_details",
+            description="""Gets the full details of a specific SafeBreach scenario by its UUID.
+Returns the complete scenario payload including all steps with attack filters, system filters,
+target/attacker filters, phases, actions, and edges. Also includes resolved category names.
+This full payload can be used for scenario inspection and future queue API integration.
+Parameters: scenario_id (required, UUID string), console (required)"""
+        )
+        async def get_scenario_details_tool(scenario_id: str, console: str = "default") -> dict:
+            from safebreach_mcp_core.environments_metadata import get_console_name, safebreach_envs
+            if not safebreach_envs:
+                console_name = get_console_name()
+                if console_name != 'default' and console not in safebreach_envs:
+                    console = console_name
+            return sb_get_scenario_details(scenario_id, console)
 
 def parse_external_config(server_type: str) -> bool:
     """Parse external connection configuration for specific server."""

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -129,14 +129,14 @@ def get_reduced_scenario_mapping(
     ]
 
     return {
-        "id": scenario.get("id"),
+        "id": str(scenario.get("id")),
         "source_type": "oob",
         "name": scenario.get("name"),
         "description": _truncate_description(scenario.get('description')),
         "createdBy": scenario.get("createdBy"),
         "recommended": scenario.get("recommended", False),
         "category_names": category_names,
-        "tags": scenario.get("tags"),
+        "tags": scenario.get("tags") or [],
         "step_count": len(scenario.get("steps", [])),
         "is_ready_to_run": compute_is_ready_to_run(scenario),
         "createdAt": scenario.get("createdAt"),
@@ -153,14 +153,14 @@ def get_reduced_plan_mapping(plan: Dict[str, Any]) -> Dict[str, Any]:
     /api/config/v2/accounts/{id}/plans endpoint and have a different schema than OOB scenarios.
     """
     return {
-        "id": plan.get("id"),
+        "id": str(plan.get("id")),
         "source_type": "custom",
         "name": plan.get("name"),
         "description": _truncate_description(plan.get('description')),
         "createdBy": None,  # Custom plans don't have createdBy; see userId instead
         "recommended": False,  # Custom plans don't have the recommended concept
         "category_names": [],  # Custom plans don't have categories
-        "tags": plan.get("tags") if plan.get("tags") else None,
+        "tags": plan.get("tags") or [],
         "step_count": len(plan.get("steps", [])),
         "is_ready_to_run": compute_is_ready_to_run(plan),
         "createdAt": plan.get("createdAt"),
@@ -431,12 +431,12 @@ def get_scenario_detail_view(
         ]
 
     return {
-        "id": scenario.get("id"),
+        "id": str(scenario.get("id")),
         "source_type": source_type,
         "name": scenario.get("name"),
         "description": scenario.get("description"),
         "category_names": category_names,
-        "tags": scenario.get("tags") if scenario.get("tags") else None,
+        "tags": scenario.get("tags") or [],
         "recommended": scenario.get("recommended", False) if source_type == 'oob' else False,
         "createdBy": scenario.get("createdBy") if source_type == 'oob' else None,
         "createdAt": scenario.get("createdAt"),

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -315,6 +315,8 @@ def _simplify_step(step: Dict[str, Any]) -> Dict[str, Any]:
             attack_selection["attack_types"] = attack_types
         if attack_tags:
             attack_selection["attack_tags"] = attack_tags
+        if not attack_types and not attack_tags:
+            attack_selection["note"] = "broad match — criteria resolved at runtime by the platform"
 
     # Target criteria (only include non-empty entries)
     target_criteria = {}

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -107,15 +107,21 @@ def compute_is_ready_to_run(scenario: Dict[str, Any]) -> bool:
     return True
 
 
+def _truncate_description(description: Optional[str]) -> Optional[str]:
+    """Truncate description to 200 chars with ellipsis if longer."""
+    if description and len(description) > 200:
+        return description[:200] + "..."
+    return description
+
+
 def get_reduced_scenario_mapping(
     scenario: Dict[str, Any],
     categories_map: Dict[int, str]
 ) -> Dict[str, Any]:
-    """Transform a full scenario object into a reduced representation for list view."""
-    description = scenario.get('description')
-    if description and len(description) > 200:
-        description = description[:200] + "..."
+    """Transform a full OOB scenario object into a reduced representation for list view.
 
+    Returns a dict with source_type='oob'. For custom plans use get_reduced_plan_mapping.
+    """
     category_names = [
         categories_map[cat_id]
         for cat_id in scenario.get('categories', [])
@@ -124,8 +130,9 @@ def get_reduced_scenario_mapping(
 
     return {
         "id": scenario.get("id"),
+        "source_type": "oob",
         "name": scenario.get("name"),
-        "description": description,
+        "description": _truncate_description(scenario.get('description')),
         "createdBy": scenario.get("createdBy"),
         "recommended": scenario.get("recommended", False),
         "category_names": category_names,
@@ -134,6 +141,32 @@ def get_reduced_scenario_mapping(
         "is_ready_to_run": compute_is_ready_to_run(scenario),
         "createdAt": scenario.get("createdAt"),
         "updatedAt": scenario.get("updatedAt"),
+        "userId": None,
+        "originalScenarioId": None,
+    }
+
+
+def get_reduced_plan_mapping(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform a full custom plan object into a reduced representation for list view.
+
+    Returns a dict with source_type='custom'. Plans come from the
+    /api/config/v2/accounts/{id}/plans endpoint and have a different schema than OOB scenarios.
+    """
+    return {
+        "id": plan.get("id"),
+        "source_type": "custom",
+        "name": plan.get("name"),
+        "description": _truncate_description(plan.get('description')),
+        "createdBy": None,  # Custom plans don't have createdBy; see userId instead
+        "recommended": False,  # Custom plans don't have the recommended concept
+        "category_names": [],  # Custom plans don't have categories
+        "tags": plan.get("tags") if plan.get("tags") else None,
+        "step_count": len(plan.get("steps", [])),
+        "is_ready_to_run": compute_is_ready_to_run(plan),
+        "createdAt": plan.get("createdAt"),
+        "updatedAt": plan.get("updatedAt"),
+        "userId": plan.get("userId"),
+        "originalScenarioId": plan.get("originalScenarioId"),
     }
 
 
@@ -155,15 +188,9 @@ def filter_scenarios_by_criteria(
 
     if creator_filter:
         if creator_filter.lower() == 'safebreach':
-            filtered = [
-                s for s in filtered
-                if s.get('createdBy', '').lower() == 'safebreach'
-            ]
+            filtered = [s for s in filtered if s.get('source_type') == 'oob']
         elif creator_filter.lower() == 'custom':
-            filtered = [
-                s for s in filtered
-                if s.get('createdBy', '').lower() != 'safebreach'
-            ]
+            filtered = [s for s in filtered if s.get('source_type') == 'custom']
 
     if category_filter:
         cat_lower = category_filter.lower()

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -270,3 +270,181 @@ def paginate_scenarios(
         'hint_to_agent': f'You can scan next page by calling with page_number={page_number + 1}'
                          if page_number + 1 < total_pages else None,
     }
+
+
+# --- Scenario Detail Transform Functions ---
+
+
+def _extract_filter_values(filter_dict: Dict[str, Any], key: str) -> Optional[List]:
+    """Extract values list from a nested filter dict, e.g. targetFilter['os']['values']."""
+    entry = filter_dict.get(key, {})
+    if isinstance(entry, dict):
+        vals = entry.get('values', [])
+        return vals if vals else None
+    return None
+
+
+def _simplify_step(step: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform a raw step (OOB or custom) into a simplified LLM-readable format."""
+    attacks_filter = step.get('attacksFilter', {})
+    target_filter = step.get('targetFilter', {})
+    attacker_filter = step.get('attackerFilter', {})
+
+    # Determine attack selection mode
+    playbook_ids = _extract_filter_values(attacks_filter, 'playbook')
+    if playbook_ids:
+        attack_selection = {
+            "mode": "playbook_ids",
+            "playbook_ids": playbook_ids,
+        }
+    else:
+        # Criteria mode — extract tags and attack types
+        attack_types = _extract_filter_values(attacks_filter, 'attackType')
+        attack_tags = {}
+        tags_dict = attacks_filter.get('tags', {})
+        if isinstance(tags_dict, dict):
+            for tag_key, tag_val in tags_dict.items():
+                if isinstance(tag_val, dict):
+                    vals = tag_val.get('values', [])
+                    if vals:
+                        attack_tags[tag_key] = vals
+        attack_selection = {
+            "mode": "criteria",
+        }
+        if attack_types:
+            attack_selection["attack_types"] = attack_types
+        if attack_tags:
+            attack_selection["attack_tags"] = attack_tags
+
+    # Target criteria (only include non-empty entries)
+    target_criteria = {}
+    for key in ('os', 'role', 'simulators'):
+        vals = _extract_filter_values(target_filter, key)
+        if vals:
+            target_criteria[key] = vals
+    if not target_criteria:
+        target_criteria = None
+
+    # Attacker criteria
+    attacker_criteria = {}
+    for key in ('os', 'role', 'simulators'):
+        vals = _extract_filter_values(attacker_filter, key)
+        if vals:
+            attacker_criteria[key] = vals
+    if not attacker_criteria:
+        attacker_criteria = None
+
+    return {
+        "name": step.get("name"),
+        "attack_selection": attack_selection,
+        "target_criteria": target_criteria,
+        "attacker_criteria": attacker_criteria,
+    }
+
+
+def _resolve_step_order_from_dag(
+    steps: List[Dict[str, Any]],
+    actions: List[Dict[str, Any]],
+    edges: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Walk the actions/edges DAG and return steps in execution order.
+
+    Skips 'wait' actions. Returns the steps list in traversal order.
+    If the graph can't be walked (missing data), falls back to steps array order.
+    """
+    if not actions or not edges:
+        return steps
+
+    # Build action ID → action map
+    action_map = {a['id']: a for a in actions}
+
+    # Build uuid → step map
+    step_by_uuid = {s['uuid']: s for s in steps if 'uuid' in s}
+
+    # Find entry: edge with no 'from' or from=0
+    entry_edge = None
+    for e in edges:
+        if 'from' not in e or e.get('from') == 0:
+            entry_edge = e
+            break
+    if not entry_edge:
+        return steps  # Fallback
+
+    # Build adjacency: from → to
+    adjacency = {}
+    for e in edges:
+        f = e.get('from', 0)
+        adjacency[f] = e['to']
+
+    # Walk from entry
+    ordered_steps = []
+    current_id = entry_edge['to']
+    visited = set()
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        action = action_map.get(current_id)
+        if not action:
+            break
+        if action.get('type') == 'multiAttack':
+            uuid = action.get('data', {}).get('uuid')
+            if uuid and uuid in step_by_uuid:
+                ordered_steps.append(step_by_uuid[uuid])
+        current_id = adjacency.get(current_id)
+
+    return ordered_steps if ordered_steps else steps
+
+
+def get_scenario_detail_view(
+    scenario: Dict[str, Any],
+    categories_map: Dict[int, str],
+    source_type: str,
+) -> Dict[str, Any]:
+    """Transform a full scenario/plan into a simplified LLM-readable detail view.
+
+    Strips execution mechanics (actions, edges, phases) and normalizes steps
+    into a unified format regardless of source type.
+    """
+    # Resolve steps in execution order
+    raw_steps = scenario.get('steps', [])
+    actions = scenario.get('actions')
+    edges = scenario.get('edges')
+
+    if actions and edges:
+        ordered_steps = _resolve_step_order_from_dag(raw_steps, actions, edges)
+    else:
+        ordered_steps = raw_steps
+
+    simplified_steps = [_simplify_step(s) for s in ordered_steps]
+
+    # Detect wait actions
+    has_wait_steps = False
+    if actions:
+        has_wait_steps = any(a.get('type') == 'wait' for a in actions)
+
+    # Resolve categories
+    category_names = []
+    if source_type == 'oob':
+        category_names = [
+            categories_map[cat_id]
+            for cat_id in scenario.get('categories', [])
+            if cat_id in categories_map
+        ]
+
+    return {
+        "id": scenario.get("id"),
+        "source_type": source_type,
+        "name": scenario.get("name"),
+        "description": scenario.get("description"),
+        "category_names": category_names,
+        "tags": scenario.get("tags") if scenario.get("tags") else None,
+        "recommended": scenario.get("recommended", False) if source_type == 'oob' else False,
+        "createdBy": scenario.get("createdBy") if source_type == 'oob' else None,
+        "createdAt": scenario.get("createdAt"),
+        "updatedAt": scenario.get("updatedAt"),
+        "originalScenarioId": scenario.get("originalScenarioId"),
+        "userId": scenario.get("userId"),
+        "step_count": len(simplified_steps),
+        "is_ready_to_run": compute_is_ready_to_run(scenario),
+        "steps": simplified_steps,
+        "has_wait_steps": has_wait_steps,
+    }

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -5,7 +5,7 @@ This module provides data type mappings and transformations for SafeBreach confi
 specifically for simulator entities and related configuration objects.
 """
 
-from typing import Dict, Any, Optional
+from typing import Dict, List, Any, Optional
 
 # Mapping for OS version information - EXACT copy from original
 reduced_simulator_os_version_mapping = {
@@ -70,3 +70,176 @@ def get_full_simulator_mapping(simulator_entity):
         full_os_version["installed_applications"] = []
     
     return full_os_version
+
+
+# --- Scenario Transform Functions ---
+
+
+def _has_real_filter_criteria(filter_dict: Dict[str, Any]) -> bool:
+    """Check if a filter dict has at least one key with non-empty values."""
+    if not filter_dict:
+        return False
+    for value in filter_dict.values():
+        if isinstance(value, dict):
+            vals = value.get('values', [])
+            if vals:
+                return True
+        elif value:
+            return True
+    return False
+
+
+def compute_is_ready_to_run(scenario: Dict[str, Any]) -> bool:
+    """
+    Determine if a scenario is ready to run.
+
+    A scenario is ready when ALL steps have BOTH targetFilter AND attackerFilter
+    with at least one key containing non-empty values arrays.
+    """
+    steps = scenario.get('steps', [])
+    if not steps:
+        return False
+    for step in steps:
+        target = step.get('targetFilter', {})
+        attacker = step.get('attackerFilter', {})
+        if not _has_real_filter_criteria(target) or not _has_real_filter_criteria(attacker):
+            return False
+    return True
+
+
+def get_reduced_scenario_mapping(
+    scenario: Dict[str, Any],
+    categories_map: Dict[int, str]
+) -> Dict[str, Any]:
+    """Transform a full scenario object into a reduced representation for list view."""
+    description = scenario.get('description')
+    if description and len(description) > 200:
+        description = description[:200] + "..."
+
+    category_names = [
+        categories_map[cat_id]
+        for cat_id in scenario.get('categories', [])
+        if cat_id in categories_map
+    ]
+
+    return {
+        "id": scenario.get("id"),
+        "name": scenario.get("name"),
+        "description": description,
+        "createdBy": scenario.get("createdBy"),
+        "recommended": scenario.get("recommended", False),
+        "category_names": category_names,
+        "tags": scenario.get("tags"),
+        "step_count": len(scenario.get("steps", [])),
+        "is_ready_to_run": compute_is_ready_to_run(scenario),
+        "createdAt": scenario.get("createdAt"),
+        "updatedAt": scenario.get("updatedAt"),
+    }
+
+
+def filter_scenarios_by_criteria(
+    scenarios: List[Dict[str, Any]],
+    name_filter: Optional[str] = None,
+    creator_filter: Optional[str] = None,
+    category_filter: Optional[str] = None,
+    recommended_filter: Optional[bool] = None,
+    tag_filter: Optional[str] = None,
+    ready_to_run_filter: Optional[bool] = None,
+) -> List[Dict[str, Any]]:
+    """Apply filters to a list of reduced scenario dicts using AND logic."""
+    filtered = scenarios.copy()
+
+    if name_filter:
+        name_lower = name_filter.lower()
+        filtered = [s for s in filtered if name_lower in s.get('name', '').lower()]
+
+    if creator_filter:
+        if creator_filter.lower() == 'safebreach':
+            filtered = [
+                s for s in filtered
+                if s.get('createdBy', '').lower() == 'safebreach'
+            ]
+        elif creator_filter.lower() == 'custom':
+            filtered = [
+                s for s in filtered
+                if s.get('createdBy', '').lower() != 'safebreach'
+            ]
+
+    if category_filter:
+        cat_lower = category_filter.lower()
+        filtered = [
+            s for s in filtered
+            if any(cat_lower in cn.lower() for cn in s.get('category_names', []))
+        ]
+
+    if recommended_filter is not None:
+        filtered = [s for s in filtered if s.get('recommended') == recommended_filter]
+
+    if tag_filter:
+        tag_lower = tag_filter.lower()
+        filtered = [
+            s for s in filtered
+            if s.get('tags') and any(tag_lower in t.lower() for t in s['tags'])
+        ]
+
+    if ready_to_run_filter is not None:
+        filtered = [
+            s for s in filtered
+            if s.get('is_ready_to_run') == ready_to_run_filter
+        ]
+
+    return filtered
+
+
+def apply_scenario_ordering(
+    scenarios: List[Dict[str, Any]],
+    order_by: str = "name",
+    order_direction: str = "asc",
+) -> List[Dict[str, Any]]:
+    """Sort scenarios by the specified field and direction."""
+    reverse = order_direction.lower() == 'desc'
+
+    def sort_key(s):
+        if order_by == 'name':
+            return s.get('name', '').lower()
+        elif order_by == 'step_count':
+            return s.get('step_count', 0)
+        elif order_by == 'createdAt':
+            return s.get('createdAt', '')
+        elif order_by == 'updatedAt':
+            return s.get('updatedAt', '')
+        return s.get('name', '').lower()
+
+    return sorted(scenarios, key=sort_key, reverse=reverse)
+
+
+def paginate_scenarios(
+    scenarios: List[Dict[str, Any]],
+    page_number: int = 0,
+    page_size: int = 10,
+) -> Dict[str, Any]:
+    """Paginate a list of scenarios."""
+    total_scenarios = len(scenarios)
+    total_pages = (total_scenarios + page_size - 1) // page_size if total_scenarios > 0 else 0
+
+    if page_number < 0 or (total_pages > 0 and page_number >= total_pages):
+        return {
+            'page_number': page_number,
+            'total_pages': total_pages,
+            'total_scenarios': total_scenarios,
+            'scenarios_in_page': [],
+            'error': f'Invalid page_number {page_number}. '
+                     f'Available pages range from 0 to {total_pages - 1} (total {total_pages} pages)'
+        }
+
+    start_idx = page_number * page_size
+    end_idx = min(start_idx + page_size, total_scenarios)
+
+    return {
+        'page_number': page_number,
+        'total_pages': total_pages,
+        'total_scenarios': total_scenarios,
+        'scenarios_in_page': scenarios[start_idx:end_idx],
+        'hint_to_agent': f'You can scan next page by calling with page_number={page_number + 1}'
+                         if page_number + 1 < total_pages else None,
+    }

--- a/safebreach_mcp_config/tests/test_config_functions.py
+++ b/safebreach_mcp_config/tests/test_config_functions.py
@@ -14,6 +14,14 @@ from safebreach_mcp_config.config_functions import (
     _apply_simulator_filters,
     _apply_simulator_ordering,
     simulators_cache,
+    sb_get_scenarios,
+    sb_get_scenario_details,
+    _get_all_scenarios_from_cache_or_api,
+    _get_categories_map_from_cache_or_api,
+    scenarios_cache,
+    categories_cache,
+    clear_scenarios_cache,
+    clear_categories_cache,
 )
 
 class TestConfigFunctions:
@@ -422,3 +430,318 @@ class TestConfigFunctions:
             # Only acceptable exceptions are AWS/network related, not validation errors
             if "Invalid status_filter parameter" in str(e):
                 pytest.fail("Case-insensitive validation should accept 'CONNECTED'")
+
+
+# --- Scenario Function Tests ---
+
+MOCK_SCENARIO_DATA = [
+    {
+        "id": "aaa-111-222-333",
+        "name": "CISA Alert Akira Ransomware",
+        "description": "A known threat scenario",
+        "createdBy": "SafeBreach",
+        "recommended": True,
+        "categories": [2],
+        "tags": ["ransomware"],
+        "createdAt": "2025-11-14T00:00:00.000Z",
+        "updatedAt": "2026-01-22T00:00:00.000Z",
+        "steps": [
+            {
+                "name": "Network Infiltration",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {},
+                "attackerFilter": {},
+                "attacksFilter": {"playbook": {"values": [11503, 11505]}}
+            }
+        ],
+        "order": None, "actions": None, "edges": None, "phases": {}
+    },
+    {
+        "id": "bbb-444-555-666",
+        "name": "KongTuke Threat Group",
+        "description": None,
+        "createdBy": "SafeBreach",
+        "recommended": False,
+        "categories": [3],
+        "tags": None,
+        "createdAt": "2026-02-10T00:00:00.000Z",
+        "updatedAt": "2026-02-10T00:00:00.000Z",
+        "steps": [
+            {
+                "name": "Infection",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {},
+                "attackerFilter": {},
+                "attacksFilter": {}
+            },
+            {
+                "name": "Lateral",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {},
+                "attackerFilter": {},
+                "attacksFilter": {}
+            }
+        ],
+        "order": None, "actions": None, "edges": None, "phases": {}
+    },
+]
+
+MOCK_CATEGORIES_DATA = [
+    {"id": 2, "name": "Known Threats Series", "description": "Known threats", "icon": "flag", "order": 1},
+    {"id": 3, "name": "Threat Groups", "description": "Threat groups", "icon": "users", "order": 2},
+    {"id": 4, "name": "Baseline Scenarios", "description": "Baselines", "icon": "crosshairs", "order": 3},
+]
+
+
+class TestGetAllScenariosFromCacheOrApi:
+    """Test _get_all_scenarios_from_cache_or_api function."""
+
+    def setup_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    def teardown_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_api_call_success(self, mock_get, mock_secret, mock_base_url):
+        mock_response = Mock()
+        mock_response.json.return_value = MOCK_SCENARIO_DATA
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = _get_all_scenarios_from_cache_or_api("test-console")
+
+        assert len(result) == 2
+        assert result[0]["id"] == "aaa-111-222-333"
+        mock_get.assert_called_once()
+        call_url = mock_get.call_args[0][0] if mock_get.call_args[0] else mock_get.call_args[1].get('url', '')
+        assert '/api/content-manager/vLatest/scenarios' in str(mock_get.call_args)
+
+    @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_cache_hit(self, mock_get, mock_secret, mock_cache_enabled):
+        scenarios_cache.set("scenarios_test-console", MOCK_SCENARIO_DATA)
+
+        result = _get_all_scenarios_from_cache_or_api("test-console")
+
+        assert len(result) == 2
+        mock_get.assert_not_called()
+
+    @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_cache_miss_fetches_api(self, mock_get, mock_secret, mock_base_url, mock_cache_enabled):
+        mock_response = Mock()
+        mock_response.json.return_value = MOCK_SCENARIO_DATA
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = _get_all_scenarios_from_cache_or_api("test-console")
+
+        assert len(result) == 2
+        mock_get.assert_called_once()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url):
+        mock_get.side_effect = Exception("Connection timeout")
+
+        with pytest.raises(Exception, match="Connection timeout"):
+            _get_all_scenarios_from_cache_or_api("test-console")
+
+
+class TestGetCategoriesMapFromCacheOrApi:
+    """Test _get_categories_map_from_cache_or_api function."""
+
+    def setup_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    def teardown_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_returns_id_to_name_map(self, mock_get, mock_secret, mock_base_url):
+        mock_response = Mock()
+        mock_response.json.return_value = MOCK_CATEGORIES_DATA
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = _get_categories_map_from_cache_or_api("test-console")
+
+        assert isinstance(result, dict)
+        assert result[2] == "Known Threats Series"
+        assert result[3] == "Threat Groups"
+        assert result[4] == "Baseline Scenarios"
+
+    @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_cache_hit(self, mock_get, mock_secret, mock_cache_enabled):
+        categories_cache.set("categories_test-console", {2: "Known Threats Series"})
+
+        result = _get_categories_map_from_cache_or_api("test-console")
+
+        assert result[2] == "Known Threats Series"
+        mock_get.assert_not_called()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url):
+        mock_get.side_effect = Exception("API unreachable")
+
+        with pytest.raises(Exception, match="API unreachable"):
+            _get_categories_map_from_cache_or_api("test-console")
+
+
+class TestSbGetScenarios:
+    """Test sb_get_scenarios orchestration function."""
+
+    def setup_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    def teardown_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_full_orchestration(self, mock_scenarios, mock_categories):
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
+
+        result = sb_get_scenarios("test-console")
+
+        assert "page_number" in result
+        assert "total_pages" in result
+        assert "total_scenarios" in result
+        assert "scenarios_in_page" in result
+        assert result["total_scenarios"] == 2
+        assert result["page_number"] == 0
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_pagination_with_large_dataset(self, mock_scenarios, mock_categories):
+        large_list = [
+            {
+                "id": f"scenario-{i}", "name": f"Scenario {i}",
+                "description": None, "createdBy": "SafeBreach",
+                "recommended": False, "categories": [2], "tags": None,
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+                "steps": [], "order": None, "actions": None, "edges": None, "phases": {}
+            }
+            for i in range(25)
+        ]
+        mock_scenarios.return_value = large_list
+        mock_categories.return_value = {2: "Known Threats Series"}
+
+        result = sb_get_scenarios("test-console", page_number=0)
+
+        assert result["total_scenarios"] == 25
+        assert result["total_pages"] == 3
+        assert len(result["scenarios_in_page"]) == 10
+        assert result["hint_to_agent"] is not None
+
+    def test_invalid_order_by(self):
+        with pytest.raises(ValueError, match="Invalid order_by"):
+            sb_get_scenarios("test-console", order_by="invalid_field")
+
+    def test_invalid_creator_filter(self):
+        with pytest.raises(ValueError, match="Invalid creator_filter"):
+            sb_get_scenarios("test-console", creator_filter="invalid")
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_api_failure_returns_error_dict(self, mock_scenarios, mock_categories):
+        mock_scenarios.side_effect = Exception("API timeout")
+
+        result = sb_get_scenarios("test-console")
+
+        assert "error" in result
+        assert "API timeout" in result["error"]
+        assert result["console"] == "test-console"
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_applied_filters_metadata(self, mock_scenarios, mock_categories):
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
+
+        result = sb_get_scenarios(
+            "test-console",
+            name_filter="Akira",
+            creator_filter="safebreach",
+        )
+
+        assert "applied_filters" in result
+        assert result["applied_filters"]["name_filter"] == "Akira"
+        assert result["applied_filters"]["creator_filter"] == "safebreach"
+
+
+class TestSbGetScenarioDetails:
+    """Test sb_get_scenario_details function."""
+
+    def setup_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    def teardown_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_found_returns_full_payload(self, mock_scenarios, mock_categories):
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
+
+        result = sb_get_scenario_details("aaa-111-222-333", "test-console")
+
+        assert result["id"] == "aaa-111-222-333"
+        assert result["name"] == "CISA Alert Akira Ransomware"
+        assert "steps" in result
+        assert "category_names" in result
+        assert result["category_names"] == ["Known Threats Series"]
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_not_found_raises_value_error(self, mock_scenarios, mock_categories):
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series"}
+
+        with pytest.raises(ValueError, match="not found"):
+            sb_get_scenario_details("nonexistent-id", "test-console")
+
+    def test_empty_scenario_id_raises_value_error(self):
+        with pytest.raises(ValueError, match="scenario_id"):
+            sb_get_scenario_details("", "test-console")
+
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_preserves_full_payload(self, mock_scenarios, mock_categories):
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series"}
+
+        result = sb_get_scenario_details("aaa-111-222-333", "test-console")
+
+        assert "order" in result
+        assert "actions" in result
+        assert "edges" in result
+        assert "phases" in result

--- a/safebreach_mcp_config/tests/test_config_functions.py
+++ b/safebreach_mcp_config/tests/test_config_functions.py
@@ -834,12 +834,14 @@ class TestSbGetScenarioDetails:
         result = sb_get_scenario_details("aaa-111-222-333", "test-console")
 
         assert result["id"] == "aaa-111-222-333"
+        assert isinstance(result["id"], str)
         assert result["source_type"] == "oob"
         assert result["name"] == "CISA Alert Akira Ransomware"
         assert "steps" in result
         assert result["category_names"] == ["Known Threats Series"]
         assert result["step_count"] == 1
         assert result["is_ready_to_run"] is False
+        assert isinstance(result["tags"], list)
         # Simplified: no raw execution mechanics
         assert "actions" not in result
         assert "edges" not in result
@@ -859,7 +861,8 @@ class TestSbGetScenarioDetails:
 
         result = sb_get_scenario_details("119", "test-console")
 
-        assert result["id"] == 119
+        assert result["id"] == "119"
+        assert isinstance(result["id"], str)
         assert result["source_type"] == "custom"
         assert result["category_names"] == []
         assert result["steps"] == []

--- a/safebreach_mcp_config/tests/test_config_functions.py
+++ b/safebreach_mcp_config/tests/test_config_functions.py
@@ -18,10 +18,13 @@ from safebreach_mcp_config.config_functions import (
     sb_get_scenario_details,
     _get_all_scenarios_from_cache_or_api,
     _get_categories_map_from_cache_or_api,
+    _get_all_plans_from_cache_or_api,
     scenarios_cache,
     categories_cache,
+    plans_cache,
     clear_scenarios_cache,
     clear_categories_cache,
+    clear_plans_cache,
 )
 
 class TestConfigFunctions:
@@ -615,14 +618,17 @@ class TestSbGetScenarios:
     def setup_method(self):
         clear_scenarios_cache()
         clear_categories_cache()
+        clear_plans_cache()
 
     def teardown_method(self):
         clear_scenarios_cache()
         clear_categories_cache()
+        clear_plans_cache()
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_full_orchestration(self, mock_scenarios, mock_categories):
+    def test_full_orchestration(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
 
@@ -635,9 +641,10 @@ class TestSbGetScenarios:
         assert result["total_scenarios"] == 2
         assert result["page_number"] == 0
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_pagination_with_large_dataset(self, mock_scenarios, mock_categories):
+    def test_pagination_with_large_dataset(self, mock_scenarios, mock_categories, mock_plans):
         large_list = [
             {
                 "id": f"scenario-{i}", "name": f"Scenario {i}",
@@ -667,9 +674,10 @@ class TestSbGetScenarios:
         with pytest.raises(ValueError, match="Invalid creator_filter"):
             sb_get_scenarios("test-console", creator_filter="invalid")
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_api_failure_returns_error_dict(self, mock_scenarios, mock_categories):
+    def test_api_failure_returns_error_dict(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.side_effect = Exception("API timeout")
 
         result = sb_get_scenarios("test-console")
@@ -678,9 +686,10 @@ class TestSbGetScenarios:
         assert "API timeout" in result["error"]
         assert result["console"] == "test-console"
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_applied_filters_metadata(self, mock_scenarios, mock_categories):
+    def test_applied_filters_metadata(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
 
@@ -694,6 +703,113 @@ class TestSbGetScenarios:
         assert result["applied_filters"]["name_filter"] == "Akira"
         assert result["applied_filters"]["creator_filter"] == "safebreach"
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_merges_oob_and_custom(self, mock_scenarios, mock_categories, mock_plans):
+        """No filter should return both OOB scenarios and custom plans."""
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA  # 2 OOB
+        mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
+        mock_plans.return_value = [
+            {
+                "id": 100, "name": "Custom Plan A",
+                "description": None, "tags": [], "userId": 1,
+                "originalScenarioId": None, "steps": [],
+                "createdAt": "2026-01-01T00:00:00.000Z",
+                "updatedAt": "2026-01-01T00:00:00.000Z",
+            }
+        ]
+
+        result = sb_get_scenarios("test-console")
+
+        assert result["total_scenarios"] == 3  # 2 OOB + 1 custom
+        source_types = {s["source_type"] for s in result["scenarios_in_page"]}
+        assert source_types == {"oob", "custom"}
+
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_creator_filter_custom_only_fetches_plans(self, mock_scenarios, mock_categories, mock_plans):
+        """creator_filter='custom' should skip fetching OOB scenarios."""
+        mock_plans.return_value = [
+            {
+                "id": 100, "name": "Custom Plan A",
+                "description": None, "tags": [], "userId": 1,
+                "originalScenarioId": None, "steps": [],
+                "createdAt": "2026-01-01T00:00:00.000Z",
+                "updatedAt": "2026-01-01T00:00:00.000Z",
+            }
+        ]
+
+        result = sb_get_scenarios("test-console", creator_filter="custom")
+
+        assert result["total_scenarios"] == 1
+        assert result["scenarios_in_page"][0]["source_type"] == "custom"
+        mock_scenarios.assert_not_called()
+        mock_plans.assert_called_once()
+
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
+    def test_creator_filter_safebreach_only_fetches_scenarios(self, mock_scenarios, mock_categories, mock_plans):
+        """creator_filter='safebreach' should skip fetching custom plans."""
+        mock_scenarios.return_value = MOCK_SCENARIO_DATA
+        mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
+
+        result = sb_get_scenarios("test-console", creator_filter="safebreach")
+
+        assert result["total_scenarios"] == 2
+        assert all(s["source_type"] == "oob" for s in result["scenarios_in_page"])
+        mock_plans.assert_not_called()
+
+
+class TestGetAllPlansFromCacheOrApi:
+    """Test _get_all_plans_from_cache_or_api function."""
+
+    def setup_method(self):
+        clear_plans_cache()
+
+    def teardown_method(self):
+        clear_plans_cache()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123456')
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_api_call_success_unwraps_data(self, mock_get, mock_secret, mock_base_url, mock_account):
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": [{"id": 1, "name": "Plan 1"}]}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = _get_all_plans_from_cache_or_api("test-console")
+
+        assert len(result) == 1
+        assert result[0]["id"] == 1
+        # Verify URL contains the plans path with account_id
+        call_args = str(mock_get.call_args)
+        assert '/api/config/v2/accounts/123456/plans' in call_args
+
+    @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_cache_hit_skips_api(self, mock_get, mock_cache_enabled):
+        plans_cache.set("plans_test-console", [{"id": 99, "name": "Cached"}])
+
+        result = _get_all_plans_from_cache_or_api("test-console")
+
+        assert result[0]["id"] == 99
+        mock_get.assert_not_called()
+
+    @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
+    @patch('safebreach_mcp_config.config_functions.requests.get')
+    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url, mock_account):
+        mock_get.side_effect = Exception("API unreachable")
+
+        with pytest.raises(Exception, match="API unreachable"):
+            _get_all_plans_from_cache_or_api("test-console")
+
 
 class TestSbGetScenarioDetails:
     """Test sb_get_scenario_details function."""
@@ -701,28 +817,49 @@ class TestSbGetScenarioDetails:
     def setup_method(self):
         clear_scenarios_cache()
         clear_categories_cache()
+        clear_plans_cache()
 
     def teardown_method(self):
         clear_scenarios_cache()
         clear_categories_cache()
+        clear_plans_cache()
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_found_returns_full_payload(self, mock_scenarios, mock_categories):
+    def test_found_returns_full_payload(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
 
         result = sb_get_scenario_details("aaa-111-222-333", "test-console")
 
         assert result["id"] == "aaa-111-222-333"
+        assert result["source_type"] == "oob"
         assert result["name"] == "CISA Alert Akira Ransomware"
         assert "steps" in result
         assert "category_names" in result
         assert result["category_names"] == ["Known Threats Series"]
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
+    @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api', return_value=[])
+    def test_finds_custom_plan_by_integer_id(self, mock_scenarios, mock_categories, mock_plans):
+        """Custom plan lookup by integer ID (passed as string) should work."""
+        mock_categories.return_value = {}
+        mock_plans.return_value = [
+            {"id": 119, "name": "Custom Plan", "steps": [], "userId": 1}
+        ]
+
+        result = sb_get_scenario_details("119", "test-console")
+
+        assert result["id"] == 119
+        assert result["source_type"] == "custom"
+        assert result["category_names"] == []
+
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_not_found_raises_value_error(self, mock_scenarios, mock_categories):
+    def test_not_found_raises_value_error(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series"}
 
@@ -733,9 +870,10 @@ class TestSbGetScenarioDetails:
         with pytest.raises(ValueError, match="scenario_id"):
             sb_get_scenario_details("", "test-console")
 
+    @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_preserves_full_payload(self, mock_scenarios, mock_categories):
+    def test_preserves_full_payload(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series"}
 
@@ -745,3 +883,4 @@ class TestSbGetScenarioDetails:
         assert "actions" in result
         assert "edges" in result
         assert "phases" in result
+        assert result["source_type"] == "oob"

--- a/safebreach_mcp_config/tests/test_config_functions.py
+++ b/safebreach_mcp_config/tests/test_config_functions.py
@@ -827,7 +827,7 @@ class TestSbGetScenarioDetails:
     @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_found_returns_full_payload(self, mock_scenarios, mock_categories, mock_plans):
+    def test_returns_simplified_view(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series", 3: "Threat Groups"}
 
@@ -837,14 +837,21 @@ class TestSbGetScenarioDetails:
         assert result["source_type"] == "oob"
         assert result["name"] == "CISA Alert Akira Ransomware"
         assert "steps" in result
-        assert "category_names" in result
         assert result["category_names"] == ["Known Threats Series"]
+        assert result["step_count"] == 1
+        assert result["is_ready_to_run"] is False
+        # Simplified: no raw execution mechanics
+        assert "actions" not in result
+        assert "edges" not in result
+        assert "phases" not in result
+        # Steps are simplified
+        assert result["steps"][0]["name"] == "Network Infiltration"
+        assert "attack_selection" in result["steps"][0]
 
     @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api', return_value=[])
     def test_finds_custom_plan_by_integer_id(self, mock_scenarios, mock_categories, mock_plans):
-        """Custom plan lookup by integer ID (passed as string) should work."""
         mock_categories.return_value = {}
         mock_plans.return_value = [
             {"id": 119, "name": "Custom Plan", "steps": [], "userId": 1}
@@ -855,6 +862,7 @@ class TestSbGetScenarioDetails:
         assert result["id"] == 119
         assert result["source_type"] == "custom"
         assert result["category_names"] == []
+        assert result["steps"] == []
 
     @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
@@ -873,14 +881,16 @@ class TestSbGetScenarioDetails:
     @patch('safebreach_mcp_config.config_functions._get_all_plans_from_cache_or_api', return_value=[])
     @patch('safebreach_mcp_config.config_functions._get_categories_map_from_cache_or_api')
     @patch('safebreach_mcp_config.config_functions._get_all_scenarios_from_cache_or_api')
-    def test_preserves_full_payload(self, mock_scenarios, mock_categories, mock_plans):
+    def test_has_simplified_step_format(self, mock_scenarios, mock_categories, mock_plans):
         mock_scenarios.return_value = MOCK_SCENARIO_DATA
         mock_categories.return_value = {2: "Known Threats Series"}
 
         result = sb_get_scenario_details("aaa-111-222-333", "test-console")
 
-        assert "order" in result
-        assert "actions" in result
-        assert "edges" in result
-        assert "phases" in result
         assert result["source_type"] == "oob"
+        assert "has_wait_steps" in result
+        for step in result["steps"]:
+            assert "name" in step
+            assert "attack_selection" in step
+            assert "target_criteria" in step
+            assert "attacker_criteria" in step

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -10,6 +10,7 @@ import pytest
 from safebreach_mcp_config.config_types import (
     compute_is_ready_to_run,
     get_reduced_scenario_mapping,
+    get_reduced_plan_mapping,
     filter_scenarios_by_criteria,
     apply_scenario_ordering,
     paginate_scenarios,
@@ -161,6 +162,7 @@ def sample_reduced_scenarios():
             "id": "aaa-111",
             "name": "CISA Alert AA24 (StopRansomware: Akira Ransomware)",
             "description": "Based on a joint Cybersecurity Advisory",
+            "source_type": "oob",
             "createdBy": "SafeBreach",
             "recommended": True,
             "category_names": ["Known Threats Series"],
@@ -174,6 +176,7 @@ def sample_reduced_scenarios():
             "id": "bbb-222",
             "name": "KongTuke",
             "description": None,
+            "source_type": "oob",
             "createdBy": "SafeBreach",
             "recommended": False,
             "category_names": ["Threat Groups"],
@@ -187,6 +190,7 @@ def sample_reduced_scenarios():
             "id": "ccc-333",
             "name": "Step 1 - Fortify your Network Perimeter",
             "description": "Fortify network perimeter defenses",
+            "source_type": "oob",
             "createdBy": "SafeBreach",
             "recommended": False,
             "category_names": ["Baseline Scenarios"],
@@ -197,12 +201,13 @@ def sample_reduced_scenarios():
             "updatedAt": "2025-12-01T00:00:00.000Z",
         },
         {
-            "id": "ddd-444",
+            "id": 444,
             "name": "Custom Data Exfil Scenario",
             "description": "A custom scenario for testing data exfiltration",
-            "createdBy": "john.doe@company.com",
+            "source_type": "custom",
+            "createdBy": None,
             "recommended": False,
-            "category_names": ["Known Threats Series"],
+            "category_names": [],
             "tags": None,
             "step_count": 2,
             "is_ready_to_run": False,
@@ -213,6 +218,7 @@ def sample_reduced_scenarios():
             "id": "eee-555",
             "name": "Email - Attachment - Infiltration - Baseline",
             "description": "Email attachment infiltration baseline scenario",
+            "source_type": "oob",
             "createdBy": "SafeBreach",
             "recommended": True,
             "category_names": ["Getting Started"],
@@ -285,11 +291,12 @@ class TestGetReducedScenarioMapping:
     def test_all_expected_keys_present(self, sample_scenario_ready, sample_categories_map):
         result = get_reduced_scenario_mapping(sample_scenario_ready, sample_categories_map)
         expected_keys = {
-            "id", "name", "description", "createdBy", "recommended",
+            "id", "source_type", "name", "description", "createdBy", "recommended",
             "category_names", "tags", "step_count", "is_ready_to_run",
-            "createdAt", "updatedAt"
+            "createdAt", "updatedAt", "userId", "originalScenarioId"
         }
         assert set(result.keys()) == expected_keys
+        assert result["source_type"] == "oob"
 
     def test_description_truncation(self, sample_categories_map):
         scenario = {
@@ -338,6 +345,81 @@ class TestGetReducedScenarioMapping:
         assert result["category_names"] == ["Known Threats Series"]
 
 
+class TestGetReducedPlanMapping:
+    """Test the get_reduced_plan_mapping function for custom plans."""
+
+    @pytest.fixture
+    def sample_plan(self):
+        """A custom plan from the /plans endpoint."""
+        return {
+            "id": 119,
+            "name": "CISA Alert AA23-347A (APT29)",
+            "description": "A custom scenario description",
+            "accountId": 3471166703,
+            "originalScenarioId": "938be06a-1e47-4a68-a10d-a4d04167896b",
+            "userId": 347116670300054,
+            "deploymentId": None,
+            "systemFilter": None,
+            "tags": [],
+            "emailRecipients": None,
+            "successCriteria": None,
+            "actions": [],
+            "edges": [],
+            "createdAt": "2026-02-23T08:19:46.295Z",
+            "updatedAt": "2026-02-23T08:19:46.295Z",
+            "steps": [
+                {
+                    "name": "Step 1",
+                    "systemFilter": {},
+                    "targetFilter": {"os": {"values": ["WINDOWS"]}},
+                    "attackerFilter": {"role": {"values": ["isInfiltration"]}},
+                    "attacksFilter": {},
+                }
+            ],
+        }
+
+    def test_source_type_is_custom(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["source_type"] == "custom"
+
+    def test_all_expected_keys_present(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        expected_keys = {
+            "id", "source_type", "name", "description", "createdBy", "recommended",
+            "category_names", "tags", "step_count", "is_ready_to_run",
+            "createdAt", "updatedAt", "userId", "originalScenarioId"
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_custom_has_no_categories_or_recommended(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["category_names"] == []
+        assert result["recommended"] is False
+        assert result["createdBy"] is None
+
+    def test_custom_preserves_user_and_original(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["userId"] == 347116670300054
+        assert result["originalScenarioId"] == "938be06a-1e47-4a68-a10d-a4d04167896b"
+
+    def test_empty_tags_list_becomes_none(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["tags"] is None  # empty list normalized to None
+
+    def test_integer_id_preserved(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["id"] == 119
+        assert isinstance(result["id"], int)
+
+    def test_step_count_computed_for_plans(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["step_count"] == 1
+
+    def test_is_ready_to_run_for_plans(self, sample_plan):
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["is_ready_to_run"] is True
+
+
 class TestFilterScenariosByCriteria:
     """Test the filter_scenarios_by_criteria function."""
 
@@ -359,14 +441,15 @@ class TestFilterScenariosByCriteria:
             sample_reduced_scenarios, creator_filter="safebreach"
         )
         assert len(result) == 4
-        assert all(s["createdBy"] == "SafeBreach" for s in result)
+        assert all(s["source_type"] == "oob" for s in result)
 
     def test_creator_filter_custom(self, sample_reduced_scenarios):
         result = filter_scenarios_by_criteria(
             sample_reduced_scenarios, creator_filter="custom"
         )
         assert len(result) == 1
-        assert result[0]["createdBy"] == "john.doe@company.com"
+        assert result[0]["source_type"] == "custom"
+        assert result[0]["name"] == "Custom Data Exfil Scenario"
 
     def test_category_filter_partial(self, sample_reduced_scenarios):
         result = filter_scenarios_by_criteria(

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -370,7 +370,7 @@ class TestFilterScenariosByCriteria:
 
     def test_category_filter_partial(self, sample_reduced_scenarios):
         result = filter_scenarios_by_criteria(
-            sample_reduced_scenarios, category_filter="Threat"
+            sample_reduced_scenarios, category_filter="Groups"
         )
         assert len(result) == 1
         assert "Threat Groups" in result[0]["category_names"]

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -1,0 +1,491 @@
+"""
+Tests for SafeBreach Config Types - Scenario Transforms
+
+TDD RED phase: These tests define the expected behavior of scenario transform,
+filter, ordering, and pagination functions. All tests should fail initially
+because the functions do not exist yet in config_types.py.
+"""
+
+import pytest
+from safebreach_mcp_config.config_types import (
+    compute_is_ready_to_run,
+    get_reduced_scenario_mapping,
+    filter_scenarios_by_criteria,
+    apply_scenario_ordering,
+    paginate_scenarios,
+)
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def sample_scenario_ready():
+    """A scenario where ALL steps have real targetFilter AND attackerFilter criteria."""
+    return {
+        "id": "3b8eade5-9285-43b8-b3e7-6350420983a5",
+        "name": "Step 1 - Fortify your Network Perimeter",
+        "description": "Test scenario that is ready to run",
+        "createdBy": "SafeBreach",
+        "recommended": True,
+        "categories": [4],
+        "tags": ["network", "perimeter"],
+        "createdAt": "2025-01-01T00:00:00.000Z",
+        "updatedAt": "2025-06-01T00:00:00.000Z",
+        "steps": [
+            {
+                "name": "Exploitation",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {
+                    "os": {
+                        "name": "os",
+                        "values": ["WINDOWS", "MAC", "LINUX"],
+                        "operator": "is"
+                    }
+                },
+                "attackerFilter": {
+                    "role": {
+                        "name": "role",
+                        "values": ["isInfiltration"],
+                        "operator": "is"
+                    }
+                },
+                "attacksFilter": {}
+            },
+            {
+                "name": "Brute Force",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {
+                    "os": {
+                        "name": "os",
+                        "values": ["WINDOWS", "LINUX"],
+                        "operator": "is"
+                    }
+                },
+                "attackerFilter": {
+                    "role": {
+                        "name": "role",
+                        "values": ["isInfiltration"],
+                        "operator": "is"
+                    }
+                },
+                "attacksFilter": {}
+            }
+        ],
+        "order": None,
+        "actions": None,
+        "edges": None,
+        "phases": {}
+    }
+
+
+@pytest.fixture
+def sample_scenario_not_ready():
+    """A scenario where steps have empty simulator values (NOT ready to run)."""
+    return {
+        "id": "66d023d9-cc16-4c8d-9f29-7fb5e6db91af",
+        "name": "AI Generated Malware",
+        "description": "Scenario with empty simulator filter values",
+        "createdBy": "SafeBreach",
+        "recommended": False,
+        "categories": [2],
+        "tags": None,
+        "createdAt": "2025-03-01T00:00:00.000Z",
+        "updatedAt": "2025-07-01T00:00:00.000Z",
+        "steps": [
+            {
+                "name": "Host Level Actions",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {
+                    "simulators": {
+                        "name": "simulators",
+                        "values": [],
+                        "operator": "is"
+                    }
+                },
+                "attackerFilter": {
+                    "simulators": {
+                        "name": "simulators",
+                        "values": [],
+                        "operator": "is"
+                    }
+                },
+                "attacksFilter": {}
+            },
+            {
+                "name": "Malware Transfer",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {
+                    "simulators": {
+                        "name": "simulators",
+                        "values": [],
+                        "operator": "is"
+                    }
+                },
+                "attackerFilter": {
+                    "simulators": {
+                        "name": "simulators",
+                        "values": [],
+                        "operator": "is"
+                    }
+                },
+                "attacksFilter": {}
+            }
+        ],
+        "order": None,
+        "actions": None,
+        "edges": None,
+        "phases": {}
+    }
+
+
+@pytest.fixture
+def sample_categories_map():
+    """Category ID to name mapping."""
+    return {
+        2: "Known Threats Series",
+        3: "Threat Groups",
+        4: "Baseline Scenarios",
+        11: "Getting Started",
+    }
+
+
+@pytest.fixture
+def sample_reduced_scenarios():
+    """Pre-transformed reduced scenario dicts for filter/ordering/pagination tests."""
+    return [
+        {
+            "id": "aaa-111",
+            "name": "CISA Alert AA24 (StopRansomware: Akira Ransomware)",
+            "description": "Based on a joint Cybersecurity Advisory",
+            "createdBy": "SafeBreach",
+            "recommended": True,
+            "category_names": ["Known Threats Series"],
+            "tags": ["ransomware", "Akira"],
+            "step_count": 5,
+            "is_ready_to_run": False,
+            "createdAt": "2025-11-14T11:29:13.000Z",
+            "updatedAt": "2026-01-22T14:25:18.000Z",
+        },
+        {
+            "id": "bbb-222",
+            "name": "KongTuke",
+            "description": None,
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "category_names": ["Threat Groups"],
+            "tags": ["KongTuke"],
+            "step_count": 4,
+            "is_ready_to_run": False,
+            "createdAt": "2026-02-10T09:42:06.000Z",
+            "updatedAt": "2026-02-10T09:42:06.000Z",
+        },
+        {
+            "id": "ccc-333",
+            "name": "Step 1 - Fortify your Network Perimeter",
+            "description": "Fortify network perimeter defenses",
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "category_names": ["Baseline Scenarios"],
+            "tags": ["network", "perimeter"],
+            "step_count": 5,
+            "is_ready_to_run": True,
+            "createdAt": "2024-06-01T00:00:00.000Z",
+            "updatedAt": "2025-12-01T00:00:00.000Z",
+        },
+        {
+            "id": "ddd-444",
+            "name": "Custom Data Exfil Scenario",
+            "description": "A custom scenario for testing data exfiltration",
+            "createdBy": "john.doe@company.com",
+            "recommended": False,
+            "category_names": ["Known Threats Series"],
+            "tags": None,
+            "step_count": 2,
+            "is_ready_to_run": False,
+            "createdAt": "2026-03-01T00:00:00.000Z",
+            "updatedAt": "2026-03-15T00:00:00.000Z",
+        },
+        {
+            "id": "eee-555",
+            "name": "Email - Attachment - Infiltration - Baseline",
+            "description": "Email attachment infiltration baseline scenario",
+            "createdBy": "SafeBreach",
+            "recommended": True,
+            "category_names": ["Getting Started"],
+            "tags": ["email", "infiltration"],
+            "step_count": 1,
+            "is_ready_to_run": True,
+            "createdAt": "2025-01-15T00:00:00.000Z",
+            "updatedAt": "2025-09-01T00:00:00.000Z",
+        },
+    ]
+
+
+# --- Test Classes ---
+
+class TestComputeIsReadyToRun:
+    """Test the compute_is_ready_to_run function."""
+
+    def test_ready_all_steps_have_os_role_criteria(self, sample_scenario_ready):
+        assert compute_is_ready_to_run(sample_scenario_ready) is True
+
+    def test_not_ready_empty_simulator_values(self, sample_scenario_not_ready):
+        assert compute_is_ready_to_run(sample_scenario_not_ready) is False
+
+    def test_not_ready_no_steps(self):
+        scenario = {"steps": []}
+        assert compute_is_ready_to_run(scenario) is False
+
+    def test_not_ready_mixed_steps(self, sample_scenario_ready):
+        """One step has real criteria, another has empty simulators."""
+        scenario = sample_scenario_ready.copy()
+        scenario["steps"] = [
+            sample_scenario_ready["steps"][0],
+            {
+                "name": "Bad Step",
+                "draft": False,
+                "systemFilter": {},
+                "targetFilter": {
+                    "simulators": {"name": "simulators", "values": [], "operator": "is"}
+                },
+                "attackerFilter": {
+                    "simulators": {"name": "simulators", "values": [], "operator": "is"}
+                },
+                "attacksFilter": {}
+            }
+        ]
+        assert compute_is_ready_to_run(scenario) is False
+
+    def test_not_ready_target_only_no_attacker(self):
+        """Step has targetFilter with real values but empty attackerFilter."""
+        scenario = {
+            "steps": [
+                {
+                    "name": "Partial Step",
+                    "draft": False,
+                    "systemFilter": {},
+                    "targetFilter": {
+                        "os": {"name": "os", "values": ["WINDOWS"], "operator": "is"}
+                    },
+                    "attackerFilter": {},
+                    "attacksFilter": {}
+                }
+            ]
+        }
+        assert compute_is_ready_to_run(scenario) is False
+
+
+class TestGetReducedScenarioMapping:
+    """Test the get_reduced_scenario_mapping function."""
+
+    def test_all_expected_keys_present(self, sample_scenario_ready, sample_categories_map):
+        result = get_reduced_scenario_mapping(sample_scenario_ready, sample_categories_map)
+        expected_keys = {
+            "id", "name", "description", "createdBy", "recommended",
+            "category_names", "tags", "step_count", "is_ready_to_run",
+            "createdAt", "updatedAt"
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_description_truncation(self, sample_categories_map):
+        scenario = {
+            "id": "trunc-test",
+            "name": "Truncation Test",
+            "description": "A" * 300,
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "categories": [2],
+            "tags": None,
+            "createdAt": "2025-01-01T00:00:00.000Z",
+            "updatedAt": "2025-01-01T00:00:00.000Z",
+            "steps": [],
+        }
+        result = get_reduced_scenario_mapping(scenario, sample_categories_map)
+        assert len(result["description"]) == 203  # 200 + "..."
+        assert result["description"].endswith("...")
+
+    def test_category_names_resolved(self, sample_scenario_ready, sample_categories_map):
+        result = get_reduced_scenario_mapping(sample_scenario_ready, sample_categories_map)
+        assert result["category_names"] == ["Baseline Scenarios"]
+
+    def test_step_count_computed(self, sample_scenario_ready, sample_categories_map):
+        result = get_reduced_scenario_mapping(sample_scenario_ready, sample_categories_map)
+        assert result["step_count"] == 2
+
+    def test_null_tags_and_description(self, sample_scenario_not_ready, sample_categories_map):
+        result = get_reduced_scenario_mapping(sample_scenario_not_ready, sample_categories_map)
+        assert result["tags"] is None
+        assert result["description"] == "Scenario with empty simulator filter values"
+
+    def test_unknown_category_id_skipped(self, sample_categories_map):
+        scenario = {
+            "id": "unknown-cat",
+            "name": "Unknown Category Test",
+            "description": None,
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "categories": [2, 999],
+            "tags": None,
+            "createdAt": "2025-01-01T00:00:00.000Z",
+            "updatedAt": "2025-01-01T00:00:00.000Z",
+            "steps": [],
+        }
+        result = get_reduced_scenario_mapping(scenario, sample_categories_map)
+        assert result["category_names"] == ["Known Threats Series"]
+
+
+class TestFilterScenariosByCriteria:
+    """Test the filter_scenarios_by_criteria function."""
+
+    def test_no_filters_returns_all(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(sample_reduced_scenarios)
+        assert len(result) == 5
+
+    def test_name_filter_partial_match(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(sample_reduced_scenarios, name_filter="Akira")
+        assert len(result) == 1
+        assert "Akira" in result[0]["name"]
+
+    def test_name_filter_case_insensitive(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(sample_reduced_scenarios, name_filter="akira")
+        assert len(result) == 1
+
+    def test_creator_filter_safebreach(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios, creator_filter="safebreach"
+        )
+        assert len(result) == 4
+        assert all(s["createdBy"] == "SafeBreach" for s in result)
+
+    def test_creator_filter_custom(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios, creator_filter="custom"
+        )
+        assert len(result) == 1
+        assert result[0]["createdBy"] == "john.doe@company.com"
+
+    def test_category_filter_partial(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios, category_filter="Threat"
+        )
+        assert len(result) == 1
+        assert "Threat Groups" in result[0]["category_names"]
+
+    def test_recommended_filter_true(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios, recommended_filter=True
+        )
+        assert len(result) == 2
+        assert all(s["recommended"] is True for s in result)
+
+    def test_tag_filter_excludes_null_tags(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios, tag_filter="ransomware"
+        )
+        assert len(result) == 1
+        assert result[0]["id"] == "aaa-111"
+
+    def test_combined_filters_and_logic(self, sample_reduced_scenarios):
+        result = filter_scenarios_by_criteria(
+            sample_reduced_scenarios,
+            creator_filter="safebreach",
+            recommended_filter=True,
+        )
+        assert len(result) == 2
+        assert all(s["createdBy"] == "SafeBreach" and s["recommended"] for s in result)
+
+
+class TestApplyScenarioOrdering:
+    """Test the apply_scenario_ordering function."""
+
+    def test_order_by_name_asc(self, sample_reduced_scenarios):
+        result = apply_scenario_ordering(
+            sample_reduced_scenarios, order_by="name", order_direction="asc"
+        )
+        names = [s["name"] for s in result]
+        assert names == sorted(names, key=str.lower)
+
+    def test_order_by_name_desc(self, sample_reduced_scenarios):
+        result = apply_scenario_ordering(
+            sample_reduced_scenarios, order_by="name", order_direction="desc"
+        )
+        names = [s["name"] for s in result]
+        assert names == sorted(names, key=str.lower, reverse=True)
+
+    def test_order_by_step_count(self, sample_reduced_scenarios):
+        result = apply_scenario_ordering(
+            sample_reduced_scenarios, order_by="step_count", order_direction="asc"
+        )
+        counts = [s["step_count"] for s in result]
+        assert counts == sorted(counts)
+
+    def test_order_by_created_at_desc(self, sample_reduced_scenarios):
+        result = apply_scenario_ordering(
+            sample_reduced_scenarios, order_by="createdAt", order_direction="desc"
+        )
+        dates = [s["createdAt"] for s in result]
+        assert dates == sorted(dates, reverse=True)
+
+
+class TestPaginateScenarios:
+    """Test the paginate_scenarios function."""
+
+    @pytest.fixture
+    def large_scenario_list(self):
+        """Generate 25 reduced scenario dicts for pagination testing."""
+        return [
+            {
+                "id": f"scenario-{i}",
+                "name": f"Scenario {i}",
+                "description": f"Description {i}",
+                "createdBy": "SafeBreach",
+                "recommended": False,
+                "category_names": ["Test"],
+                "tags": None,
+                "step_count": i,
+                "is_ready_to_run": False,
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+            }
+            for i in range(25)
+        ]
+
+    def test_first_page(self, large_scenario_list):
+        result = paginate_scenarios(large_scenario_list, page_number=0, page_size=10)
+        assert result["page_number"] == 0
+        assert result["total_pages"] == 3
+        assert result["total_scenarios"] == 25
+        assert len(result["scenarios_in_page"]) == 10
+        assert result["hint_to_agent"] is not None
+
+    def test_last_page(self, large_scenario_list):
+        result = paginate_scenarios(large_scenario_list, page_number=2, page_size=10)
+        assert result["page_number"] == 2
+        assert len(result["scenarios_in_page"]) == 5
+        assert result["hint_to_agent"] is None
+
+    def test_empty_list(self):
+        result = paginate_scenarios([], page_number=0, page_size=10)
+        assert result["page_number"] == 0
+        assert result["total_pages"] == 0
+        assert result["total_scenarios"] == 0
+        assert len(result["scenarios_in_page"]) == 0
+
+    def test_invalid_page_beyond_total(self, large_scenario_list):
+        result = paginate_scenarios(large_scenario_list, page_number=10, page_size=10)
+        assert "error" in result
+        assert "Invalid page_number 10" in result["error"]
+        assert result["total_scenarios"] == 25
+        assert len(result["scenarios_in_page"]) == 0
+
+    def test_single_page_result(self, sample_reduced_scenarios):
+        result = paginate_scenarios(sample_reduced_scenarios, page_number=0, page_size=10)
+        assert result["page_number"] == 0
+        assert result["total_pages"] == 1
+        assert result["total_scenarios"] == 5
+        assert len(result["scenarios_in_page"]) == 5
+        assert result["hint_to_agent"] is None

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -201,14 +201,14 @@ def sample_reduced_scenarios():
             "updatedAt": "2025-12-01T00:00:00.000Z",
         },
         {
-            "id": 444,
+            "id": "444",
             "name": "Custom Data Exfil Scenario",
             "description": "A custom scenario for testing data exfiltration",
             "source_type": "custom",
             "createdBy": None,
             "recommended": False,
             "category_names": [],
-            "tags": None,
+            "tags": [],
             "step_count": 2,
             "is_ready_to_run": False,
             "createdAt": "2026-03-01T00:00:00.000Z",
@@ -325,7 +325,7 @@ class TestGetReducedScenarioMapping:
 
     def test_null_tags_and_description(self, sample_scenario_not_ready, sample_categories_map):
         result = get_reduced_scenario_mapping(sample_scenario_not_ready, sample_categories_map)
-        assert result["tags"] is None
+        assert result["tags"] == []
         assert result["description"] == "Scenario with empty simulator filter values"
 
     def test_unknown_category_id_skipped(self, sample_categories_map):
@@ -402,14 +402,14 @@ class TestGetReducedPlanMapping:
         assert result["userId"] == 347116670300054
         assert result["originalScenarioId"] == "938be06a-1e47-4a68-a10d-a4d04167896b"
 
-    def test_empty_tags_list_becomes_none(self, sample_plan):
+    def test_empty_tags_list_becomes_empty_list(self, sample_plan):
         result = get_reduced_plan_mapping(sample_plan)
-        assert result["tags"] is None  # empty list normalized to None
+        assert result["tags"] == []
 
-    def test_integer_id_preserved(self, sample_plan):
+    def test_id_is_always_string(self, sample_plan):
         result = get_reduced_plan_mapping(sample_plan)
-        assert result["id"] == 119
-        assert isinstance(result["id"], int)
+        assert result["id"] == "119"
+        assert isinstance(result["id"], str)
 
     def test_step_count_computed_for_plans(self, sample_plan):
         result = get_reduced_plan_mapping(sample_plan)

--- a/safebreach_mcp_config/tests/test_e2e_scenarios.py
+++ b/safebreach_mcp_config/tests/test_e2e_scenarios.py
@@ -1,0 +1,141 @@
+"""
+End-to-End Tests for SafeBreach Scenario Tools (Config Server)
+
+Tests the complete functionality using real API calls to the scenarios and
+scenarioCategories endpoints. Requires:
+- Real SafeBreach console access with valid API tokens
+- Environment variables configured via private .vscode/set_env.sh file
+- Network access to SafeBreach consoles
+
+Setup: source .vscode/set_env.sh && uv run pytest -m "e2e" -v
+"""
+
+import pytest
+import os
+from safebreach_mcp_config.config_functions import (
+    sb_get_scenarios,
+    sb_get_scenario_details,
+    clear_scenarios_cache,
+    clear_categories_cache,
+)
+
+
+E2E_CONSOLE = os.environ.get('E2E_CONSOLE', 'pentest01')
+SKIP_E2E_TESTS = os.environ.get('SKIP_E2E_TESTS', 'false').lower() == 'true'
+
+skip_e2e = pytest.mark.skipif(
+    SKIP_E2E_TESTS,
+    reason="E2E tests skipped (set SKIP_E2E_TESTS=false to enable)"
+)
+
+
+@skip_e2e
+@pytest.mark.e2e
+class TestScenarioE2E:
+    """End-to-end tests for scenario tools against real SafeBreach API."""
+
+    def setup_method(self):
+        clear_scenarios_cache()
+        clear_categories_cache()
+
+    def test_get_scenarios_basic(self):
+        """Test basic scenario listing returns valid paginated response."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+
+        assert 'page_number' in result
+        assert 'total_pages' in result
+        assert 'total_scenarios' in result
+        assert 'scenarios_in_page' in result
+        assert 'hint_to_agent' in result
+
+        assert result['total_scenarios'] > 0
+        assert len(result['scenarios_in_page']) > 0
+        assert len(result['scenarios_in_page']) <= 10
+
+    def test_scenario_structure(self):
+        """Verify each scenario in the list has expected keys."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+
+        for scenario in result['scenarios_in_page']:
+            assert 'id' in scenario
+            assert 'name' in scenario
+            assert 'createdBy' in scenario
+            assert 'category_names' in scenario
+            assert 'step_count' in scenario
+            assert 'is_ready_to_run' in scenario
+            assert 'recommended' in scenario
+            assert isinstance(scenario['category_names'], list)
+            assert isinstance(scenario['step_count'], int)
+            assert isinstance(scenario['is_ready_to_run'], bool)
+
+    def test_name_filter(self):
+        """Test name filter with a known substring."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, name_filter="CISA")
+
+        assert result['total_scenarios'] > 0
+        for scenario in result['scenarios_in_page']:
+            assert 'cisa' in scenario['name'].lower()
+
+    def test_creator_filter_safebreach(self):
+        """Test filtering for SafeBreach-created (OOB) scenarios."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="safebreach")
+
+        assert result['total_scenarios'] > 0
+        for scenario in result['scenarios_in_page']:
+            assert scenario['createdBy'] == 'SafeBreach'
+
+    def test_recommended_filter(self):
+        """Test filtering for recommended scenarios."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, recommended_filter=True)
+
+        assert result['total_scenarios'] > 0
+        for scenario in result['scenarios_in_page']:
+            assert scenario['recommended'] is True
+
+    def test_ready_to_run_filter(self):
+        """Test filtering for ready-to-run scenarios."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, ready_to_run_filter=True)
+
+        assert result['total_scenarios'] > 0
+        for scenario in result['scenarios_in_page']:
+            assert scenario['is_ready_to_run'] is True
+
+    def test_pagination_hint(self):
+        """Test that pagination hint works correctly."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+
+        if result['total_pages'] > 1:
+            assert result['hint_to_agent'] is not None
+            assert 'page_number=1' in result['hint_to_agent']
+
+    def test_get_scenario_details(self):
+        """Test getting full scenario details by ID."""
+        list_result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+        first_id = list_result['scenarios_in_page'][0]['id']
+
+        detail = sb_get_scenario_details(first_id, console=E2E_CONSOLE)
+
+        assert detail['id'] == first_id
+        assert 'name' in detail
+        assert 'steps' in detail
+        assert 'categories' in detail
+        assert 'category_names' in detail
+        assert isinstance(detail['category_names'], list)
+
+    def test_get_scenario_details_not_found(self):
+        """Test that non-existent scenario ID raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            sb_get_scenario_details("00000000-0000-0000-0000-000000000000", console=E2E_CONSOLE)
+
+    def test_scenario_details_has_full_payload(self):
+        """Test that details include full payload fields needed for queue API."""
+        list_result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+        first_id = list_result['scenarios_in_page'][0]['id']
+
+        detail = sb_get_scenario_details(first_id, console=E2E_CONSOLE)
+
+        assert 'steps' in detail
+        assert 'phases' in detail
+        assert 'createdBy' in detail
+        assert 'createdAt' in detail
+        assert 'updatedAt' in detail

--- a/safebreach_mcp_config/tests/test_e2e_scenarios.py
+++ b/safebreach_mcp_config/tests/test_e2e_scenarios.py
@@ -109,11 +109,10 @@ class TestScenarioE2E:
             assert 'page_number=1' in result['hint_to_agent']
 
     def test_get_scenario_details(self):
-        """Test getting full scenario details by ID (passes both UUID and int IDs)."""
+        """Test getting simplified scenario details by ID."""
         list_result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
         first_id = list_result['scenarios_in_page'][0]['id']
 
-        # Pass as string to support both UUID (OOB) and integer (custom plan) IDs
         detail = sb_get_scenario_details(str(first_id), console=E2E_CONSOLE)
 
         assert str(detail['id']) == str(first_id)
@@ -121,16 +120,23 @@ class TestScenarioE2E:
         assert 'steps' in detail
         assert 'source_type' in detail
         assert 'category_names' in detail
+        assert 'step_count' in detail
+        assert 'is_ready_to_run' in detail
+        assert 'has_wait_steps' in detail
         assert isinstance(detail['category_names'], list)
+        # Steps are simplified
+        for step in detail['steps']:
+            assert 'name' in step
+            assert 'attack_selection' in step
+            assert 'mode' in step['attack_selection']
 
     def test_get_scenario_details_not_found(self):
         """Test that non-existent scenario ID raises ValueError."""
         with pytest.raises(ValueError, match="not found"):
             sb_get_scenario_details("00000000-0000-0000-0000-000000000000", console=E2E_CONSOLE)
 
-    def test_scenario_details_has_full_payload(self):
-        """Test that details include full payload fields needed for queue API."""
-        # Get an OOB scenario specifically to check phases/createdBy fields
+    def test_scenario_details_simplified_format(self):
+        """Test that details return simplified LLM-readable format."""
         list_result = sb_get_scenarios(
             console=E2E_CONSOLE, creator_filter="safebreach", page_number=0
         )
@@ -138,12 +144,15 @@ class TestScenarioE2E:
 
         detail = sb_get_scenario_details(str(first_id), console=E2E_CONSOLE)
 
+        assert detail['source_type'] == 'oob'
         assert 'steps' in detail
-        assert 'phases' in detail
         assert 'createdBy' in detail
         assert 'createdAt' in detail
         assert 'updatedAt' in detail
-        assert detail['source_type'] == 'oob'
+        # Simplified — no raw execution mechanics
+        assert 'actions' not in detail
+        assert 'edges' not in detail
+        assert 'phases' not in detail
 
     def test_custom_scenarios_returned(self):
         """Custom plans should be fetched and returned with source_type='custom'."""
@@ -168,7 +177,7 @@ class TestScenarioE2E:
             oob_only['total_scenarios'] + custom_only['total_scenarios']
 
     def test_get_custom_plan_details_by_integer_id(self):
-        """Custom plan details should be retrievable by their integer ID."""
+        """Custom plan details should be retrievable and in simplified format."""
         list_result = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="custom")
         first_custom = list_result['scenarios_in_page'][0]
         plan_id = first_custom['id']
@@ -178,3 +187,8 @@ class TestScenarioE2E:
         assert detail['source_type'] == 'custom'
         assert str(detail['id']) == str(plan_id)
         assert 'steps' in detail
+        assert 'has_wait_steps' in detail
+        # Same simplified step format as OOB
+        for step in detail['steps']:
+            assert 'name' in step
+            assert 'attack_selection' in step

--- a/safebreach_mcp_config/tests/test_e2e_scenarios.py
+++ b/safebreach_mcp_config/tests/test_e2e_scenarios.py
@@ -109,16 +109,17 @@ class TestScenarioE2E:
             assert 'page_number=1' in result['hint_to_agent']
 
     def test_get_scenario_details(self):
-        """Test getting full scenario details by ID."""
+        """Test getting full scenario details by ID (passes both UUID and int IDs)."""
         list_result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
         first_id = list_result['scenarios_in_page'][0]['id']
 
-        detail = sb_get_scenario_details(first_id, console=E2E_CONSOLE)
+        # Pass as string to support both UUID (OOB) and integer (custom plan) IDs
+        detail = sb_get_scenario_details(str(first_id), console=E2E_CONSOLE)
 
-        assert detail['id'] == first_id
+        assert str(detail['id']) == str(first_id)
         assert 'name' in detail
         assert 'steps' in detail
-        assert 'categories' in detail
+        assert 'source_type' in detail
         assert 'category_names' in detail
         assert isinstance(detail['category_names'], list)
 
@@ -129,13 +130,51 @@ class TestScenarioE2E:
 
     def test_scenario_details_has_full_payload(self):
         """Test that details include full payload fields needed for queue API."""
-        list_result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+        # Get an OOB scenario specifically to check phases/createdBy fields
+        list_result = sb_get_scenarios(
+            console=E2E_CONSOLE, creator_filter="safebreach", page_number=0
+        )
         first_id = list_result['scenarios_in_page'][0]['id']
 
-        detail = sb_get_scenario_details(first_id, console=E2E_CONSOLE)
+        detail = sb_get_scenario_details(str(first_id), console=E2E_CONSOLE)
 
         assert 'steps' in detail
         assert 'phases' in detail
         assert 'createdBy' in detail
         assert 'createdAt' in detail
         assert 'updatedAt' in detail
+        assert detail['source_type'] == 'oob'
+
+    def test_custom_scenarios_returned(self):
+        """Custom plans should be fetched and returned with source_type='custom'."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="custom")
+
+        assert result['total_scenarios'] > 0, \
+            "Expected custom plans on pentest01 (My Scenarios tab)"
+        for scenario in result['scenarios_in_page']:
+            assert scenario['source_type'] == 'custom'
+            assert scenario['category_names'] == []
+            assert scenario['recommended'] is False
+
+    def test_merged_oob_and_custom_by_default(self):
+        """No filter should return both OOB scenarios and custom plans."""
+        result = sb_get_scenarios(console=E2E_CONSOLE, page_number=0)
+
+        # Sanity: there should be more than just OOB on pentest01
+        oob_only = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="safebreach")
+        custom_only = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="custom")
+
+        assert result['total_scenarios'] == \
+            oob_only['total_scenarios'] + custom_only['total_scenarios']
+
+    def test_get_custom_plan_details_by_integer_id(self):
+        """Custom plan details should be retrievable by their integer ID."""
+        list_result = sb_get_scenarios(console=E2E_CONSOLE, creator_filter="custom")
+        first_custom = list_result['scenarios_in_page'][0]
+        plan_id = first_custom['id']
+
+        detail = sb_get_scenario_details(str(plan_id), console=E2E_CONSOLE)
+
+        assert detail['source_type'] == 'custom'
+        assert str(detail['id']) == str(plan_id)
+        assert 'steps' in detail


### PR DESCRIPTION
## Summary

- Add `get_scenarios` MCP tool — paginated listing of both OOB (SafeBreach-published) and custom (user-created) scenarios with 6 filters (name, creator, category, recommended, tag, ready-to-run) and ordering
- Add `get_scenario_details` MCP tool — simplified, unified LLM-readable detail view with normalized step format (strips execution mechanics, normalizes DAG to flat step list)
- OOB scenarios fetched from `/api/content-manager/vLatest/scenarios`, custom plans from `/api/config/v2/accounts/{id}/plans`
- Unified schema: `source_type` field distinguishes OOB/custom, `id` always string, `tags` always list

## Key Design Decisions

- **Dual source**: OOB scenarios + custom plans merged by default; `creator_filter` narrows to one source
- **Simplified details**: `get_scenario_details` explains scenario intent to the LLM (not raw payload for execution). A future "run scenario" tool will handle queue API integration separately
- **Ready-to-run**: All steps must have both `targetFilter` AND `attackerFilter` with non-empty criteria values
- **DAG traversal**: Custom plan steps ordered by walking `actions`/`edges` graph; wait nodes flagged via `has_wait_steps`

## Test plan

- [x] 82 unit tests (types: 37, functions: 45) — all passing
- [x] 13 E2E tests against pentest01 console — all passing
- [x] 667 cross-server unit tests — no regressions
- [x] 70 full E2E suite — all passing (excl. 3 drift `attack_name` tests pending backend deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)