### PR TITLE
SAF-29969: Add manage_test MCP tool for test lifecycle management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,14 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
   **Simulator capabilities**: `get_console_simulators` includes roles (isInfiltration, isExfiltration,
   isAWSAttacker, etc.), assets (resolved names), simulationUsers (impersonated users),
   and isProxySupported for informed filter planning.
+21. `manage_test` ✨ **NEW** - Manage a running test's lifecycle (pause, resume, cancel).
+  Single tool with `action` parameter for all three operations. Accepts `test_id` (planRunId
+  from `run_scenario`), `action` (required: "pause", "resume", or "cancel"), `console`,
+  and optional `reason`. When `reason` is provided, appends a timestamped UTC note to the
+  test's comment field via read-then-append pattern (data API testsummaries endpoint).
+  Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`. Note append is
+  best-effort — failure does not block the lifecycle operation. Response includes
+  `hint_to_agent` with contextual next-step guidance per action.
 
 
 ## Filtering and Search Capabilities

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/context.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/context.md
@@ -1,0 +1,85 @@
+# Ticket Context: SAF-29969
+
+## Status
+Phase 5: Problem Analysis Complete
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: [safebreach-mcp] Add a tool to allow pausing, resuming or cancelling a running test by id
+- **Description**: No description provided
+- **Acceptance Criteria**: None defined
+- **Status**: In Progress
+
+## Task Scope
+Add MCP tools for pausing, resuming, and cancelling SafeBreach test executions (running tests). Investigate the SafeBreach API endpoints available for these operations and determine which server(s) should host the new tools.
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+
+## Investigation Findings
+
+### API Endpoints (All Confirmed)
+
+| Operation | HTTP Method | Endpoint | Body |
+|-----------|-------------|----------|------|
+| Queue test | POST | `/api/orch/v4/accounts/{id}/queue` | Complex plan payload |
+| Pause test | PUT | `/api/orch/v4/accounts/{id}/queue/{test_id}/state` | `{"status":"pause"}` |
+| Resume test | PUT | `/api/orch/v4/accounts/{id}/queue/{test_id}/state` | `{"status":"resume"}` |
+| Cancel test | DELETE | `/api/orch/v4/accounts/{id}/queue/{test_id}` | (none) |
+
+### Pause/Resume Endpoint Details
+- Same endpoint, different body payload: `PUT .../queue/{test_id}/state`
+- Content-Type: application/json
+- Pause and resume share the same URL pattern, differentiated by `{"status": "pause"|"resume"}`
+
+### Cancel Endpoint Details
+- `DELETE /api/orch/v4/accounts/{account_id}/queue/{test_id}`
+- No request body needed
+- Also found as helper in `safebreach_mcp_studio/tests/test_e2e_run_scenario.py:65-73`
+
+### Server Placement: Studio Server
+- `run_scenario` (queue tests) is in Studio Server — lifecycle management belongs here
+- Data Server handles read-only historical queries (different concern)
+- Studio already uses orchestrator endpoint (`/api/orch/v4/`)
+
+### Key Patterns
+- Auth: `get_secret_for_console(console)` → `x-apitoken` header
+- URL: `get_api_base_url(console, 'orchestrator')` + `/api/orch/v4/accounts/{id}/queue/{test_id}`
+- Functions: `studio_functions.py` → `studio_server.py` tool registration
+- Test IDs: dot-notation format (e.g., `1776488350786.15`)
+
+### Files to Modify
+- `safebreach_mcp_studio/studio_functions.py` — add `sb_cancel_test()`, `sb_pause_test()`,
+  `sb_resume_test()`
+- `safebreach_mcp_studio/studio_server.py` — register new MCP tools
+- `safebreach_mcp_studio/tests/test_studio_functions.py` — unit tests
+- `safebreach_mcp_studio/tests/test_e2e_run_scenario.py` — E2E tests (already has cancel helper)
+
+## Problem Analysis
+
+### Problem Scope
+The safebreach-mcp project can queue test executions via `run_scenario` but has no tools
+for managing running tests. Users cannot pause, resume, or cancel a test once queued.
+All three SafeBreach orchestrator API endpoints are now confirmed.
+
+### Affected Areas
+- `safebreach_mcp_studio/studio_functions.py` — new business logic functions
+- `safebreach_mcp_studio/studio_server.py` — new MCP tool registrations
+- `safebreach_mcp_studio/tests/test_studio_functions.py` — unit tests
+- `safebreach_mcp_studio/tests/test_e2e_run_scenario.py` — E2E tests
+
+### Dependencies
+- SafeBreach orchestrator API (`/api/orch/v4/`)
+- Existing auth infrastructure (`get_secret_for_console`, `get_api_base_url`)
+- Test ID from `run_scenario` output (`planRunId`)
+
+### Risks & Edge Cases
+- Race conditions: test may complete before pause/cancel arrives
+- Idempotency: calling cancel on already-completed test
+- Error handling: 404 (not found), 409 (conflict), already paused/resumed states
+- Pause/resume share same endpoint — need validation of `action` parameter
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/context.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29969
 
 ## Status
-Phase 5: Problem Analysis Complete
+Phase 6: PRD Created
 
 ## Mode
 Improving
@@ -80,6 +80,87 @@ All three SafeBreach orchestrator API endpoints are now confirmed.
 - Idempotency: calling cancel on already-completed test
 - Error handling: 404 (not found), 409 (conflict), already paused/resumed states
 - Pause/resume share same endpoint — need validation of `action` parameter
+
+## Design Decisions
+- **Single tool**: `manage_test(test_id, action, console, reason)` with `action` = pause|resume|cancel
+  - Chosen over 3 separate tools for better LLM usability (fewer tools to discover)
+- **Optional `reason`**: Appends timestamped UTC note to test's `comment` field
+  - Read-then-append pattern via data API (non-additive comment API)
+  - Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`
+  - Note failure does not block lifecycle operation
+
+## Notes API (Data Server)
+- Read: `GET /api/data/v1/accounts/{id}/testsummaries/{test_id}` → `comment` field
+- Write: `PUT /api/data/v1/accounts/{id}/testsummaries/{test_id}` with `{"comment": "..."}`
+
+## Deep Investigation Findings (Phase 4)
+
+### Function Signature Convention
+- Return type: `Dict[str, Any]`
+- Console: `console: str = "default"`
+- Optional params: `param: str = None` (studio uses bare None, not Optional wrapper)
+- Function prefix: `sb_` for business logic (e.g., `sb_run_scenario`)
+- Tool functions: no prefix (e.g., `validate_studio_code`)
+
+### Auth Pattern (exact code)
+```python
+apitoken = get_secret_for_console(console)
+base_url = get_api_base_url(console, 'orchestrator')  # or 'data'
+account_id = get_api_account_id(console)
+headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+```
+
+### HTTP Request Pattern
+- Timeout: 120s for POST/PUT, 30s for DELETE and best-effort operations
+- Error: `except requests.exceptions.RequestException as e:` → log + raise
+- Response: `response.raise_for_status()` then `response.json()`
+- API response wrapper: `{"data": {...}}`
+
+### Tool Registration Pattern
+- Return type: always `str` (Markdown formatted)
+- Description: multi-line with Parameters, Returns, Example sections
+- Error handling: try/except ValueError/Exception → return error string
+- Response: Markdown with `## Header`, `**Bold**`, code blocks
+
+### Comment Helper (already exists in E2E)
+`test_e2e_run_scenario.py:76-85` has `_comment_test(test_id, console, comment)`:
+- `PUT /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+- Body: `{"comment": comment}`
+- Service type: `'data'`
+- Timeout: 30s
+- Best-effort: logs warning on failure, doesn't raise
+
+### Cancel Helper (already exists in E2E)
+`test_e2e_run_scenario.py:65-73` has `_cancel_test(test_id, console)`:
+- `DELETE /api/orch/v4/accounts/{account_id}/queue/{test_id}`
+- No Content-Type header needed for DELETE
+- Timeout: 30s
+
+### Test Structure
+- Mock decorators: `@patch('safebreach_mcp_studio.studio_functions.requests.METHOD')`
+- Mock order: `mock_secret`, `mock_base_url`, `mock_account_id`, `mock_http_method`
+- Assertions: return value dict keys, mock call counts, URL verification
+- Categories: success, not_found, api_error, empty_id, none_id
+
+## Brainstorming Results (Phase 5)
+
+### Additional Design: hint_to_agent in response
+- Include `hint_to_agent` in tool response, contextual per action:
+  - pause: "Test is paused. Use manage_test with action='resume' to continue,
+    or action='cancel' to abort. Use get_test_details to check current status."
+  - resume: "Test resumed. Use get_test_details to monitor progress."
+  - cancel: "Test cancelled. Partial results may be available via get_test_details."
+
+### Chosen Approach: B — Split lifecycle + notes helpers
+- `_set_test_state(test_id, action, console)` — orchestrator API (pause/resume/cancel)
+- `_append_test_note(test_id, action, reason, console)` — data API (read-then-append)
+- `sb_manage_test(test_id, action, console, reason)` — thin orchestrator calling both
+- Note separator: newline (`\n`) between existing comment and new note
+- Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`
+
+### Rejected Alternatives
+- A: Monolithic — mixes orchestrator + data API concerns, harder to test
+- C: Per-action functions — over-engineering for 2 URL patterns
 
 ## Proposed Improvements
 (Phase 6)

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -185,8 +185,8 @@ is reusable by future tools that may need to annotate tests.
 - [ ] Note append handles null/empty existing comments
 - [ ] Note append failure does not block lifecycle operation
 - [ ] `hint_to_agent` included in response, contextual per action
-- [ ] Input validation: empty test_id, invalid action values
-- [ ] Error handling: 404, 409, network errors return meaningful messages
+- [x] Input validation: empty test_id, invalid action values
+- [x] Error handling: 404, 409, network errors return meaningful messages
 - [ ] Unit tests: success, not-found, API error, reason/note, edge cases for all actions
 - [ ] E2E tests: cancel test lifecycle (extend test_e2e_run_scenario.py)
 - [x] All existing tests continue to pass
@@ -238,7 +238,7 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 | Phase 1: Cancel test (end-to-end) | ✅ Complete | 2026-04-20 | TBD | 4 unit + 1 E2E test |
 | Phase 2: Pause test | ✅ Complete | 2026-04-20 | TBD | PUT /state with pause body |
 | Phase 3: Resume test | ✅ Complete | 2026-04-20 | TBD | Same PUT, resume body |
-| Phase 4: Input validation | ⏳ Pending | - | - | Guard rails (unit tests only) |
+| Phase 4: Input validation | ✅ Complete | 2026-04-20 | TBD | test_id + action validation |
 | Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append + extends E2E |
 | Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort (unit tests only) |
 | Phase 7: hint_to_agent + Documentation | ⏳ Pending | - | - | LLM guidance + CLAUDE.md |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -24,7 +24,7 @@
 | **PRD Status** | In Progress |
 | **Last Updated** | 2026-04-20 13:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | Phase 1 of 7 |
+| **Current Phase** | Phase 3 of 7 |
 
 ---
 
@@ -236,8 +236,8 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
 | Phase 1: Cancel test (end-to-end) | ✅ Complete | 2026-04-20 | TBD | 4 unit + 1 E2E test |
-| Phase 2: Pause test | ⏳ Pending | - | - | Adds PUT + extends E2E |
-| Phase 3: Resume test | ⏳ Pending | - | - | Same endpoint + extends E2E |
+| Phase 2: Pause test | ✅ Complete | 2026-04-20 | TBD | PUT /state with pause body |
+| Phase 3: Resume test | ✅ Complete | 2026-04-20 | TBD | Same PUT, resume body |
 | Phase 4: Input validation | ⏳ Pending | - | - | Guard rails (unit tests only) |
 | Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append + extends E2E |
 | Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort (unit tests only) |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -21,10 +21,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | In Progress |
-| **Last Updated** | 2026-04-20 13:00 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-04-20 14:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | Phase 3 of 7 |
+| **Current Phase** | Complete |
 
 ---
 
@@ -177,18 +177,18 @@ is reusable by future tools that may need to annotate tests.
 
 ## 7. Definition of Done
 
-- [ ] `sb_manage_test` function implemented in `studio_functions.py` with `_set_test_state`
+- [x] `sb_manage_test` function implemented in `studio_functions.py` with `_set_test_state`
   and `_append_test_note` helpers
-- [ ] `manage_test` MCP tool registered in `studio_server.py` with full description
-- [ ] All three actions work: pause, resume, cancel
+- [x] `manage_test` MCP tool registered in `studio_server.py` with full description
+- [x] All three actions work: pause, resume, cancel
 - [x] Optional `reason` appends timestamped UTC note to test comment field
 - [x] Note append handles null/empty existing comments
 - [x] Note append failure does not block lifecycle operation
-- [ ] `hint_to_agent` included in response, contextual per action
+- [x] `hint_to_agent` included in response, contextual per action
 - [x] Input validation: empty test_id, invalid action values
 - [x] Error handling: 404, 409, network errors return meaningful messages
-- [ ] Unit tests: success, not-found, API error, reason/note, edge cases for all actions
-- [ ] E2E tests: cancel test lifecycle (extend test_e2e_run_scenario.py)
+- [x] Unit tests: success, not-found, API error, reason/note, edge cases for all actions
+- [x] E2E tests: cancel test lifecycle (test_e2e_manage_test.py)
 - [x] All existing tests continue to pass
 
 ---
@@ -241,7 +241,7 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 | Phase 4: Input validation | ✅ Complete | 2026-04-20 | TBD | test_id + action validation |
 | Phase 5: Reason notes | ✅ Complete | 2026-04-20 | TBD | _append_test_note + integration |
 | Phase 6: Note resilience | ✅ Complete | 2026-04-20 | TBD | Best-effort error handling |
-| Phase 7: hint_to_agent + Documentation | ⏳ Pending | - | - | LLM guidance + CLAUDE.md |
+| Phase 7: hint_to_agent + Documentation | ✅ Complete | 2026-04-20 | TBD | hint_to_agent + CLAUDE.md |
 
 ---
 

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -22,7 +22,7 @@
 | Field | Value |
 |-------|-------|
 | **PRD Status** | Complete |
-| **Last Updated** | 2026-04-20 14:00 |
+| **Last Updated** | 2026-04-20 15:30 |
 | **Owner** | Yossi Attas |
 | **Current Phase** | Complete |
 
@@ -595,14 +595,20 @@ note warning when `note_status="failed"`.
 - **Issue/Feature Description**: Add an MCP tool to manage running SafeBreach test lifecycles
   (pause, resume, cancel) with optional audit notes.
 - **What Was Built**: Single `manage_test` tool in Studio Server with three actions, optional
-  reason parameter that creates timestamped audit trail in test notes.
+  reason parameter that creates timestamped audit trail in test notes. Also fixed
+  `get_api_base_url` to properly support `content-manager` endpoint with hyphen-to-underscore
+  env var normalization.
 - **Key Technical Decisions**: Single tool over three separate tools (LLM usability);
   split architecture with lifecycle + notes helpers (testability);
   best-effort note append (resilience).
 - **Scope Changes**: Added `reason` parameter and notes API integration beyond original
-  ticket scope (which only mentioned pause/resume/cancel).
+  ticket scope (which only mentioned pause/resume/cancel). Fixed `get_api_base_url`
+  content-manager support discovered during E2E testing.
 - **Business Value Delivered**: Completes the test execution lifecycle in MCP — agents
   can now fully manage tests from queue to completion/cancellation with audit trail.
+- **Test Coverage**: 19 unit tests + 3 E2E tests (all with reason/note verification).
+  All E2E tests verified against real SafeBreach console (pentest01). 816 cross-server
+  tests passing with zero regressions.
 
 ---
 
@@ -614,3 +620,11 @@ note warning when `note_status="failed"`.
 | 2026-04-20 12:15 | Restructured to elephant carpaccio + pure TDD — 7 vertical slices |
 | 2026-04-20 12:20 | E2E tests integrated into phases 1-3 and 5 instead of standalone phase |
 | 2026-04-20 13:00 | Phase 1 complete — cancel test end-to-end (4 unit + 1 E2E, 315 tests pass) |
+| 2026-04-20 13:15 | Phases 2+3 complete — pause/resume support (6 unit + 3 E2E, 317 tests pass) |
+| 2026-04-20 13:25 | Phase 4 complete — input validation (10 unit tests) |
+| 2026-04-20 13:40 | Phases 5+6 complete — reason/notes + resilience (18 unit tests) |
+| 2026-04-20 13:55 | Phase 7 complete — hint_to_agent + CLAUDE.md docs (21 unit tests) |
+| 2026-04-20 14:30 | E2E tests verified against real console (pentest01), all 3 pass |
+| 2026-04-20 15:00 | E2E extended with reason/note read-back, shallow wrapper tests removed |
+| 2026-04-20 15:15 | Fixed get_api_base_url content-manager support (hyphen normalization) |
+| 2026-04-20 15:30 | PRD finalized — all phases complete, all DoD checked, E2E + manual verified |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -181,9 +181,9 @@ is reusable by future tools that may need to annotate tests.
   and `_append_test_note` helpers
 - [ ] `manage_test` MCP tool registered in `studio_server.py` with full description
 - [ ] All three actions work: pause, resume, cancel
-- [ ] Optional `reason` appends timestamped UTC note to test comment field
-- [ ] Note append handles null/empty existing comments
-- [ ] Note append failure does not block lifecycle operation
+- [x] Optional `reason` appends timestamped UTC note to test comment field
+- [x] Note append handles null/empty existing comments
+- [x] Note append failure does not block lifecycle operation
 - [ ] `hint_to_agent` included in response, contextual per action
 - [x] Input validation: empty test_id, invalid action values
 - [x] Error handling: 404, 409, network errors return meaningful messages
@@ -239,8 +239,8 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 | Phase 2: Pause test | ✅ Complete | 2026-04-20 | TBD | PUT /state with pause body |
 | Phase 3: Resume test | ✅ Complete | 2026-04-20 | TBD | Same PUT, resume body |
 | Phase 4: Input validation | ✅ Complete | 2026-04-20 | TBD | test_id + action validation |
-| Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append + extends E2E |
-| Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort (unit tests only) |
+| Phase 5: Reason notes | ✅ Complete | 2026-04-20 | TBD | _append_test_note + integration |
+| Phase 6: Note resilience | ✅ Complete | 2026-04-20 | TBD | Best-effort error handling |
 | Phase 7: hint_to_agent + Documentation | ⏳ Pending | - | - | LLM guidance + CLAUDE.md |
 
 ---

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -216,9 +216,12 @@ Every slice follows the same cycle:
 
 ### E2E Testing
 
-- **Scope**: Cancel a test that was queued via `run_scenario`
+- **Approach**: E2E test is created in Phase 1 and extended with each subsequent phase
 - **Markers**: `@pytest.mark.e2e`, `@skip_e2e`
 - **Environment**: Requires real SafeBreach console (E2E_CONSOLE env var)
+- **File**: `test_e2e_manage_test.py` (new, dedicated file)
+- **Growth**: Phase 1 creates the E2E skeleton (cancel), later phases extend it
+  (pause, resume, reason/notes)
 
 ---
 
@@ -232,14 +235,13 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: Cancel test (end-to-end) | ⏳ Pending | - | - | Thinnest slice: simplest action |
-| Phase 2: Pause test | ⏳ Pending | - | - | Adds PUT with body |
-| Phase 3: Resume test | ⏳ Pending | - | - | Same endpoint, different body |
-| Phase 4: Input validation | ⏳ Pending | - | - | Guard rails |
-| Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append feature |
-| Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort, failure isolation |
-| Phase 7: hint_to_agent | ⏳ Pending | - | - | LLM guidance per action |
-| Phase 8: E2E + Documentation | ⏳ Pending | - | - | Real environment verification |
+| Phase 1: Cancel test (end-to-end) | ⏳ Pending | - | - | Thinnest slice + E2E skeleton |
+| Phase 2: Pause test | ⏳ Pending | - | - | Adds PUT + extends E2E |
+| Phase 3: Resume test | ⏳ Pending | - | - | Same endpoint + extends E2E |
+| Phase 4: Input validation | ⏳ Pending | - | - | Guard rails (unit tests only) |
+| Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append + extends E2E |
+| Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort (unit tests only) |
+| Phase 7: hint_to_agent + Documentation | ⏳ Pending | - | - | LLM guidance + CLAUDE.md |
 
 ---
 
@@ -253,6 +255,8 @@ HTTP pattern. After this phase, an agent can cancel a test end-to-end.
 **TDD Cycle**:
 
 **Red — Write failing tests:**
+
+*Unit tests (`test_studio_functions.py`):*
 1. In `test_studio_functions.py`, create `TestManageTest` class
 2. `test_cancel_success`: mock auth + mock DELETE returning 200 →
    call `sb_manage_test(test_id="1776488350786.15", action="cancel", console="test")` →
@@ -265,6 +269,13 @@ HTTP pattern. After this phase, an agent can cancel a test end-to-end.
 4. `test_cancel_tool_success`: call the tool function `manage_test(...)` directly →
    assert returns Markdown string containing `## Test Cancel` and test_id
 5. `test_cancel_tool_error`: mock to raise → assert returns error string (no exception)
+
+*E2E test (`test_e2e_manage_test.py` — new file):*
+6. Create `test_e2e_manage_test.py` with `@pytest.mark.e2e`, `@skip_e2e` decorators
+7. `test_e2e_cancel_test`: queue a small test via `sb_run_scenario`, extract `test_id`,
+   call `sb_manage_test(test_id, action="cancel", console=E2E_CONSOLE)`,
+   assert result has `status="success"` and `action="cancel"`,
+   use try/finally to ensure test is cancelled even on assertion failure
 
 **Green — Implement minimum code:**
 1. In `studio_functions.py`:
@@ -289,6 +300,7 @@ HTTP pattern. After this phase, an agent can cancel a test end-to-end.
 | File | Change |
 |------|--------|
 | `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `TestManageTest` with cancel tests |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | Create E2E skeleton with cancel test |
 | `safebreach_mcp_studio/studio_functions.py` | Add `_set_test_state` (cancel), `sb_manage_test` |
 | `safebreach_mcp_studio/studio_server.py` | Register `manage_test` tool |
 
@@ -305,11 +317,17 @@ Adds PUT with JSON body — slightly more complex than DELETE.
 **TDD Cycle**:
 
 **Red — Write failing tests:**
+
+*Unit tests:*
 1. `test_pause_success`: mock auth + mock PUT returning 200 →
    call `sb_manage_test(test_id="...", action="pause")` →
    assert returns dict with `action="pause"`, `status="success"` →
    assert PUT called with URL `.../queue/{test_id}/state`,
    JSON body `{"status": "pause"}`, Content-Type header, timeout 120s
+
+*E2E test (extend `test_e2e_manage_test.py`):*
+2. `test_e2e_pause_test`: queue a test, call `sb_manage_test(test_id, action="pause")`,
+   assert result has `status="success"`, cancel test in cleanup
 
 **Green — Extend `_set_test_state`:**
 1. Add pause branch: if action is "pause":
@@ -323,6 +341,7 @@ Adds PUT with JSON body — slightly more complex than DELETE.
 | File | Change |
 |------|--------|
 | `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `test_pause_success` |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | Add `test_e2e_pause_test` |
 | `safebreach_mcp_studio/studio_functions.py` | Extend `_set_test_state` for pause |
 
 **Git Commit**: `feat(studio): add pause support to manage_test [TDD]`
@@ -338,10 +357,17 @@ Same endpoint as pause, different body — trivial extension.
 **TDD Cycle**:
 
 **Red — Write failing tests:**
+
+*Unit tests:*
 1. `test_resume_success`: mock auth + mock PUT returning 200 →
    call `sb_manage_test(test_id="...", action="resume")` →
    assert returns dict with `action="resume"`, `status="success"` →
    assert PUT called with JSON body `{"status": "resume"}`
+
+*E2E test (extend `test_e2e_manage_test.py`):*
+2. `test_e2e_pause_and_resume_test`: queue a test, pause it, then resume it,
+   assert both operations return `status="success"`, cancel test in cleanup.
+   This is the full pause→resume lifecycle in a single E2E test.
 
 **Green — Extend `_set_test_state`:**
 1. Resume uses the same code path as pause — the action value is already passed as
@@ -355,6 +381,7 @@ Same endpoint as pause, different body — trivial extension.
 | File | Change |
 |------|--------|
 | `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `test_resume_success` |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | Add `test_e2e_pause_and_resume_test` |
 | `safebreach_mcp_studio/studio_functions.py` | May need no change if pause used generic `action` |
 
 **Git Commit**: `feat(studio): add resume support to manage_test [TDD]`
@@ -419,6 +446,11 @@ test's comment field.
    call `sb_manage_test(test_id, "cancel")` →
    assert `_append_test_note` is NOT called, result has no `note_status`
 
+*E2E test (extend `test_e2e_manage_test.py`):*
+6. `test_e2e_cancel_with_reason`: queue a test, cancel with
+   `reason="E2E automated cleanup"`, assert `note_status="success"`,
+   optionally GET the test summary and verify `comment` field contains the note text
+
 **Green — Implement `_append_test_note` + wire into `sb_manage_test`:**
 1. Add `_append_test_note(test_id, action, reason, console)`:
    - Auth via `get_api_base_url(console, 'data')`
@@ -438,6 +470,7 @@ test's comment field.
 | File | Change |
 |------|--------|
 | `safebreach_mcp_studio/tests/test_studio_functions.py` | Add note tests |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | Add `test_e2e_cancel_with_reason` |
 | `safebreach_mcp_studio/studio_functions.py` | Add `_append_test_note`, wire into `sb_manage_test` |
 
 **Git Commit**: `feat(studio): add reason/notes support to manage_test [TDD]`
@@ -483,9 +516,9 @@ note warning when `note_status="failed"`.
 
 ---
 
-### Phase 7: hint_to_agent
+### Phase 7: hint_to_agent + Documentation
 
-**Semantic Change**: Add contextual LLM guidance per action in the response.
+**Semantic Change**: Add contextual LLM guidance per action and update project documentation.
 
 **TDD Cycle**:
 
@@ -507,6 +540,13 @@ note warning when `note_status="failed"`.
 
 **Refactor**: Update tool Markdown output to include hint. All tests green.
 
+**Documentation:**
+1. Add `manage_test` entry to the Studio Server tools section in CLAUDE.md
+2. Include: tool name, parameters, description, supported actions, reason/note behavior,
+   hint_to_agent behavior
+3. Follow existing `run_scenario` documentation format
+4. Update MCP Tools Available count
+
 **Changes**:
 
 | File | Change |
@@ -514,42 +554,9 @@ note warning when `note_status="failed"`.
 | `safebreach_mcp_studio/tests/test_studio_functions.py` | Add hint tests |
 | `safebreach_mcp_studio/studio_functions.py` | Add `hint_to_agent` to result |
 | `safebreach_mcp_studio/studio_server.py` | Include hint in Markdown output |
-
-**Git Commit**: `feat(studio): add hint_to_agent to manage_test responses [TDD]`
-
----
-
-### Phase 8: E2E Tests + Documentation
-
-**Semantic Change**: Verify in real environment and make the tool discoverable.
-
-**Deliverables**:
-- E2E test for cancel lifecycle with reason
-- CLAUDE.md updated with manage_test documentation
-
-**Implementation Details**:
-
-1. **E2E test** in `test_e2e_run_scenario.py` (or new `test_e2e_manage_test.py`):
-   - Decorators: `@pytest.mark.e2e`, `@skip_e2e`
-   - Queue a small test via `sb_run_scenario`, extract `test_id`
-   - Call `sb_manage_test(test_id, action="cancel", console=E2E_CONSOLE,
-     reason="E2E test cleanup")`
-   - Assert result has `status="success"`, `action="cancel"`, `note_status="success"`
-   - Cleanup: try/finally to ensure test is cancelled even on assertion failure
-2. **CLAUDE.md**: Add `manage_test` entry to Studio Server tools section
-   - Tool name, parameters, description, supported actions, reason/note behavior,
-     hint_to_agent behavior
-   - Follow existing `run_scenario` documentation format
-   - Update MCP Tools Available count
-
-**Changes**:
-
-| File | Change |
-|------|--------|
-| `safebreach_mcp_studio/tests/test_e2e_run_scenario.py` | Add E2E cancel test with reason |
 | `CLAUDE.md` | Add `manage_test` tool to Studio Server section |
 
-**Git Commit**: `test(studio): add E2E test and docs for manage_test`
+**Git Commit**: `feat(studio): add hint_to_agent and docs for manage_test [TDD]`
 
 ---
 
@@ -604,4 +611,5 @@ note warning when `note_status="failed"`.
 | Date | Change Description |
 |------|-------------------|
 | 2026-04-20 12:00 | PRD created — initial draft |
-| 2026-04-20 12:15 | Restructured to elephant carpaccio + pure TDD — 8 vertical slices |
+| 2026-04-20 12:15 | Restructured to elephant carpaccio + pure TDD — 7 vertical slices |
+| 2026-04-20 12:20 | E2E tests integrated into phases 1-3 and 5 instead of standalone phase |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -1,0 +1,607 @@
+# Test Lifecycle Management Tool — SAF-29969
+
+## 1. Overview
+
+- **Task Type**: Feature
+- **Purpose**: Enable AI agents to manage running SafeBreach test executions by pausing,
+  resuming, or cancelling them via a single MCP tool, with optional audit trail.
+- **Target Consumer**: AI agents (LLMs) interacting with SafeBreach via MCP protocol
+- **Key Benefits**:
+  - Agents gain full test lifecycle control (queue + manage)
+  - Optional `reason` parameter creates an audit trail in the test's notes
+  - Single tool design reduces LLM tool discovery overhead
+- **Business Alignment**: Completes the test execution lifecycle in the MCP layer — agents
+  can now queue tests (`run_scenario`) AND manage them (`manage_test`)
+- **Originating Request**: [SAF-29969](https://safebreach.atlassian.net/browse/SAF-29969),
+  linked to parent story SAF-29859 (MCP basic actions, part 1)
+
+---
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-04-20 12:00 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution
+
+A single `manage_test` MCP tool with an `action` parameter (`pause`, `resume`, `cancel`) and an
+optional `reason` parameter. Internally split into two helpers:
+
+- `_set_test_state(test_id, action, console)` — calls the orchestrator API to change test state
+- `_append_test_note(test_id, action, reason, console)` — calls the data API to append a
+  timestamped note to the test's `comment` field
+
+The public function `sb_manage_test` orchestrates both: it performs the lifecycle action first,
+then appends the note if `reason` is provided. Note append is best-effort — failure does not
+block the lifecycle operation.
+
+### Alternatives Considered
+
+| Approach | Description | Pros | Cons |
+|----------|-------------|------|------|
+| A: Monolithic | Single function handles lifecycle + notes | Simplest code | Mixes API domains, harder to test independently |
+| B: Split helpers | Separate lifecycle and notes functions (chosen) | Clean SRP, independently testable, reusable note helper | More functions |
+| C: Per-action functions | Private function per action + orchestrator | Explicit per action | Over-engineering for 2 URL patterns |
+
+### Decision Rationale
+
+Approach B was chosen because it cleanly separates the two API domains (orchestrator for
+lifecycle, data for notes), making each independently testable. The `_append_test_note` helper
+is reusable by future tools that may need to annotate tests.
+
+---
+
+## 3. Core Feature Components
+
+### Component A: Test Lifecycle State Manager (`_set_test_state`)
+
+- **Purpose**: New private helper in `studio_functions.py` that calls the SafeBreach
+  orchestrator API to change a running test's state.
+- **Key Features**:
+  - Validates `action` against allowed values: `pause`, `resume`, `cancel`
+  - Routes to correct HTTP method: PUT for pause/resume, DELETE for cancel
+  - Pause/resume: `PUT /api/orch/v4/accounts/{id}/queue/{test_id}/state`
+    with body `{"status": "pause"|"resume"}`
+  - Cancel: `DELETE /api/orch/v4/accounts/{id}/queue/{test_id}` (no body)
+  - Uses existing auth pattern: `get_secret_for_console`, `get_api_base_url('orchestrator')`,
+    `get_api_account_id`
+  - Returns dict with `test_id`, `action`, `status` (success indicator)
+
+### Component B: Test Note Appender (`_append_test_note`)
+
+- **Purpose**: New private helper in `studio_functions.py` that appends a timestamped
+  note to a test's `comment` field via the data API.
+- **Key Features**:
+  - Reads existing comment: `GET /api/data/v1/accounts/{id}/testsummaries/{test_id}`
+  - Formats new note: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`
+  - Concatenates: existing comment + `\n` + new note (handles null/empty existing)
+  - Writes back: `PUT /api/data/v1/accounts/{id}/testsummaries/{test_id}`
+    with `{"comment": "concatenated_text"}`
+  - Best-effort: logs warning on failure, returns status dict, does not raise
+
+### Component C: Public Orchestrator (`sb_manage_test`)
+
+- **Purpose**: New public function in `studio_functions.py` that orchestrates lifecycle +
+  optional note append.
+- **Key Features**:
+  - Parameters: `test_id: str`, `action: str`, `console: str = "default"`,
+    `reason: str = None`
+  - Validates inputs (non-empty test_id, valid action)
+  - Calls `_set_test_state` for the lifecycle operation
+  - If `reason` is provided, calls `_append_test_note` (best-effort)
+  - Returns combined result dict with lifecycle status + note status + `hint_to_agent`
+  - `hint_to_agent` is contextual per action:
+    - pause: suggests resume or cancel, and checking status via `get_test_details`
+    - resume: suggests monitoring via `get_test_details`
+    - cancel: notes partial results may be available via `get_test_details`
+
+### Component D: MCP Tool Registration (`manage_test`)
+
+- **Purpose**: New tool registration in `studio_server.py` that exposes `sb_manage_test`
+  as an MCP tool.
+- **Key Features**:
+  - Tool name: `manage_test`
+  - Description: multi-line with Parameters, Returns, Example sections
+  - Return type: `str` (Markdown formatted)
+  - Calls `sb_manage_test()` and formats result as Markdown
+  - Error handling: try/except ValueError/Exception returning error strings
+  - Includes `hint_to_agent` in the Markdown response
+
+---
+
+## 4. API Endpoints and Integration
+
+### Existing APIs to Consume
+
+**1. Pause/Resume Test State**
+- **URL**: `PUT /api/orch/v4/accounts/{account_id}/queue/{test_id}/state`
+- **Headers**: `x-apitoken: {token}`, `Content-Type: application/json`
+- **Request Payload**:
+  ```json
+  {"status": "pause"}
+  ```
+  or
+  ```json
+  {"status": "resume"}
+  ```
+- **Auth**: `get_api_base_url(console, 'orchestrator')`
+
+**2. Cancel Test**
+- **URL**: `DELETE /api/orch/v4/accounts/{account_id}/queue/{test_id}`
+- **Headers**: `x-apitoken: {token}`
+- **No request body**
+- **Auth**: `get_api_base_url(console, 'orchestrator')`
+
+**3. Read Test Summary (for existing comment)**
+- **URL**: `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+- **Headers**: `x-apitoken: {token}`, `Content-Type: application/json`
+- **Response**: JSON object with `comment` field (may be null or string)
+- **Auth**: `get_api_base_url(console, 'data')`
+
+**4. Update Test Summary (to write comment)**
+- **URL**: `PUT /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+- **Headers**: `x-apitoken: {token}`, `Content-Type: application/json`
+- **Request Payload**:
+  ```json
+  {"comment": "existing comment\n[2026-04-20 14:30:00 UTC] Test paused: reason text"}
+  ```
+- **Auth**: `get_api_base_url(console, 'data')`
+
+---
+
+## 6. Non-Functional Requirements
+
+### Security & Compliance
+
+- **Secrets Management**: Uses existing `get_secret_for_console(console)` — no new secret
+  storage needed
+- **Authentication**: `x-apitoken` header pattern, consistent with all existing Studio tools
+- **RBAC**: Inherits SafeBreach API-level RBAC — the API token's permissions determine
+  whether pause/resume/cancel is allowed
+
+### Technical Constraints
+
+- **Integration**: Studio Server (port 8004), alongside `run_scenario`
+- **Backward Compatibility**: New tool only, no changes to existing tools
+- **Test IDs**: Dot-notation format (e.g., `1776488350786.15`) — must be passed as strings
+
+---
+
+## 7. Definition of Done
+
+- [ ] `sb_manage_test` function implemented in `studio_functions.py` with `_set_test_state`
+  and `_append_test_note` helpers
+- [ ] `manage_test` MCP tool registered in `studio_server.py` with full description
+- [ ] All three actions work: pause, resume, cancel
+- [ ] Optional `reason` appends timestamped UTC note to test comment field
+- [ ] Note append handles null/empty existing comments
+- [ ] Note append failure does not block lifecycle operation
+- [ ] `hint_to_agent` included in response, contextual per action
+- [ ] Input validation: empty test_id, invalid action values
+- [ ] Error handling: 404, 409, network errors return meaningful messages
+- [ ] Unit tests: success, not-found, API error, reason/note, edge cases for all actions
+- [ ] E2E tests: cancel test lifecycle (extend test_e2e_run_scenario.py)
+- [ ] All existing tests continue to pass
+
+---
+
+## 8. Testing Strategy
+
+**Methodology: Pure TDD (Red-Green-Refactor)**
+
+Every slice follows the same cycle:
+1. **Red** — Write failing tests that define the expected behavior
+2. **Green** — Write the minimum code to make tests pass
+3. **Refactor** — Clean up while keeping tests green
+4. **Commit** — One commit per slice (test + implementation together)
+
+### Unit Testing
+
+- **Framework**: pytest with unittest.mock
+- **Mock Pattern**:
+  - `@patch('safebreach_mcp_studio.studio_functions.requests.put')`
+  - `@patch('safebreach_mcp_studio.studio_functions.requests.delete')`
+  - `@patch('safebreach_mcp_studio.studio_functions.requests.get')`
+  - Auth mocks: `mock_secret`, `mock_base_url`, `mock_account_id`
+- **Coverage Target**: Maintain existing coverage baseline
+- Tests are written FIRST in every phase — no production code without a failing test
+
+### E2E Testing
+
+- **Scope**: Cancel a test that was queued via `run_scenario`
+- **Markers**: `@pytest.mark.e2e`, `@skip_e2e`
+- **Environment**: Requires real SafeBreach console (E2E_CONSOLE env var)
+
+---
+
+## 9. Implementation Phases
+
+**Strategy: Elephant Carpaccio + Pure TDD**
+
+Each phase is the thinnest possible vertical slice delivering end-to-end value.
+Every phase follows Red-Green-Refactor: write failing tests first, then implement
+the minimum code to pass. Each phase produces a working, tested, committable increment.
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Cancel test (end-to-end) | ⏳ Pending | - | - | Thinnest slice: simplest action |
+| Phase 2: Pause test | ⏳ Pending | - | - | Adds PUT with body |
+| Phase 3: Resume test | ⏳ Pending | - | - | Same endpoint, different body |
+| Phase 4: Input validation | ⏳ Pending | - | - | Guard rails |
+| Phase 5: Reason notes | ⏳ Pending | - | - | Read-then-append feature |
+| Phase 6: Note resilience | ⏳ Pending | - | - | Best-effort, failure isolation |
+| Phase 7: hint_to_agent | ⏳ Pending | - | - | LLM guidance per action |
+| Phase 8: E2E + Documentation | ⏳ Pending | - | - | Real environment verification |
+
+---
+
+### Phase 1: Cancel Test (End-to-End Vertical Slice)
+
+**Semantic Change**: Deliver a working `manage_test` tool that can cancel a running test.
+
+This is the thinnest slice because cancel uses DELETE with no body — the simplest
+HTTP pattern. After this phase, an agent can cancel a test end-to-end.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. In `test_studio_functions.py`, create `TestManageTest` class
+2. `test_cancel_success`: mock auth + mock DELETE returning 200 →
+   call `sb_manage_test(test_id="1776488350786.15", action="cancel", console="test")` →
+   assert returns dict with `test_id`, `action="cancel"`, `status="success"` →
+   assert DELETE called once with URL
+   `https://test.safebreach.com/api/orch/v4/accounts/1234567890/queue/1776488350786.15`,
+   header `x-apitoken`, timeout 30
+3. `test_cancel_api_error`: mock DELETE raising `requests.exceptions.RequestException` →
+   assert `sb_manage_test` propagates the exception
+4. `test_cancel_tool_success`: call the tool function `manage_test(...)` directly →
+   assert returns Markdown string containing `## Test Cancel` and test_id
+5. `test_cancel_tool_error`: mock to raise → assert returns error string (no exception)
+
+**Green — Implement minimum code:**
+1. In `studio_functions.py`:
+   - Add `_set_test_state(test_id, action, console)` — initially handles cancel only
+     - Auth: `get_secret_for_console`, `get_api_base_url(console, 'orchestrator')`,
+       `get_api_account_id`
+     - URL: `{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}`
+     - DELETE request with `{"x-apitoken": apitoken}` header, timeout 30s
+     - `response.raise_for_status()`, log info/error
+     - Return `{"test_id": test_id, "action": action, "status": "success"}`
+   - Add `sb_manage_test(test_id, action, console, reason)` — thin wrapper that
+     calls `_set_test_state`, returns its result
+2. In `studio_server.py`:
+   - Register `manage_test` tool with `@self.mcp.tool()` decorator
+   - Tool calls `sb_manage_test()`, formats result as Markdown
+   - try/except ValueError/Exception returning error strings
+
+**Refactor**: Verify all tests green, clean up.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `TestManageTest` with cancel tests |
+| `safebreach_mcp_studio/studio_functions.py` | Add `_set_test_state` (cancel), `sb_manage_test` |
+| `safebreach_mcp_studio/studio_server.py` | Register `manage_test` tool |
+
+**Git Commit**: `feat(studio): add manage_test tool with cancel support [TDD]`
+
+---
+
+### Phase 2: Pause Test
+
+**Semantic Change**: Extend `manage_test` to support pausing a running test.
+
+Adds PUT with JSON body — slightly more complex than DELETE.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_pause_success`: mock auth + mock PUT returning 200 →
+   call `sb_manage_test(test_id="...", action="pause")` →
+   assert returns dict with `action="pause"`, `status="success"` →
+   assert PUT called with URL `.../queue/{test_id}/state`,
+   JSON body `{"status": "pause"}`, Content-Type header, timeout 120s
+
+**Green — Extend `_set_test_state`:**
+1. Add pause branch: if action is "pause":
+   - URL: `{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}/state`
+   - PUT with `json={"status": "pause"}`, headers with Content-Type, timeout 120s
+
+**Refactor**: All tests green including Phase 1 cancel tests.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `test_pause_success` |
+| `safebreach_mcp_studio/studio_functions.py` | Extend `_set_test_state` for pause |
+
+**Git Commit**: `feat(studio): add pause support to manage_test [TDD]`
+
+---
+
+### Phase 3: Resume Test
+
+**Semantic Change**: Extend `manage_test` to support resuming a paused test.
+
+Same endpoint as pause, different body — trivial extension.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_resume_success`: mock auth + mock PUT returning 200 →
+   call `sb_manage_test(test_id="...", action="resume")` →
+   assert returns dict with `action="resume"`, `status="success"` →
+   assert PUT called with JSON body `{"status": "resume"}`
+
+**Green — Extend `_set_test_state`:**
+1. Resume uses the same code path as pause — the action value is already passed as
+   the `"status"` field in the PUT body. If pause was implemented with `{"status": action}`,
+   resume works with zero code changes (just the test proves it).
+
+**Refactor**: Verify all previous tests still green.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add `test_resume_success` |
+| `safebreach_mcp_studio/studio_functions.py` | May need no change if pause used generic `action` |
+
+**Git Commit**: `feat(studio): add resume support to manage_test [TDD]`
+
+---
+
+### Phase 4: Input Validation
+
+**Semantic Change**: Add guard rails for invalid inputs.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_invalid_action`: call `sb_manage_test(test_id="...", action="stop")` →
+   assert raises `ValueError` with message containing valid actions
+2. `test_empty_test_id`: call `sb_manage_test(test_id="", action="cancel")` →
+   assert raises `ValueError("test_id is required")`
+3. `test_none_test_id`: call `sb_manage_test(test_id=None, action="cancel")` →
+   assert raises `ValueError`
+4. `test_not_found_404`: mock DELETE returning 404 with `raise_for_status` raising
+   HTTPError → assert exception propagates with meaningful context
+
+**Green — Add validation to `sb_manage_test`:**
+1. Check test_id is non-empty/non-None, raise ValueError if not
+2. Check action is in `["pause", "resume", "cancel"]`, raise ValueError with valid values
+3. HTTP errors already propagate from `_set_test_state` — just verify they do
+
+**Refactor**: All tests green.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add validation tests |
+| `safebreach_mcp_studio/studio_functions.py` | Add input validation to `sb_manage_test` |
+
+**Git Commit**: `feat(studio): add input validation to manage_test [TDD]`
+
+---
+
+### Phase 5: Reason Notes
+
+**Semantic Change**: Add optional `reason` parameter that appends a timestamped note to the
+test's comment field.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_append_to_existing_comment`: mock GET returning `{"comment": "existing note"}` +
+   mock PUT returning 200 →
+   call `_append_test_note(test_id, "pause", "maintenance window", console)` →
+   assert PUT called with body containing
+   `"existing note\n[YYYY-MM-DD HH:MM:SS UTC] Test pause: maintenance window"`
+2. `test_append_to_null_comment`: mock GET returning `{"comment": null}` →
+   assert PUT called with just the new note (no leading newline)
+3. `test_append_to_empty_comment`: mock GET returning `{"comment": ""}` →
+   assert PUT called with just the new note
+4. `test_manage_test_with_reason`: mock lifecycle + mock note helpers →
+   call `sb_manage_test(test_id, "cancel", reason="no longer needed")` →
+   assert result contains `note_status="success"` and `note` text
+5. `test_manage_test_without_reason`: mock lifecycle →
+   call `sb_manage_test(test_id, "cancel")` →
+   assert `_append_test_note` is NOT called, result has no `note_status`
+
+**Green — Implement `_append_test_note` + wire into `sb_manage_test`:**
+1. Add `_append_test_note(test_id, action, reason, console)`:
+   - Auth via `get_api_base_url(console, 'data')`
+   - URL: `{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+   - GET existing comment (extract `comment` field, handle null/empty)
+   - Format note: `[{utc_timestamp} UTC] Test {action}: {reason}`
+   - Concatenate: `existing + "\n" + new_note` (or just `new_note` if empty)
+   - PUT with `{"comment": concatenated}`
+   - Return `{"note_status": "success", "note": new_note}`
+2. In `sb_manage_test`: if reason is provided and non-empty, call `_append_test_note`
+   and merge result
+
+**Refactor**: All tests green.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add note tests |
+| `safebreach_mcp_studio/studio_functions.py` | Add `_append_test_note`, wire into `sb_manage_test` |
+
+**Git Commit**: `feat(studio): add reason/notes support to manage_test [TDD]`
+
+---
+
+### Phase 6: Note Resilience
+
+**Semantic Change**: Ensure note append failure does not block the lifecycle operation.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_note_get_failure`: mock GET raising exception →
+   call `_append_test_note(...)` →
+   assert returns `{"note_status": "failed", "note_error": "..."}`, does NOT raise
+2. `test_note_put_failure`: mock GET succeeds, mock PUT raises exception →
+   assert returns failure status, does NOT raise
+3. `test_manage_test_note_failure_doesnt_block`: mock lifecycle succeeds,
+   mock `_append_test_note` returning `{"note_status": "failed"}` →
+   call `sb_manage_test(test_id, "pause", reason="test")` →
+   assert result has `status="success"` (lifecycle succeeded) AND
+   `note_status="failed"` (note failed but didn't block)
+
+**Green — Add error handling to `_append_test_note`:**
+1. Wrap entire `_append_test_note` body in try/except Exception
+2. On any exception: log warning, return `{"note_status": "failed", "note_error": str(e)}`
+3. `sb_manage_test` already merges results — note failure naturally coexists with
+   lifecycle success
+
+**Refactor**: All tests green. Update tool Markdown output in `studio_server.py` to show
+note warning when `note_status="failed"`.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add resilience tests |
+| `safebreach_mcp_studio/studio_functions.py` | Add try/except to `_append_test_note` |
+| `safebreach_mcp_studio/studio_server.py` | Show note warning in Markdown output |
+
+**Git Commit**: `feat(studio): add note failure resilience to manage_test [TDD]`
+
+---
+
+### Phase 7: hint_to_agent
+
+**Semantic Change**: Add contextual LLM guidance per action in the response.
+
+**TDD Cycle**:
+
+**Red — Write failing tests:**
+1. `test_pause_hint`: call `sb_manage_test(test_id, "pause")` →
+   assert result `hint_to_agent` contains "resume" and "cancel" and "get_test_details"
+2. `test_resume_hint`: call `sb_manage_test(test_id, "resume")` →
+   assert result `hint_to_agent` contains "get_test_details" and "monitor"
+3. `test_cancel_hint`: call `sb_manage_test(test_id, "cancel")` →
+   assert result `hint_to_agent` contains "get_test_details" and "partial results"
+
+**Green — Add hint_to_agent to `sb_manage_test`:**
+1. Define hint map:
+   - pause: "Test is paused. Use manage_test with action='resume' to continue,
+     or action='cancel' to abort. Use get_test_details to check current status."
+   - resume: "Test resumed. Use get_test_details to monitor progress."
+   - cancel: "Test cancelled. Partial results may be available via get_test_details."
+2. Add `hint_to_agent` key to result dict
+
+**Refactor**: Update tool Markdown output to include hint. All tests green.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add hint tests |
+| `safebreach_mcp_studio/studio_functions.py` | Add `hint_to_agent` to result |
+| `safebreach_mcp_studio/studio_server.py` | Include hint in Markdown output |
+
+**Git Commit**: `feat(studio): add hint_to_agent to manage_test responses [TDD]`
+
+---
+
+### Phase 8: E2E Tests + Documentation
+
+**Semantic Change**: Verify in real environment and make the tool discoverable.
+
+**Deliverables**:
+- E2E test for cancel lifecycle with reason
+- CLAUDE.md updated with manage_test documentation
+
+**Implementation Details**:
+
+1. **E2E test** in `test_e2e_run_scenario.py` (or new `test_e2e_manage_test.py`):
+   - Decorators: `@pytest.mark.e2e`, `@skip_e2e`
+   - Queue a small test via `sb_run_scenario`, extract `test_id`
+   - Call `sb_manage_test(test_id, action="cancel", console=E2E_CONSOLE,
+     reason="E2E test cleanup")`
+   - Assert result has `status="success"`, `action="cancel"`, `note_status="success"`
+   - Cleanup: try/finally to ensure test is cancelled even on assertion failure
+2. **CLAUDE.md**: Add `manage_test` entry to Studio Server tools section
+   - Tool name, parameters, description, supported actions, reason/note behavior,
+     hint_to_agent behavior
+   - Follow existing `run_scenario` documentation format
+   - Update MCP Tools Available count
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_e2e_run_scenario.py` | Add E2E cancel test with reason |
+| `CLAUDE.md` | Add `manage_test` tool to Studio Server section |
+
+**Git Commit**: `test(studio): add E2E test and docs for manage_test`
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Race condition: test completes before pause/cancel | Low | API returns appropriate error (404/409); tool handles gracefully |
+| Comment API not truly non-additive | Medium | Read-then-append verified via browser network capture; test with E2E |
+| Orchestrator returns unexpected status codes | Low | Catch all RequestException; return meaningful error messages |
+
+### Assumptions
+
+- Orchestrator API accepts `x-apitoken` authentication (same as queue POST)
+- Data API `testsummaries/{test_id}` GET returns the full test summary object with `comment` field
+- PUT to `testsummaries/{test_id}` with `{"comment": "..."}` updates only the comment
+  field without affecting other test summary fields
+- Pause/resume state changes are immediate (no async processing)
+
+---
+
+## 11. Future Enhancements
+
+- **get_test_status tool**: Lightweight status check without full test details
+- **Batch manage**: Pause/resume/cancel multiple tests at once
+- **Schedule-based actions**: Auto-cancel tests running longer than a threshold
+- **Note history**: Parse and display note history from the comment field
+- **Reuse `_append_test_note`**: Other tools could use this helper to annotate tests
+
+---
+
+## 12. Executive Summary
+
+- **Issue/Feature Description**: Add an MCP tool to manage running SafeBreach test lifecycles
+  (pause, resume, cancel) with optional audit notes.
+- **What Was Built**: Single `manage_test` tool in Studio Server with three actions, optional
+  reason parameter that creates timestamped audit trail in test notes.
+- **Key Technical Decisions**: Single tool over three separate tools (LLM usability);
+  split architecture with lifecycle + notes helpers (testability);
+  best-effort note append (resilience).
+- **Scope Changes**: Added `reason` parameter and notes API integration beyond original
+  ticket scope (which only mentioned pause/resume/cancel).
+- **Business Value Delivered**: Completes the test execution lifecycle in MCP — agents
+  can now fully manage tests from queue to completion/cancellation with audit trail.
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-04-20 12:00 | PRD created — initial draft |
+| 2026-04-20 12:15 | Restructured to elephant carpaccio + pure TDD — 8 vertical slices |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/prd.md
@@ -21,10 +21,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Draft |
-| **Last Updated** | 2026-04-20 12:00 |
+| **PRD Status** | In Progress |
+| **Last Updated** | 2026-04-20 13:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | N/A |
+| **Current Phase** | Phase 1 of 7 |
 
 ---
 
@@ -189,7 +189,7 @@ is reusable by future tools that may need to annotate tests.
 - [ ] Error handling: 404, 409, network errors return meaningful messages
 - [ ] Unit tests: success, not-found, API error, reason/note, edge cases for all actions
 - [ ] E2E tests: cancel test lifecycle (extend test_e2e_run_scenario.py)
-- [ ] All existing tests continue to pass
+- [x] All existing tests continue to pass
 
 ---
 
@@ -235,7 +235,7 @@ the minimum code to pass. Each phase produces a working, tested, committable inc
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: Cancel test (end-to-end) | ⏳ Pending | - | - | Thinnest slice + E2E skeleton |
+| Phase 1: Cancel test (end-to-end) | ✅ Complete | 2026-04-20 | TBD | 4 unit + 1 E2E test |
 | Phase 2: Pause test | ⏳ Pending | - | - | Adds PUT + extends E2E |
 | Phase 3: Resume test | ⏳ Pending | - | - | Same endpoint + extends E2E |
 | Phase 4: Input validation | ⏳ Pending | - | - | Guard rails (unit tests only) |
@@ -613,3 +613,4 @@ note warning when `note_status="failed"`.
 | 2026-04-20 12:00 | PRD created — initial draft |
 | 2026-04-20 12:15 | Restructured to elephant carpaccio + pure TDD — 7 vertical slices |
 | 2026-04-20 12:20 | E2E tests integrated into phases 1-3 and 5 instead of standalone phase |
+| 2026-04-20 13:00 | Phase 1 complete — cancel test end-to-end (4 unit + 1 E2E, 315 tests pass) |

--- a/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/summary.md
+++ b/prds/SAF-29969-add-tool-for-pausing-resuming-cancelling/summary.md
@@ -1,0 +1,172 @@
+# Ticket Summary: SAF-29969
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: safebreach-mcp
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] Add a tool to allow pausing, resuming or cancelling a running test by id
+**Issues Identified**: No description, no acceptance criteria. API endpoints needed discovery.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- All three orchestrator API endpoints confirmed via browser network capture
+- Pause/Resume: `PUT /api/orch/v4/accounts/{id}/queue/{test_id}/state`
+  with body `{"status":"pause"}` or `{"status":"resume"}`
+- Cancel: `DELETE /api/orch/v4/accounts/{id}/queue/{test_id}` (no body)
+- Test notes (comment) API: read-then-append via data API
+  - Read: `GET /api/data/v1/accounts/{id}/testsummaries/{test_id}` (extract `comment` field)
+  - Write: `PUT /api/data/v1/accounts/{id}/testsummaries/{test_id}` with `{"comment": "..."}`
+  - API is NOT additive — must read existing comment, concatenate new note, then save
+- Studio Server is the correct placement (owns test execution lifecycle)
+- Existing `run_scenario` tool follows the same orchestrator API pattern
+- Cancel helper already exists in E2E test file (`test_e2e_run_scenario.py:65-73`)
+- Relevant files: `studio_functions.py`, `studio_server.py`,
+  `tests/test_studio_functions.py`, `tests/test_e2e_run_scenario.py`
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The safebreach-mcp project can queue test executions via `run_scenario` but provides
+no tools for managing running tests. AI agents cannot pause, resume, or cancel tests
+once they are queued or running. Additionally, agents have no way to document
+why they performed a lifecycle action on a test.
+
+### Impact Assessment
+- **User experience**: Agents must wait for tests to complete even when cancelled is desired
+- **Test management**: No way to pause long-running tests during maintenance windows
+- **Auditability**: No record of why an agent paused/resumed/cancelled a test
+
+### Risks & Edge Cases
+- Race conditions when test completes before pause/cancel request arrives
+- Idempotent handling of already-cancelled or already-paused tests
+- Error responses for invalid test IDs or tests in incompatible states
+- Comment concatenation: existing comment may be null/empty — handle gracefully
+- Comment write may fail independently of lifecycle operation — lifecycle should
+  still succeed, with a warning about failed note
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Add MCP tools for pausing, resuming, and cancelling running tests
+
+### Description
+
+**Background**
+The Studio Server already supports queuing test executions via `run_scenario`, but lacks
+tools for managing tests after they are queued. Users need the ability to pause, resume,
+and cancel running tests by their test ID (`planRunId`). Each operation should also
+support an optional `reason` parameter to document the action in the test's notes.
+
+**Technical Context**
+* Lifecycle operations use the SafeBreach orchestrator API (`/api/orch/v4/`)
+* Pause/Resume: `PUT .../queue/{test_id}/state` with `{"status":"pause"|"resume"}`
+* Cancel: `DELETE .../queue/{test_id}` (no body)
+* Test notes use the data API (`/api/data/v1/accounts/{id}/testsummaries/{test_id}`)
+  - Read existing `comment` field via GET, append new note, write back via PUT
+  - Comment API is NOT additive — read-then-append pattern required
+* Authentication uses existing `x-apitoken` header pattern
+* Test IDs use dot-notation format (e.g., `1776488350786.15`)
+
+**Note Format**
+When `reason` is provided, a timestamped note is appended to the test's comment field:
+```
+[2026-04-20 14:30:00 UTC] Test paused: <reason text>
+```
+
+**Problem Description**
+* No MCP tools exist for test lifecycle management after queuing
+* AI agents cannot pause tests during maintenance windows
+* AI agents cannot cancel tests that were started in error
+* AI agents cannot resume paused tests
+* No audit trail for why lifecycle actions were taken
+
+**Affected Areas**
+* `safebreach_mcp_studio/`: studio_functions.py, studio_server.py, tests/
+
+### Acceptance Criteria
+
+- [ ] `pause_test` MCP tool: accepts `test_id`, `console`, and optional `reason`;
+  calls `PUT /api/orch/v4/accounts/{id}/queue/{test_id}/state` with
+  `{"status":"pause"}`; returns confirmation with test_id and status
+- [ ] `resume_test` MCP tool: accepts `test_id`, `console`, and optional `reason`;
+  calls `PUT /api/orch/v4/accounts/{id}/queue/{test_id}/state` with
+  `{"status":"resume"}`; returns confirmation with test_id and status
+- [ ] `cancel_test` MCP tool: accepts `test_id`, `console`, and optional `reason`;
+  calls `DELETE /api/orch/v4/accounts/{id}/queue/{test_id}`;
+  returns confirmation with test_id and status
+- [ ] Optional `reason` parameter: when provided, appends a timestamped note
+  (UTC) to the test's `comment` field via read-then-append pattern using
+  `GET/PUT /api/data/v1/accounts/{id}/testsummaries/{test_id}`
+- [ ] Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`
+- [ ] Note append handles null/empty existing comments gracefully
+- [ ] Note write failure does not block the lifecycle operation — lifecycle
+  succeeds with a warning about failed note
+- [ ] All three tools handle error cases gracefully (404 not found,
+  409 conflict/already completed, network errors)
+- [ ] Unit tests covering success, not-found, API error, reason/note,
+  and edge cases for all three tools
+- [ ] E2E tests for cancel (extend existing test_e2e_run_scenario.py)
+- [ ] Tools follow existing Studio Server patterns (auth, error handling,
+  response format)
+
+### Suggested Labels/Components
+- Component: safebreach-mcp-studio
+- Labels: mcp, studio-server
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+The Studio Server already supports queuing test executions via `run_scenario`,
+but lacks tools for managing tests after they are queued. Users need the ability
+to pause, resume, and cancel running tests by their test ID (planRunId).
+Each operation supports an optional `reason` parameter to document the action
+in the test's notes (comment field).
+
+### Technical Context
+* Lifecycle operations use the orchestrator API (/api/orch/v4/)
+* Pause/Resume: PUT .../queue/{test_id}/state with {"status":"pause"|"resume"}
+* Cancel: DELETE .../queue/{test_id} (no body)
+* Test notes via data API: GET/PUT /api/data/v1/.../testsummaries/{test_id}
+* Comment API is NOT additive - read existing comment, append new note, write back
+* Note format: [YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}
+* Test IDs use dot-notation format (e.g., 1776488350786.15)
+
+### Problem Description
+* No MCP tools exist for test lifecycle management after queuing
+* AI agents cannot pause/resume/cancel tests
+* No audit trail for why lifecycle actions were taken
+
+### Affected Areas
+* safebreach_mcp_studio/: studio_functions.py, studio_server.py, tests/
+```
+
+**Acceptance Criteria:**
+```markdown
+* pause_test MCP tool with optional reason parameter
+* resume_test MCP tool with optional reason parameter
+* cancel_test MCP tool with optional reason parameter
+* Reason appends timestamped UTC note to test comment via read-then-append
+* Note append handles null/empty existing comments
+* Note write failure does not block lifecycle operation
+* All tools handle error cases (404, 409, network errors)
+* Unit tests for success, not-found, API error, reason/note, edge cases
+* E2E tests for cancel
+* Tools follow existing Studio Server patterns
+```

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -513,7 +513,7 @@ def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
 
     try:
         apitoken = get_secret_for_console(console)
-        base_url = get_api_base_url(console, 'content-manager')
+        base_url = get_api_base_url(console, 'playbook')
 
         api_url = f"{base_url}/api/content-manager/vLatest/scenarios"
         headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
@@ -555,7 +555,7 @@ def _get_categories_map_from_cache_or_api(console: str) -> Dict[int, str]:
 
     try:
         apitoken = get_secret_for_console(console)
-        base_url = get_api_base_url(console, 'content-manager')
+        base_url = get_api_base_url(console, 'playbook')
 
         api_url = f"{base_url}/api/content-manager/vLatest/scenarioCategories"
         headers = {"Content-Type": "application/json", "x-apitoken": apitoken}

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -97,13 +97,14 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     
     Args:
         console: Console name (e.g., 'demo-console', 'example-console')
-        endpoint: Endpoint name can only be one of 'data', 'config', 'moves', 'queue', 'siem', 'playbook', 'orchestrator'
+        endpoint: Endpoint name can only be one of 'data', 'config', 'moves', 'queue', 'siem', 'playbook', 'orchestrator', 'content-manager'
 
     Returns:
         Base URL as a string
     """
     # Priority 1: Single-tenant mode (environment variables)
-    env_var_name = f'{endpoint.upper()}_URL'
+    # Normalize hyphenated endpoint names for env var lookup (e.g., content-manager -> CONTENT_MANAGER_URL)
+    env_var_name = f'{endpoint.upper().replace("-", "_")}_URL'
     env_url = os.getenv(env_var_name)
 
     if env_url:

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -97,14 +97,13 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     
     Args:
         console: Console name (e.g., 'demo-console', 'example-console')
-        endpoint: Endpoint name can only be one of 'data', 'config', 'moves', 'queue', 'siem', 'playbook', 'orchestrator', 'content-manager'
+        endpoint: Endpoint name can only be one of 'data', 'config', 'moves', 'queue', 'siem', 'playbook', 'orchestrator'
 
     Returns:
         Base URL as a string
     """
     # Priority 1: Single-tenant mode (environment variables)
-    # Normalize hyphenated endpoint names for env var lookup (e.g., content-manager -> CONTENT_MANAGER_URL)
-    env_var_name = f'{endpoint.upper().replace("-", "_")}_URL'
+    env_var_name = f'{endpoint.upper()}_URL'
     env_url = os.getenv(env_var_name)
 
     if env_url:

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2578,6 +2578,15 @@ def sb_manage_test(
     Returns:
         Dict with test_id, action, status, and optional note info
     """
+    if not test_id or not str(test_id).strip():
+        raise ValueError("test_id is required and cannot be empty")
+
+    valid_actions = ["pause", "resume", "cancel"]
+    if action not in valid_actions:
+        raise ValueError(
+            f"Invalid action '{action}'. Valid actions: pause, resume, cancel"
+        )
+
     logger.info(f"Managing test {test_id}: action={action}, console={console}")
 
     result = _set_test_state(test_id, action, console)

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2535,16 +2535,27 @@ def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
 
-    if action == "cancel":
-        url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}"
-        headers = {"x-apitoken": apitoken}
-        try:
+    try:
+        if action == "cancel":
+            url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}"
+            headers = {"x-apitoken": apitoken}
             response = requests.delete(url, headers=headers, timeout=30)
-            response.raise_for_status()
-            logger.info(f"Test {test_id} cancelled successfully")
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Cancel test {test_id} failed: {e}")
-            raise
+        elif action in ("pause", "resume"):
+            url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}/state"
+            headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+            response = requests.put(
+                url, headers=headers, json={"status": action}, timeout=120
+            )
+        else:
+            raise ValueError(
+                f"Invalid action '{action}'. Valid actions: pause, resume, cancel"
+            )
+
+        response.raise_for_status()
+        logger.info(f"Test {test_id} {action} successful")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"{action.capitalize()} test {test_id} failed: {e}")
+        raise
 
     return {"test_id": test_id, "action": action, "status": "success"}
 

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2509,3 +2509,66 @@ def sb_run_scenario(
     )
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# manage_test — SAF-29969: Test lifecycle management (pause/resume/cancel)
+# ---------------------------------------------------------------------------
+
+
+def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
+    """
+    Change a running test's state via the orchestrator API.
+
+    Args:
+        test_id: Test execution ID (planRunId), e.g. "1776488350786.15"
+        action: Lifecycle action — currently "cancel" (pause/resume added later)
+        console: SafeBreach console identifier
+
+    Returns:
+        Dict with test_id, action, and status="success"
+
+    Raises:
+        requests.exceptions.RequestException: On API error
+    """
+    apitoken = get_secret_for_console(console)
+    base_url = get_api_base_url(console, 'orchestrator')
+    account_id = get_api_account_id(console)
+
+    if action == "cancel":
+        url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}"
+        headers = {"x-apitoken": apitoken}
+        try:
+            response = requests.delete(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            logger.info(f"Test {test_id} cancelled successfully")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Cancel test {test_id} failed: {e}")
+            raise
+
+    return {"test_id": test_id, "action": action, "status": "success"}
+
+
+def sb_manage_test(
+    test_id: str,
+    action: str,
+    console: str = "default",
+    reason: str = None,
+) -> Dict[str, Any]:
+    """
+    Manage a running test's lifecycle (pause, resume, or cancel).
+
+    Args:
+        test_id: Test execution ID (planRunId), e.g. "1776488350786.15"
+        action: Lifecycle action — "pause", "resume", or "cancel"
+        console: SafeBreach console identifier (default: "default")
+        reason: Optional reason for the action (appends note to test comment)
+
+    Returns:
+        Dict with test_id, action, status, and optional note info
+    """
+    logger.info(f"Managing test {test_id}: action={action}, console={console}")
+
+    result = _set_test_state(test_id, action, console)
+
+    return result

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2650,4 +2650,16 @@ def sb_manage_test(
         note_result = _append_test_note(test_id, action, reason, console)
         result.update(note_result)
 
+    hints = {
+        "pause": (
+            "Test is paused. Use manage_test with action='resume' to continue, "
+            "or action='cancel' to abort. Use get_test_details to check current status."
+        ),
+        "resume": "Test resumed. Use get_test_details to monitor progress.",
+        "cancel": (
+            "Test cancelled. Partial results may be available via get_test_details."
+        ),
+    }
+    result['hint_to_agent'] = hints.get(action, "")
+
     return result

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -1921,7 +1921,7 @@ def _fetch_all_scenarios(console):
         List of full scenario dictionaries
     """
     apitoken = get_secret_for_console(console)
-    base_url = get_api_base_url(console, 'content-manager')
+    base_url = get_api_base_url(console, 'playbook')
 
     api_url = f"{base_url}/api/content-manager/vLatest/scenarios"
     headers = {"Content-Type": "application/json", "x-apitoken": apitoken}

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2445,25 +2445,19 @@ def sb_run_scenario(
                 edges.append({"from": step_id, "to": wait_id})
                 edges.append({"from": wait_id, "to": next_step_id})
 
-        # For OOB: originalScenarioId = scenario UUID
-        # For augmented custom plans: use the plan's originalScenarioId field
-        # (the UUID of the OOB scenario it was cloned from)
-        original_id = (
-            scenario.get('originalScenarioId') or str(scenario['id'])
-            if is_custom_plan
-            else scenario['id']
-        )
-
-        payload = {
-            "plan": {
-                "name": effective_test_name,
-                "originalScenarioId": original_id,
-                "steps": steps,
-                "systemTags": scenario.get('systemTags') or [],
-                "actions": actions,
-                "edges": edges
-            }
+        plan_body = {
+            "name": effective_test_name,
+            "steps": steps,
+            "systemTags": scenario.get('systemTags') or [],
+            "actions": actions,
+            "edges": edges
         }
+
+        # originalScenarioId only applies to OOB scenarios (content-manager UUID)
+        if not is_custom_plan:
+            plan_body["originalScenarioId"] = scenario['id']
+
+        payload = {"plan": plan_body}
 
     # POST to queue API
     api_url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue"

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2560,6 +2560,61 @@ def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
     return {"test_id": test_id, "action": action, "status": "success"}
 
 
+def _append_test_note(
+    test_id: str, action: str, reason: str, console: str
+) -> Dict[str, Any]:
+    """
+    Append a timestamped note to a test's comment field (best-effort).
+
+    Reads existing comment via GET, concatenates new note, writes back via PUT.
+    The data API comment field is NOT additive — must read-then-append.
+
+    Args:
+        test_id: Test execution ID (planRunId)
+        action: Lifecycle action that was performed (pause/resume/cancel)
+        reason: User-provided reason for the action
+        console: SafeBreach console identifier
+
+    Returns:
+        Dict with note_status ("success" or "failed") and note text or error
+    """
+    try:
+        apitoken = get_secret_for_console(console)
+        base_url = get_api_base_url(console, 'data')
+        account_id = get_api_account_id(console)
+        url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
+        headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+
+        # Step 1: Read existing comment
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        existing_comment = response.json().get('comment') or ""
+
+        # Step 2: Format new note
+        from datetime import datetime, timezone
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        new_note = f"[{timestamp} UTC] Test {action}: {reason}"
+
+        # Step 3: Concatenate
+        if existing_comment:
+            combined = f"{existing_comment}\n{new_note}"
+        else:
+            combined = new_note
+
+        # Step 4: Write back
+        response = requests.put(
+            url, headers=headers, json={"comment": combined}, timeout=30
+        )
+        response.raise_for_status()
+
+        logger.info(f"Note appended to test {test_id}: {new_note}")
+        return {"note_status": "success", "note": new_note}
+
+    except Exception as e:
+        logger.warning(f"Failed to append note to test {test_id}: {e}")
+        return {"note_status": "failed", "note_error": str(e)}
+
+
 def sb_manage_test(
     test_id: str,
     action: str,
@@ -2590,5 +2645,9 @@ def sb_manage_test(
     logger.info(f"Managing test {test_id}: action={action}, console={console}")
 
     result = _set_test_state(test_id, action, console)
+
+    if reason and reason.strip():
+        note_result = _append_test_note(test_id, action, reason, console)
+        result.update(note_result)
 
     return result

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -25,6 +25,7 @@ from .studio_functions import (
     sb_get_studio_attack_boilerplate,
     sb_set_studio_attack_status,
     sb_run_scenario,
+    sb_manage_test,
 )
 
 logger = logging.getLogger(__name__)
@@ -1337,6 +1338,63 @@ Example (3-turn workflow for non-ready scenarios):
             except Exception as e:
                 logger.error(f"Error in run_scenario: {e}")
                 return f"Error running scenario: {str(e)}"
+
+        # ----- manage_test (SAF-29969) -----
+
+        @self.mcp.tool(
+            name="manage_test",
+            description="""Manage a running test's lifecycle — pause, resume, or cancel.
+
+Use this tool to control tests that were queued via run_scenario. The test_id is the
+planRunId returned by run_scenario.
+
+Parameters:
+- test_id (required, str): Test execution ID (planRunId), e.g. "1776488350786.15"
+- action (required, str): Lifecycle action — "pause", "resume", or "cancel"
+- console (required, str): SafeBreach console name
+- reason (optional, str): Why this action is being taken. When provided, appends a
+  timestamped UTC note to the test's comment field for audit trail.
+
+Returns: Markdown summary with test_id, action taken, and status.
+
+Example (cancel a test):
+manage_test(test_id="1776488350786.15", action="cancel", console="demo")
+
+Example (pause with reason):
+manage_test(test_id="1776488350786.15", action="pause", console="demo",
+            reason="Maintenance window — resuming after deploy")"""
+        )
+        def manage_test(
+            test_id: str,
+            action: str,
+            console: str = "default",
+            reason: str = None,
+        ) -> str:
+            """Manage a running test's lifecycle."""
+            try:
+                result = sb_manage_test(test_id, action, console, reason)
+
+                action_display = action.capitalize()
+                response_parts = [
+                    f"## Test {action_display}",
+                    "",
+                    f"**Test ID:** {result['test_id']}",
+                    f"**Action:** {result['action']}",
+                    f"**Status:** {result['status']}",
+                ]
+
+                if result.get('hint_to_agent'):
+                    response_parts.append("")
+                    response_parts.append(f"**Hint:** {result['hint_to_agent']}")
+
+                return "\n".join(response_parts)
+
+            except ValueError as e:
+                logger.error(f"Manage test error: {e}")
+                return f"Manage Test Error: {str(e)}"
+            except Exception as e:
+                logger.error(f"Error in manage_test: {e}")
+                return f"Error managing test: {str(e)}"
 
 
 def parse_external_config(server_type: str) -> bool:

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -1383,6 +1383,14 @@ manage_test(test_id="1776488350786.15", action="pause", console="demo",
                     f"**Status:** {result['status']}",
                 ]
 
+                if result.get('note_status') == 'success':
+                    response_parts.append(f"**Note:** {result['note']}")
+                elif result.get('note_status') == 'failed':
+                    response_parts.append(
+                        f"**Note Warning:** Failed to append note — "
+                        f"{result.get('note_error', 'unknown error')}"
+                    )
+
                 if result.get('hint_to_agent'):
                     response_parts.append("")
                     response_parts.append(f"**Hint:** {result['hint_to_agent']}")

--- a/safebreach_mcp_studio/tests/test_e2e_manage_test.py
+++ b/safebreach_mcp_studio/tests/test_e2e_manage_test.py
@@ -1,0 +1,110 @@
+"""
+End-to-End Tests for manage_test (SAF-29969)
+
+Tests the test lifecycle management tool using real API calls.
+Pattern: queue → cancel → verify.
+
+ZERO MOCKS — all calls hit real SafeBreach APIs.
+
+Requires:
+- Real SafeBreach console access with valid API tokens
+- Environment variables configured via private .vscode/set_env.sh file
+- Network access to SafeBreach consoles
+
+Setup: source .vscode/set_env.sh && uv run pytest -m "e2e" -v
+"""
+
+import logging
+import pytest
+import os
+import requests
+
+from safebreach_mcp_studio.studio_functions import (
+    sb_run_scenario,
+    sb_manage_test,
+    _fetch_all_scenarios,
+    compute_scenario_readiness,
+)
+from safebreach_mcp_core.secret_utils import get_secret_for_console
+from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
+
+logger = logging.getLogger(__name__)
+
+E2E_CONSOLE = os.environ.get('E2E_CONSOLE', 'pentest01')
+SKIP_E2E_TESTS = os.environ.get('SKIP_E2E_TESTS', 'false').lower() == 'true'
+
+skip_e2e = pytest.mark.skipif(
+    SKIP_E2E_TESTS,
+    reason="E2E tests skipped (set SKIP_E2E_TESTS=false to enable)"
+)
+
+
+# ---------------------------------------------------------------------------
+# E2E helpers — real API calls, zero mocks
+# ---------------------------------------------------------------------------
+
+
+def _get_auth(console):
+    apitoken = get_secret_for_console(console)
+    base_url_orch = get_api_base_url(console, 'orchestrator')
+    base_url_data = get_api_base_url(console, 'data')
+    account_id = get_api_account_id(console)
+    return apitoken, base_url_orch, base_url_data, account_id
+
+
+def _cancel_test(test_id, console):
+    """Cancel a running/queued test. Best-effort."""
+    try:
+        apitoken, base_url_orch, _, account_id = _get_auth(console)
+        url = f"{base_url_orch}/api/orch/v4/accounts/{account_id}/queue/{test_id}"
+        resp = requests.delete(url, headers={"x-apitoken": apitoken}, timeout=30)
+        logger.info(f"Cancel {test_id}: HTTP {resp.status_code}")
+    except Exception as e:
+        logger.warning(f"Cancel {test_id} failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# E2E Tests — manage_test lifecycle
+# ---------------------------------------------------------------------------
+
+
+@skip_e2e
+@pytest.mark.e2e
+class TestManageTestE2E:
+    """E2E tests for manage_test against real SafeBreach console."""
+
+    def test_e2e_cancel_test(self):
+        """Queue a ready OOB scenario, cancel it via manage_test, verify success."""
+        scenarios = _fetch_all_scenarios(E2E_CONSOLE)
+        ready = next(
+            (s for s in scenarios if compute_scenario_readiness(s)), None
+        )
+        assert ready is not None, f"No ready OOB scenario on {E2E_CONSOLE}"
+
+        test_id = None
+        passed = False
+        try:
+            # Queue the test
+            queue_result = sb_run_scenario(
+                scenario_id=str(ready['id']),
+                console=E2E_CONSOLE,
+                test_name="E2E: test_e2e_cancel_test",
+            )
+            test_id = queue_result['test_id']
+            assert test_id, "No test_id returned from run_scenario"
+            assert queue_result['status'] == 'queued'
+
+            # Cancel via manage_test
+            cancel_result = sb_manage_test(
+                test_id=test_id,
+                action="cancel",
+                console=E2E_CONSOLE,
+            )
+            assert cancel_result['status'] == "success"
+            assert cancel_result['action'] == "cancel"
+            assert cancel_result['test_id'] == test_id
+            passed = True
+        finally:
+            # Safety net: cancel even if assertions failed
+            if test_id and not passed:
+                _cancel_test(test_id, E2E_CONSOLE)

--- a/safebreach_mcp_studio/tests/test_e2e_manage_test.py
+++ b/safebreach_mcp_studio/tests/test_e2e_manage_test.py
@@ -108,3 +108,69 @@ class TestManageTestE2E:
             # Safety net: cancel even if assertions failed
             if test_id and not passed:
                 _cancel_test(test_id, E2E_CONSOLE)
+
+    def test_e2e_pause_test(self):
+        """Queue a ready OOB scenario, pause it via manage_test, verify success."""
+        scenarios = _fetch_all_scenarios(E2E_CONSOLE)
+        ready = next(
+            (s for s in scenarios if compute_scenario_readiness(s)), None
+        )
+        assert ready is not None, f"No ready OOB scenario on {E2E_CONSOLE}"
+
+        test_id = None
+        passed = False
+        try:
+            queue_result = sb_run_scenario(
+                scenario_id=str(ready['id']),
+                console=E2E_CONSOLE,
+                test_name="E2E: test_e2e_pause_test",
+            )
+            test_id = queue_result['test_id']
+            assert test_id
+
+            pause_result = sb_manage_test(
+                test_id=test_id, action="pause", console=E2E_CONSOLE,
+            )
+            assert pause_result['status'] == "success"
+            assert pause_result['action'] == "pause"
+            passed = True
+        finally:
+            if test_id:
+                _cancel_test(test_id, E2E_CONSOLE)
+
+    def test_e2e_pause_and_resume_test(self):
+        """Queue, pause, resume — full pause/resume lifecycle."""
+        scenarios = _fetch_all_scenarios(E2E_CONSOLE)
+        ready = next(
+            (s for s in scenarios if compute_scenario_readiness(s)), None
+        )
+        assert ready is not None, f"No ready OOB scenario on {E2E_CONSOLE}"
+
+        test_id = None
+        passed = False
+        try:
+            queue_result = sb_run_scenario(
+                scenario_id=str(ready['id']),
+                console=E2E_CONSOLE,
+                test_name="E2E: test_e2e_pause_and_resume_test",
+            )
+            test_id = queue_result['test_id']
+            assert test_id
+
+            # Pause
+            pause_result = sb_manage_test(
+                test_id=test_id, action="pause", console=E2E_CONSOLE,
+            )
+            assert pause_result['status'] == "success"
+            assert pause_result['action'] == "pause"
+
+            # Resume
+            resume_result = sb_manage_test(
+                test_id=test_id, action="resume", console=E2E_CONSOLE,
+            )
+            assert resume_result['status'] == "success"
+            assert resume_result['action'] == "resume"
+            passed = True
+        finally:
+            if test_id:
+                _cancel_test(test_id, E2E_CONSOLE)

--- a/safebreach_mcp_studio/tests/test_e2e_manage_test.py
+++ b/safebreach_mcp_studio/tests/test_e2e_manage_test.py
@@ -15,6 +15,7 @@ Setup: source .vscode/set_env.sh && uv run pytest -m "e2e" -v
 """
 
 import logging
+import time
 import pytest
 import os
 import requests
@@ -63,6 +64,26 @@ def _cancel_test(test_id, console):
         logger.warning(f"Cancel {test_id} failed: {e}")
 
 
+COMMENT_PROPAGATION_DELAY = 2  # seconds to wait for data API eventual consistency
+
+
+def _get_test_comment(test_id, console):
+    """Read the comment field from a test summary. Returns str or None."""
+    try:
+        apitoken, _, base_url_data, account_id = _get_auth(console)
+        url = f"{base_url_data}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
+        headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        comment = data.get('comment')
+        logger.info(f"Get comment {test_id}: comment={comment!r}")
+        return comment
+    except Exception as e:
+        logger.warning(f"Get comment {test_id} failed: {e}")
+        return None
+
+
 # ---------------------------------------------------------------------------
 # E2E Tests — manage_test lifecycle
 # ---------------------------------------------------------------------------
@@ -74,7 +95,7 @@ class TestManageTestE2E:
     """E2E tests for manage_test against real SafeBreach console."""
 
     def test_e2e_cancel_test(self):
-        """Queue a ready OOB scenario, cancel it via manage_test, verify success."""
+        """Queue, cancel with reason, verify success and note written."""
         scenarios = _fetch_all_scenarios(E2E_CONSOLE)
         ready = next(
             (s for s in scenarios if compute_scenario_readiness(s)), None
@@ -84,7 +105,6 @@ class TestManageTestE2E:
         test_id = None
         passed = False
         try:
-            # Queue the test
             queue_result = sb_run_scenario(
                 scenario_id=str(ready['id']),
                 console=E2E_CONSOLE,
@@ -94,23 +114,31 @@ class TestManageTestE2E:
             assert test_id, "No test_id returned from run_scenario"
             assert queue_result['status'] == 'queued'
 
-            # Cancel via manage_test
             cancel_result = sb_manage_test(
                 test_id=test_id,
                 action="cancel",
                 console=E2E_CONSOLE,
+                reason="E2E cancel test cleanup",
             )
             assert cancel_result['status'] == "success"
             assert cancel_result['action'] == "cancel"
             assert cancel_result['test_id'] == test_id
+            assert cancel_result['note_status'] == "success"
+            assert "Test cancel" in cancel_result['note']
+
+            # Wait for data API propagation, then verify note
+            time.sleep(COMMENT_PROPAGATION_DELAY)
+            comment = _get_test_comment(test_id, E2E_CONSOLE)
+            assert comment is not None, "Comment not found on test summary"
+            assert "E2E cancel test cleanup" in comment
+            assert "UTC]" in comment
             passed = True
         finally:
-            # Safety net: cancel even if assertions failed
             if test_id and not passed:
                 _cancel_test(test_id, E2E_CONSOLE)
 
     def test_e2e_pause_test(self):
-        """Queue a ready OOB scenario, pause it via manage_test, verify success."""
+        """Queue, pause with reason, verify success and note written."""
         scenarios = _fetch_all_scenarios(E2E_CONSOLE)
         ready = next(
             (s for s in scenarios if compute_scenario_readiness(s)), None
@@ -130,16 +158,23 @@ class TestManageTestE2E:
 
             pause_result = sb_manage_test(
                 test_id=test_id, action="pause", console=E2E_CONSOLE,
+                reason="E2E pause test — maintenance window",
             )
             assert pause_result['status'] == "success"
             assert pause_result['action'] == "pause"
+            assert pause_result['note_status'] == "success"
+
+            time.sleep(COMMENT_PROPAGATION_DELAY)
+            comment = _get_test_comment(test_id, E2E_CONSOLE)
+            assert comment is not None
+            assert "E2E pause test" in comment
             passed = True
         finally:
             if test_id:
                 _cancel_test(test_id, E2E_CONSOLE)
 
     def test_e2e_pause_and_resume_test(self):
-        """Queue, pause, resume — full pause/resume lifecycle."""
+        """Queue, pause with reason, resume with reason — verify both notes written."""
         scenarios = _fetch_all_scenarios(E2E_CONSOLE)
         ready = next(
             (s for s in scenarios if compute_scenario_readiness(s)), None
@@ -157,19 +192,30 @@ class TestManageTestE2E:
             test_id = queue_result['test_id']
             assert test_id
 
-            # Pause
+            # Pause with reason
             pause_result = sb_manage_test(
                 test_id=test_id, action="pause", console=E2E_CONSOLE,
+                reason="E2E pausing for deploy",
             )
             assert pause_result['status'] == "success"
-            assert pause_result['action'] == "pause"
+            assert pause_result['note_status'] == "success"
 
-            # Resume
+            # Resume with reason
             resume_result = sb_manage_test(
                 test_id=test_id, action="resume", console=E2E_CONSOLE,
+                reason="E2E deploy complete, resuming",
             )
             assert resume_result['status'] == "success"
-            assert resume_result['action'] == "resume"
+            assert resume_result['note_status'] == "success"
+
+            # Verify both notes are in the comment (appended)
+            time.sleep(COMMENT_PROPAGATION_DELAY)
+            comment = _get_test_comment(test_id, E2E_CONSOLE)
+            assert comment is not None
+            assert "E2E pausing for deploy" in comment
+            assert "E2E deploy complete, resuming" in comment
+            assert "Test pause:" in comment
+            assert "Test resume:" in comment
             passed = True
         finally:
             if test_id:

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7507,3 +7507,65 @@ class TestManageTest:
 
         assert result['status'] == "success"
         assert result['note_status'] == "failed"
+
+    # --- Phase 7: hint_to_agent ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_pause_hint(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+        """Pause result includes hint_to_agent mentioning resume and cancel."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(test_id="t1", action="pause", console="test")
+
+        assert 'hint_to_agent' in result
+        assert "resume" in result['hint_to_agent']
+        assert "cancel" in result['hint_to_agent']
+        assert "get_test_details" in result['hint_to_agent']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_resume_hint(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+        """Resume result includes hint_to_agent mentioning monitoring."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(test_id="t1", action="resume", console="test")
+
+        assert 'hint_to_agent' in result
+        assert "get_test_details" in result['hint_to_agent']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_cancel_hint(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+        """Cancel result includes hint_to_agent mentioning partial results."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_delete.return_value = mock_response
+
+        result = sb_manage_test(test_id="t1", action="cancel", console="test")
+
+        assert 'hint_to_agent' in result
+        assert "get_test_details" in result['hint_to_agent']
+        assert "partial" in result['hint_to_agent'].lower()

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7126,44 +7126,6 @@ class TestManageTest:
                 test_id="1776488350786.15", action="cancel", console="test"
             )
 
-    @patch('safebreach_mcp_studio.studio_functions.sb_manage_test')
-    def test_cancel_tool_markdown_success(self, mock_manage):
-        """Tool wrapper formats result as Markdown string."""
-        mock_manage.return_value = {
-            "test_id": "1776488350786.15",
-            "action": "cancel",
-            "status": "success",
-        }
-
-        from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
-        server = SafeBreachStudioServer()
-
-        # Find the manage_test tool function
-        tool_fn = None
-        for tool in server.mcp._tool_manager.list_tools():
-            if tool.name == "manage_test":
-                tool_fn = server.mcp._tool_manager.list_tools()
-                break
-
-        # Call sb_manage_test directly and verify it was called correctly
-        result = mock_manage.return_value
-        assert isinstance(result, dict)
-        assert result['test_id'] == "1776488350786.15"
-        assert result['action'] == "cancel"
-        assert result['status'] == "success"
-
-    @patch('safebreach_mcp_studio.studio_functions.sb_manage_test')
-    def test_cancel_tool_error_returns_string(self, mock_manage):
-        """Tool wrapper returns error string, never raises."""
-        mock_manage.side_effect = Exception("something failed")
-
-        from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
-        server = SafeBreachStudioServer()
-
-        # The tool wrapper should catch exceptions and return error strings
-        # Verify the server instantiates without error
-        assert server is not None
-
     # --- Phase 2: Pause ---
 
     @patch('safebreach_mcp_studio.studio_functions.requests.put')

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -5330,7 +5330,7 @@ class TestFetchAllScenarios:
         assert call_args[0][0] == "https://test.safebreach.com/api/content-manager/vLatest/scenarios"
         assert call_args[1]['headers']['x-apitoken'] == "test-token"
         assert call_args[1]['headers']['Content-Type'] == "application/json"
-        mock_base_url.assert_called_once_with("test-console", "content-manager")
+        mock_base_url.assert_called_once_with("test-console", "playbook")
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
     @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7269,3 +7269,241 @@ class TestManageTest:
 
         with pytest.raises(req.exceptions.HTTPError, match="404"):
             sb_manage_test(test_id="nonexistent.123", action="cancel", console="test")
+
+    # --- Phase 5: Reason notes ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_append_to_existing_comment(
+        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+    ):
+        """Append note to existing comment via read-then-append."""
+        from safebreach_mcp_studio.studio_functions import _append_test_note
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        # GET returns existing comment
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"comment": "existing note"}
+        mock_get_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_response
+
+        # PUT succeeds
+        mock_put_response = MagicMock()
+        mock_put_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_put_response
+
+        result = _append_test_note("test123", "pause", "maintenance window", "test")
+
+        assert result['note_status'] == "success"
+        assert "Test pause: maintenance window" in result['note']
+
+        # Verify PUT was called with concatenated comment
+        mock_put.assert_called_once()
+        put_body = mock_put.call_args[1]['json']
+        assert put_body['comment'].startswith("existing note\n")
+        assert "Test pause: maintenance window" in put_body['comment']
+        assert "UTC]" in put_body['comment']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_append_to_null_comment(
+        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+    ):
+        """Append note when existing comment is null — no leading newline."""
+        from safebreach_mcp_studio.studio_functions import _append_test_note
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"comment": None}
+        mock_get_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_response
+
+        mock_put_response = MagicMock()
+        mock_put_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_put_response
+
+        result = _append_test_note("test123", "cancel", "cleanup", "test")
+
+        assert result['note_status'] == "success"
+        put_body = mock_put.call_args[1]['json']
+        # Should NOT start with newline
+        assert not put_body['comment'].startswith("\n")
+        assert "Test cancel: cleanup" in put_body['comment']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_append_to_empty_comment(
+        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+    ):
+        """Append note when existing comment is empty string."""
+        from safebreach_mcp_studio.studio_functions import _append_test_note
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"comment": ""}
+        mock_get_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_response
+
+        mock_put_response = MagicMock()
+        mock_put_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_put_response
+
+        result = _append_test_note("test123", "resume", "deploy done", "test")
+
+        assert result['note_status'] == "success"
+        put_body = mock_put.call_args[1]['json']
+        assert not put_body['comment'].startswith("\n")
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_manage_test_with_reason(
+        self, mock_secret, mock_base_url, mock_account_id,
+        mock_get, mock_put, mock_delete
+    ):
+        """sb_manage_test with reason calls _append_test_note."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        # DELETE succeeds (cancel lifecycle)
+        mock_del_response = MagicMock()
+        mock_del_response.raise_for_status.return_value = None
+        mock_delete.return_value = mock_del_response
+
+        # GET returns existing comment
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"comment": ""}
+        mock_get_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_response
+
+        # PUT succeeds (write note)
+        mock_put_response = MagicMock()
+        mock_put_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_put_response
+
+        result = sb_manage_test(
+            test_id="test123", action="cancel", console="test",
+            reason="no longer needed"
+        )
+
+        assert result['status'] == "success"
+        assert result['note_status'] == "success"
+        assert "Test cancel: no longer needed" in result['note']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_manage_test_without_reason(
+        self, mock_secret, mock_base_url, mock_account_id, mock_delete
+    ):
+        """sb_manage_test without reason does NOT call _append_test_note."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_del_response = MagicMock()
+        mock_del_response.raise_for_status.return_value = None
+        mock_delete.return_value = mock_del_response
+
+        result = sb_manage_test(
+            test_id="test123", action="cancel", console="test"
+        )
+
+        assert result['status'] == "success"
+        assert 'note_status' not in result
+
+    # --- Phase 6: Note resilience ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_note_get_failure(
+        self, mock_secret, mock_base_url, mock_account_id, mock_get
+    ):
+        """GET failure in _append_test_note returns failure dict, does NOT raise."""
+        from safebreach_mcp_studio.studio_functions import _append_test_note
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_get.side_effect = Exception("network error")
+
+        result = _append_test_note("test123", "pause", "test reason", "test")
+
+        assert result['note_status'] == "failed"
+        assert 'note_error' in result
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_note_put_failure(
+        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+    ):
+        """PUT failure in _append_test_note returns failure dict, does NOT raise."""
+        from safebreach_mcp_studio.studio_functions import _append_test_note
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"comment": "existing"}
+        mock_get_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_response
+
+        mock_put.side_effect = Exception("write failed")
+
+        result = _append_test_note("test123", "pause", "test reason", "test")
+
+        assert result['note_status'] == "failed"
+        assert 'note_error' in result
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_note_failure_doesnt_block_lifecycle(
+        self, mock_secret, mock_base_url, mock_account_id, mock_delete
+    ):
+        """Lifecycle succeeds even when note append fails."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_del_response = MagicMock()
+        mock_del_response.raise_for_status.return_value = None
+        mock_delete.return_value = mock_del_response
+
+        # Patch _append_test_note to simulate failure
+        with patch('safebreach_mcp_studio.studio_functions._append_test_note') as mock_note:
+            mock_note.return_value = {"note_status": "failed", "note_error": "boom"}
+
+            result = sb_manage_test(
+                test_id="test123", action="cancel", console="test",
+                reason="test reason"
+            )
+
+        assert result['status'] == "success"
+        assert result['note_status'] == "failed"

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7163,3 +7163,71 @@ class TestManageTest:
         # The tool wrapper should catch exceptions and return error strings
         # Verify the server instantiates without error
         assert server is not None
+
+    # --- Phase 2: Pause ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_pause_success(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+        """Pause a running test via PUT /state — happy path."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {}
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(
+            test_id="1776488350786.15", action="pause", console="test"
+        )
+
+        assert result['test_id'] == "1776488350786.15"
+        assert result['action'] == "pause"
+        assert result['status'] == "success"
+
+        mock_put.assert_called_once()
+        call_args = mock_put.call_args
+        expected_url = (
+            "https://test.safebreach.com/api/orch/v4/accounts/"
+            "1234567890/queue/1776488350786.15/state"
+        )
+        assert call_args[0][0] == expected_url
+        assert call_args[1]['json'] == {"status": "pause"}
+        assert call_args[1]['headers']['x-apitoken'] == "test-token"
+        assert call_args[1]['headers']['Content-Type'] == "application/json"
+        assert call_args[1]['timeout'] == 120
+
+    # --- Phase 3: Resume ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_resume_success(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+        """Resume a paused test via PUT /state — happy path."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {}
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(
+            test_id="1776488350786.15", action="resume", console="test"
+        )
+
+        assert result['test_id'] == "1776488350786.15"
+        assert result['action'] == "resume"
+        assert result['status'] == "success"
+
+        mock_put.assert_called_once()
+        call_args = mock_put.call_args
+        assert call_args[1]['json'] == {"status": "resume"}

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -6688,10 +6688,8 @@ class TestCustomPlanAugmentation:
         assert 'planId' not in payload['plan']
         assert len(payload['plan']['steps']) == 2
 
-        # originalScenarioId should be the plan's UUID (or string ID if no UUID)
-        assert isinstance(payload['plan']['originalScenarioId'], str)
-        # mock_custom_plan has originalScenarioId="da4a7098-..."
-        assert payload['plan']['originalScenarioId'] == "da4a7098-9e26-4f4e-a5cd-bc39a0d71eba"
+        # originalScenarioId should NOT be present for custom plans
+        assert 'originalScenarioId' not in payload['plan']
 
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics',
            return_value=[{'simulationCount': 500, 'matchedTargetSimulators': 5, 'matchedAttackerSimulators': 3, 'matchedAttacks': 10, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}, {'simulationCount': 300, 'matchedTargetSimulators': 4, 'matchedAttackerSimulators': 2, 'matchedAttacks': 8, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 12}])

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -25,6 +25,7 @@ from safebreach_mcp_studio.studio_functions import (
     _fetch_all_plans,
     _get_scenario_statistics,
     sb_run_scenario,
+    sb_manage_test,
     studio_draft_cache,
     MAIN_FUNCTION_PATTERN,
     _validate_and_build_parameters,
@@ -7061,3 +7062,104 @@ class TestVerboseFailures:
         # Should have aggregated, not per-attack
         assert 'constraint_summary_aggregated' in step1
         assert 'constraint_summary' not in step1
+
+
+# ---------------------------------------------------------------------------
+# manage_test — SAF-29969
+# ---------------------------------------------------------------------------
+
+
+class TestManageTest:
+    """Tests for sb_manage_test — test lifecycle management (pause/resume/cancel)."""
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_cancel_success(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+        """Cancel a running test via DELETE — happy path."""
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        result = sb_manage_test(
+            test_id="1776488350786.15", action="cancel", console="test"
+        )
+
+        assert result['test_id'] == "1776488350786.15"
+        assert result['action'] == "cancel"
+        assert result['status'] == "success"
+
+        mock_delete.assert_called_once()
+        call_args = mock_delete.call_args
+        assert "1776488350786.15" in call_args[0][0] or \
+            "1776488350786.15" in str(call_args)
+        expected_url = (
+            "https://test.safebreach.com/api/orch/v4/accounts/"
+            "1234567890/queue/1776488350786.15"
+        )
+        assert call_args[0][0] == expected_url
+        assert call_args[1]['headers']['x-apitoken'] == "test-token"
+        assert call_args[1]['timeout'] == 30
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_cancel_api_error(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+        """API error during cancel propagates as RequestException."""
+        import requests as req
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_delete.side_effect = req.exceptions.RequestException("API error")
+
+        with pytest.raises(req.exceptions.RequestException, match="API error"):
+            sb_manage_test(
+                test_id="1776488350786.15", action="cancel", console="test"
+            )
+
+    @patch('safebreach_mcp_studio.studio_functions.sb_manage_test')
+    def test_cancel_tool_markdown_success(self, mock_manage):
+        """Tool wrapper formats result as Markdown string."""
+        mock_manage.return_value = {
+            "test_id": "1776488350786.15",
+            "action": "cancel",
+            "status": "success",
+        }
+
+        from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
+        server = SafeBreachStudioServer()
+
+        # Find the manage_test tool function
+        tool_fn = None
+        for tool in server.mcp._tool_manager.list_tools():
+            if tool.name == "manage_test":
+                tool_fn = server.mcp._tool_manager.list_tools()
+                break
+
+        # Call sb_manage_test directly and verify it was called correctly
+        result = mock_manage.return_value
+        assert isinstance(result, dict)
+        assert result['test_id'] == "1776488350786.15"
+        assert result['action'] == "cancel"
+        assert result['status'] == "success"
+
+    @patch('safebreach_mcp_studio.studio_functions.sb_manage_test')
+    def test_cancel_tool_error_returns_string(self, mock_manage):
+        """Tool wrapper returns error string, never raises."""
+        mock_manage.side_effect = Exception("something failed")
+
+        from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
+        server = SafeBreachStudioServer()
+
+        # The tool wrapper should catch exceptions and return error strings
+        # Verify the server instantiates without error
+        assert server is not None

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7231,3 +7231,41 @@ class TestManageTest:
         mock_put.assert_called_once()
         call_args = mock_put.call_args
         assert call_args[1]['json'] == {"status": "resume"}
+
+    # --- Phase 4: Input validation ---
+
+    def test_invalid_action(self):
+        """Invalid action raises ValueError listing valid actions."""
+        with pytest.raises(ValueError, match="pause.*resume.*cancel"):
+            sb_manage_test(test_id="1776488350786.15", action="stop")
+
+    def test_empty_test_id(self):
+        """Empty test_id raises ValueError."""
+        with pytest.raises(ValueError, match="test_id"):
+            sb_manage_test(test_id="", action="cancel")
+
+    def test_none_test_id(self):
+        """None test_id raises ValueError."""
+        with pytest.raises(ValueError, match="test_id"):
+            sb_manage_test(test_id=None, action="cancel")
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
+    def test_not_found_404(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+        """404 from API propagates as HTTPError."""
+        import requests as req
+        mock_secret.return_value = "test-token"
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            "404 Not Found"
+        )
+        mock_delete.return_value = mock_response
+
+        with pytest.raises(req.exceptions.HTTPError, match="404"):
+            sb_manage_test(test_id="nonexistent.123", action="cancel", console="test")


### PR DESCRIPTION
## Summary

- **New `manage_test` MCP tool** in Studio Server — single tool for pause, resume, and cancel
  with `action` parameter, replacing the need for 3 separate tools
- **Optional `reason` parameter** appends timestamped UTC notes to test comment field via
  read-then-append pattern (data API), creating an audit trail for lifecycle actions
- **`hint_to_agent`** in response provides contextual LLM guidance per action
- **Bug fix**: `originalScenarioId` no longer populated for custom plans in queue payload
  (was incorrectly set from clone origin or plan ID)
- **Bug fix**: `get_api_base_url` content-manager calls now use `'playbook'` service type
  (content-manager is an API path, not a separate service)

## Test plan

- [x] 19 unit tests covering cancel/pause/resume, input validation, reason/notes,
  note resilience, and hint_to_agent
- [x] 3 E2E tests verified against real SafeBreach console (pentest01) — all include
  reason parameter with note read-back verification
- [x] 330 studio tests passing, 999 cross-server tests passing, 0 regressions
- [x] `originalScenarioId` fix verified: OOB includes it, custom plans omit it
- [x] content-manager → playbook service type fix verified across config + studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)