### PR TITLE
fix(config,studio): handle malformed scenario steps in readiness check

### DIFF
--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -130,6 +130,8 @@ def compute_is_ready_to_run(scenario: Dict[str, Any]) -> bool:
     if not steps:
         return False
     for step in steps:
+        if not isinstance(step, dict):
+            return False
         target = step.get('targetFilter', {})
         attacker = step.get('attackerFilter', {})
         if not _has_real_filter_criteria(target) or not _has_real_filter_criteria(attacker):

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -572,3 +572,37 @@ class TestPaginateScenarios:
         assert result["total_scenarios"] == 5
         assert len(result["scenarios_in_page"]) == 5
         assert result["hint_to_agent"] is None
+
+
+class TestMalformedScenarioSteps:
+    """Regression tests for malformed scenario data from content-manager API.
+
+    Staging (scenario index 218) has a scenario with id=None where steps[0]
+    is a list instead of a dict, causing 'list' object has no attribute 'get'.
+    """
+
+    def test_compute_is_ready_to_run_with_list_step(self):
+        """Steps containing a list instead of dict should not crash."""
+        scenario = {
+            "id": None,
+            "name": "Malformed scenario",
+            "steps": [
+                [{"name": "inner step", "targetFilter": {}, "attackerFilter": {}}]
+            ],
+        }
+        result = compute_is_ready_to_run(scenario)
+        assert result is False
+
+    def test_get_reduced_scenario_mapping_with_list_step(self):
+        """get_reduced_scenario_mapping should handle scenario with list-type step."""
+        scenario = {
+            "id": "abc-123",
+            "name": "Malformed scenario",
+            "steps": [
+                [{"name": "inner step"}]
+            ],
+            "categories": [],
+        }
+        result = get_reduced_scenario_mapping(scenario, {})
+        assert result["is_ready_to_run"] is False
+        assert result["step_count"] == 1

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -1683,6 +1683,8 @@ def compute_scenario_readiness(scenario):
     if not steps:
         return False
     for step in steps:
+        if not isinstance(step, dict):
+            return False
         target = step.get('targetFilter', {})
         attacker = step.get('attackerFilter', {})
         if not _has_real_filter_criteria(target) or not _has_real_filter_criteria(attacker):


### PR DESCRIPTION
## Summary

- Staging content-manager API returns a scenario (id=None, index 218) where `steps[0]` is a
  **list** instead of a dict, causing `AttributeError: 'list' object has no attribute 'get'`
  in `compute_is_ready_to_run` / `compute_scenario_readiness`
- Added `isinstance(step, dict)` guard in both `config_types.py` and `studio_functions.py` —
  non-dict steps are treated as not-ready
- Regression tests added in `TestMalformedScenarioSteps` (TDD: test-first, then fix)

## Test plan

- [x] 2 regression tests reproducing the exact bug (list-type step in scenario)
- [x] 414 config+studio tests passing, 0 regressions
- [x] Root cause confirmed via SSH into staging mcp-proxy container — scenario at
  index 218 has `steps[0]` as a list wrapping a dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)