### PR TITLE
SAF-29865: Add MCP ToolAnnotations to all tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ This MCP server enables AI agents to interact with SafeBreach management console
 **Additional Components:**
 - **`mcp_server_bug_423_hotfix.py`**: MCP initialization fix
 
+## Tool Annotations
+
+Every tool ships with MCP
+[`ToolAnnotations`](https://modelcontextprotocol.io/specification/server/tools#tool-annotations)
+so clients can decide whether to prompt the user before a call.
+
+| Hint | Use when the tool… |
+|---|---|
+| `readOnlyHint=True` | only fetches data — no state change on the console. |
+| `readOnlyHint=False`, `destructiveHint=False` | mutates user-owned drafts/templates and is reversible (e.g. `save_studio_attack_draft`). |
+| `readOnlyHint=False`, `destructiveHint=True` | triggers execution or changes shared/published state (e.g. `run_studio_attack`, `set_studio_attack_status`, `manage_test`). |
+
+When adding a tool, set it `readOnlyHint=True` unless it calls a
+state-changing API; if the effect can't be reversed from the same
+client, also set `destructiveHint=True`.
+
 ## Configuration
 Configuration of the SafeBreach MCP Server consists of:
 - Specifying which SafeBreach consoles are in scope for the MCP. For each SafeBreach console, provide the 'url', 'account' and the provider (method) for fetching the API key

--- a/prds/SAF-29865.md
+++ b/prds/SAF-29865.md
@@ -1,15 +1,10 @@
-# SAF-29865: Operator-pinned tool deny list + standard tool annotations
-
-## Overview
+# SAF-29865: Tool annotations + operator-pinned deny list
 
 Two additive changes to safebreach-mcp. Both are no-ops for deployments
 that don't opt in.
 
-- **Task Type**: Feature (API contract — additive, fully backwards compatible)
+- **Task Type**: Feature (additive, fully backwards compatible)
 - **Originating Request**: SAF-29865 — AI Agent: Support opt-in for AI related actions
-- **Scope (this repo)**: deploy-time operator pin list + tool annotations.
-  The customer-facing AI-actions gate (FF + per-account consent) is
-  enforced in `mcp-proxy` and does not touch this repo.
 
 ## Change 1 — `ToolAnnotations` on every tool
 
@@ -35,11 +30,6 @@ from mcp.types import ToolAnnotations
 **Why annotate:**
 - Spec-compliant clients (Claude Desktop, Cursor, IDE extensions, OpenAI
   Apps SDK) consume them without SafeBreach-specific knowledge.
-- mcp-proxy uses them to populate its write-tool deny set via FastMCP's
-  public `mcp.list_tools()` API — no hardcoded list, no string matching
-  on names.
-- breach-genie's per-action approval flow reads them to decide which
-  visible tools need a UI confirmation panel.
 - Pure metadata: doesn't change tool behavior or call-site contracts.
 
 **Classification shipped:**
@@ -54,11 +44,14 @@ from mcp.types import ToolAnnotations
 | Studio (writes, non-destructive) | `save_studio_attack_draft`, `update_studio_attack_draft`, `create_new_studio_attack` | False | False |
 | Studio (writes, destructive) | `run_studio_attack`, `set_studio_attack_status`, `run_scenario`, `manage_test` | False | True |
 
+See the [Tool Annotations](../README.md#tool-annotations) section in the
+README for the read/write/destructive semantics used to classify each
+tool.
+
 ## Change 2 — `DISABLE_TOOL_LIST` deny list in `SafeBreachMCPBase`
 
 A single deploy-time deny list. Configured via env var, re-read on every
-server start. Used by operators only — the customer-facing AI-actions gate
-lives in mcp-proxy.
+server start.
 
 ### Configuration
 
@@ -107,63 +100,11 @@ Python interpreter, not just restarting the server task. Re-reading
 inside `_install_disable_filtering` lets an operator change the deny
 list with a server restart (no full Python relaunch needed).
 
-## Architecture in context
-
-```
-┌──────────────────────────────────────────────────┐
-│  safebreach-mcp                                  │
-│  - reads DISABLE_TOOL_LIST at server start       │
-│  - hides listed tools (filter wraps FastMCP      │
-│    tool manager's list_tools and call_tool)      │
-│  - emits ToolAnnotations on every tool           │
-└──────────────────────────────────────────────────┘
-       ▲
-       │ MCP traffic
-       │
-┌──────────────────────────────────────────────────┐
-│  Direct consumers (Claude Desktop, Cursor, …)    │
-│  see the post-pin catalog. Done.                 │
-└──────────────────────────────────────────────────┘
-
-OR via SIMP:
-
-┌──────────────────────────────────────────────────┐
-│  mcp-proxy (SIMP)                                │
-│  Adds the AI-actions gate on top:                │
-│  - polls FF + per-account consent                │
-│  - on transition: rewrites DISABLE_TOOL_LIST     │
-│    env and SIGTERMs the proxy. Docker            │
-│    restart_policy: always brings it back; every  │
-│    safebreach-mcp server boots cold with the     │
-│    new deny list.                                │
-│  - gateway is pure transport plumbing, no        │
-│    wire-level filtering.                         │
-│  Discovers write tools via mcp.list_tools()      │
-│  reading the readOnlyHint annotations.           │
-└──────────────────────────────────────────────────┘
-       ▲
-       │
-┌──────────────────────────────────────────────────┐
-│  breach-genie (mastra MCPClient)                 │
-│  Recovery on proxy restart: per-server           │
-│  reconnectServer driven by                       │
-│  listToolsetsWithErrors.                         │
-└──────────────────────────────────────────────────┘
-```
-
-safebreach-mcp's contract is identical regardless of who's calling it.
-
 ## Out of scope
 
-- **Per-tool RBAC / per-user scopes.** SAF-29974 (architect's RBAC design)
-  covers per-user scoping and is layered on top of this work, not a
-  replacement.
+- **Per-tool RBAC / per-user scopes.** Layered on top, not a replacement.
 - **Dynamic reload of `DISABLE_TOOL_LIST` without restart.** Captured at
-  server-start time. Changing it requires restarting that server. Fine
-  for the intended use case (operator deploy-time pins).
-- **Customer-facing AI-actions gate.** mcp-proxy owns the FF + consent
-  poll and rewrites `DISABLE_TOOL_LIST` + SIGTERMs itself on a flip;
-  docker brings it back fresh. See SAF-29865 in `mcp-proxy`.
+  server-start time. Changing it requires restarting that server.
 
 ## Testing
 

--- a/prds/SAF-29865.md
+++ b/prds/SAF-29865.md
@@ -113,8 +113,8 @@ list with a server restart (no full Python relaunch needed).
 ┌──────────────────────────────────────────────────┐
 │  safebreach-mcp                                  │
 │  - reads DISABLE_TOOL_LIST at server start       │
-│  - hides listed tools forever (until restart)    │
-│  - operator deploy-time pins only                │
+│  - hides listed tools (filter wraps FastMCP      │
+│    tool manager's list_tools and call_tool)      │
 │  - emits ToolAnnotations on every tool           │
 └──────────────────────────────────────────────────┘
        ▲
@@ -131,10 +131,13 @@ OR via SIMP:
 │  mcp-proxy (SIMP)                                │
 │  Adds the AI-actions gate on top:                │
 │  - polls FF + per-account consent                │
-│  - filters tools/list further on the wire        │
-│  - rejects tools/call for write tools when gate  │
-│    is closed (JSON-RPC -32602)                   │
-│  - in-memory flag, no restart on flip            │
+│  - on transition: rewrites DISABLE_TOOL_LIST     │
+│    env and SIGTERMs the proxy. Docker            │
+│    restart_policy: always brings it back; every  │
+│    safebreach-mcp server boots cold with the     │
+│    new deny list.                                │
+│  - gateway is pure transport plumbing, no        │
+│    wire-level filtering.                         │
 │  Discovers write tools via mcp.list_tools()      │
 │  reading the readOnlyHint annotations.           │
 └──────────────────────────────────────────────────┘
@@ -142,6 +145,9 @@ OR via SIMP:
        │
 ┌──────────────────────────────────────────────────┐
 │  breach-genie (mastra MCPClient)                 │
+│  Recovery on proxy restart: per-server           │
+│  reconnectServer driven by                       │
+│  listToolsetsWithErrors.                         │
 └──────────────────────────────────────────────────┘
 ```
 
@@ -155,9 +161,9 @@ safebreach-mcp's contract is identical regardless of who's calling it.
 - **Dynamic reload of `DISABLE_TOOL_LIST` without restart.** Captured at
   server-start time. Changing it requires restarting that server. Fine
   for the intended use case (operator deploy-time pins).
-- **Customer-facing AI-actions gate.** Enforced at the proxy edge in
-  mcp-proxy and takes effect on the next request without any restart.
-  See SAF-29865 in `mcp-proxy`.
+- **Customer-facing AI-actions gate.** mcp-proxy owns the FF + consent
+  poll and rewrites `DISABLE_TOOL_LIST` + SIGTERMs itself on a flip;
+  docker brings it back fresh. See SAF-29865 in `mcp-proxy`.
 
 ## Testing
 

--- a/prds/SAF-29865.md
+++ b/prds/SAF-29865.md
@@ -1,0 +1,319 @@
+# SAF-29865: Per-tool disable mechanism for AI actions opt-in
+
+## Overview
+
+- **Task Type**: Feature (API contract — additive, fully backwards compatible)
+- **Purpose**: Let callers opt into hiding a server-configured list of tools for a single request
+  — without breaking any existing consumer.
+- **Target Consumer**: Initially the SafeBreach Internal MCP Proxy (SIMP), which decides per account
+  whether AI write actions are allowed (feature flag + customer consent) and asks the MCP server
+  to hide the write tools when they aren't. The mechanism is generic, so any MCP client can adopt it.
+- **Originating Request**: SAF-29865 — AI Agent: Support opt-in for AI related actions
+
+## Design motivation — what changed from the first design round
+
+The first iteration used an `X-MCP-Mode: read|readwrite` header where the _client_ declared the
+mode it wanted and the server filtered based on `readOnlyHint` annotations. Internal review
+pushed back on that shape: the **server's policy** (what counts as "off limits") was effectively
+being dictated by the client header, which inverts ownership of the decision.
+
+This design moves ownership to the right places:
+
+- **safebreach-mcp owns _what_ can be hidden** — the operator sets `DISABLE_TOOL_LIST` at deploy
+  time with the exact list of tool names that are eligible for gating. The server never relies on
+  the client to tell it which tools are "write tools."
+- **The caller (mcp-proxy) owns _when_ to hide them** — it flips the `X-Disable-Tools` header
+  based on its own policy decision (FF + consent), which is cached and refreshed on its existing
+  polling loop.
+- **Annotations are preserved** for every tool because they're still useful to downstream
+  consumers (Claude Desktop, Cursor, any MCP client) and they match the protocol spec — but they
+  no longer drive the server-side filter.
+
+## Problem
+
+Today every MCP tool is exposed unconditionally. A consumer that needs to hide specific tools on
+a per-request basis (e.g. when a customer hasn't opted in to AI actions) has no way to ask for a
+filtered view, and the server has no way to refuse a `tools/call` for one of those tools.
+
+We need a mechanism that:
+1. Lets an operator declare, at deploy time, the exact list of tool names that _may_ be hidden.
+2. Lets a caller signal per-request "apply your configured disable list to this one."
+3. Filters those names out of `tools/list` responses for that request.
+4. Refuses `tools/call` invocations of those names for that request (defense in depth).
+5. **Does not change behavior for any existing consumer that doesn't send the signal, or on
+   any deployment that doesn't configure the env var.**
+
+## Solution
+
+Two additive changes — both are no-ops for deployments that don't opt in.
+
+### Change 1 — Annotate every tool (unchanged in shape from the first design)
+
+Add MCP standard `ToolAnnotations` (from `mcp.types`) to every `@self.mcp.tool(...)` registration
+across all five servers.
+
+```python
+from mcp.types import ToolAnnotations
+
+@self.mcp.tool(
+    name="get_tests_history",
+    annotations=ToolAnnotations(readOnlyHint=True),
+    description="...",
+)
+
+@self.mcp.tool(
+    name="run_studio_attack",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    description="...",
+)
+```
+
+**Why keep annotations even though they no longer drive the server filter:**
+- They're the MCP spec's official metadata for tool behavior — any spec-compliant client
+  (Claude Desktop, Cursor, IDE extensions, OpenAI Apps SDK) can consume them without
+  SafeBreach-specific knowledge.
+- A client-side consumer (breach-genie, for example) can still use them to decide whether a tool
+  needs a UI confirmation panel, regardless of what the server gate decides.
+- They're pure metadata — they don't change tool behavior or call-site contracts, so they're
+  strictly additive for all consumers.
+
+**Tool classification shipped in this PR:**
+
+| Server | Tools | `readOnlyHint` | `destructiveHint` |
+|--------|-------|:---:|:---:|
+| Config | `get_console_simulators`, `get_simulator_details`, `get_scenarios`, `get_scenario_details` | True | — |
+| Data | all 15 `get_*` tools | True | — |
+| Utilities | `convert_datetime_to_epoch`, `convert_epoch_to_datetime` | True | — |
+| Playbook | `get_playbook_attacks`, `get_playbook_attack_details` | True | — |
+| Studio | `validate_studio_code`, `get_all_studio_attacks`, `get_studio_attack_source`, `get_studio_attack_latest_result`, `create_new_studio_attack` | True | — |
+| Studio | `save_studio_attack_draft`, `update_studio_attack_draft` | False | False (additive write) |
+| Studio | `run_studio_attack`, `set_studio_attack_status`, `run_scenario` | False | True (destructive) |
+
+### Change 2 — Two filter layers in `SafeBreachMCPBase`: `DISABLE_TOOL_LIST` (absolute deny) + `X-Disable-Tools` header (write-tool gate)
+
+The filter has **two independent layers** that compose. The deny list trumps everything; the
+write-tool gate sits below it and only affects tools that are not deny-listed.
+
+#### Layer 1 — `DISABLE_TOOL_LIST` (operator-owned, absolute)
+
+Environment variable set at server startup:
+
+```bash
+DISABLE_TOOL_LIST='["save_studio_attack_draft","update_studio_attack_draft","run_studio_attack","set_studio_attack_status","run_scenario"]'
+```
+
+- JSON array of tool names, parsed once at module load into a `frozenset`.
+- Invalid JSON, wrong shape, or non-string elements → logged and treated as empty.
+- Tools whose names appear here are **always** stripped from `tools/list` and rejected by
+  `tools/call`, regardless of header, FF, or consent. The only way to re-enable a tool is to
+  remove it from the env var and restart the server.
+- Empty / missing env var → Layer 1 is a no-op.
+
+#### Layer 2 — `X-Disable-Tools` header (write-tool gate)
+
+Per-request HTTP header read by ASGI middleware in `SafeBreachMCPBase`:
+
+```
+X-Disable-Tools: true
+```
+
+- Only the literal `"true"` (case-insensitive) closes the gate. Anything else opens it.
+- The middleware stashes the decoded boolean into a `ContextVar` consumed by the tool-manager
+  wrappers.
+- When the gate is **closed** (header is `"true"`):
+  - `tools/list` additionally filters out any tool whose annotation `readOnlyHint != True`
+  - `tools/call` additionally rejects any non-deny-listed tool whose annotation
+    `readOnlyHint != True` with a `ToolError` referencing the "AI actions are not enabled"
+    message
+  - Tools without annotations fail safe — treated as write
+- When the gate is **open** (no header, or `false`/anything-else):
+  - `tools/list` and `tools/call` operate normally on Layer-1-surviving tools
+
+#### Combined truth table
+
+`DISABLE_TOOL_LIST = ["banned"]`. Three example tools — `banned` (write, deny-listed),
+`writable` (write, not deny-listed), `safe` (read-only).
+
+| `X-Disable-Tools` | `banned` | `writable` | `safe` |
+|---|:---:|:---:|:---:|
+| absent (gate open) | hidden / blocked | visible / runs | visible / runs |
+| `true` (gate closed) | hidden / blocked | hidden / blocked | visible / runs |
+
+`banned` is unreachable in every state. `writable` becomes reachable only when the gate opens.
+`safe` is always reachable.
+
+#### Who sends the header
+
+In this deployment topology, SIMP is the sole sender of `X-Disable-Tools`. It builds the gate
+state from the account's feature flag (`feature.performActionsByAiAgent`, content-manager KB)
+and consent setting (`enableAiAgentActions`, Configuration service), refreshes on the existing
+5-minute polling cycle, and injects `X-Disable-Tools: true` on every outgoing MCP forward when
+either input is missing/false. See the mcp-proxy PR for the counterpart.
+
+#### How `breach-genie` sees the catalog
+
+breach-genie's `MCPClient` calls `tools/list` per session through SIMP. The catalog it receives
+is the **post-filter** result — both layers have already been applied at safebreach-mcp before
+SIMP forwards the response back. This means:
+
+- breach-genie's LLM never knows about deny-listed tools (Layer 1).
+- breach-genie's LLM never knows about write tools when the gate is closed (Layer 2).
+- breach-genie's `requireToolApproval` (mastra 1.5.0) can still wrap any visible write tool with
+  per-call human approval — that's an additive client-side defense; it does not affect the
+  server-side filter.
+
+#### Why two layers and not one
+
+A single switch can't satisfy both requirements:
+
+- **Deny list (Layer 1) without a gate**: would force operators to redeploy to enable / disable
+  AI actions for an account. Too coarse.
+- **Gate (Layer 2) without a deny list**: once the gate opens, every write tool — including the
+  most dangerous ones — becomes reachable. Until SAF-29974 (per-user RBAC + auditing) ships,
+  some tools should remain unreachable even on accounts that have opted into AI actions.
+
+Two layers let the operator carve out a hard-no list (deny) while still gating the
+account-level opt-in (gate). When RBAC + auditing ship, operators remove tools from the deny
+list as they become safe to expose; the gate continues to control the account-level switch.
+
+#### Defense in depth
+
+Filtering happens on both `tools/list` (well-behaved clients never see the filtered tools) and
+`tools/call` (server refuses execution for stale or misbehaving clients that try anyway).
+
+### Changes to `safebreach_mcp_core/safebreach_base.py`
+
+**1. Parse the env var once at module load:**
+
+```python
+def _parse_disable_tool_list() -> frozenset[str]:
+    raw = os.environ.get('DISABLE_TOOL_LIST', '').strip()
+    if not raw:
+        return frozenset()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.error(f"Invalid DISABLE_TOOL_LIST JSON, ignoring: {exc}")
+        return frozenset()
+    if not isinstance(parsed, list) or not all(isinstance(n, str) for n in parsed):
+        logger.error("DISABLE_TOOL_LIST must be a JSON array of strings, ignoring")
+        return frozenset()
+    return frozenset(n for n in parsed if n)
+
+_DISABLE_TOOL_LIST: frozenset[str] = _parse_disable_tool_list()
+```
+
+**2. Per-request ContextVar for the header's decoded value:**
+
+```python
+_disable_tools_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    'disable_tools_flag', default=False
+)
+```
+
+**3. Tool-manager wrapping (idempotent, short-circuits when the list is empty):**
+
+```python
+def _apply_disable_filtering(self) -> None:
+    if self._disable_filtering_applied:
+        return
+    self._disable_filtering_applied = True
+    if not _DISABLE_TOOL_LIST:
+        logger.info('DISABLE_TOOL_LIST is empty; tool-disable filtering is inert')
+        return
+
+    from mcp.server.fastmcp.exceptions import ToolError
+    tool_manager = self.mcp._tool_manager
+    original_list_tools = tool_manager.list_tools
+    original_call_tool = tool_manager.call_tool
+
+    def filtered_list_tools():
+        tools = original_list_tools()
+        if _disable_tools_flag.get():
+            return [t for t in tools if t.name not in _DISABLE_TOOL_LIST]
+        return tools
+
+    async def filtered_call_tool(name, arguments, context=None, convert_result=False):
+        if _disable_tools_flag.get() and name in _DISABLE_TOOL_LIST:
+            raise ToolError(
+                f"Tool '{name}' is not available. "
+                "AI actions are not enabled for this account. "
+                "Please contact your administrator to enable the 'Perform Actions by AI Agent' setting."
+            )
+        return await original_call_tool(name, arguments, context=context, convert_result=convert_result)
+
+    tool_manager.list_tools = filtered_list_tools
+    tool_manager.call_tool = filtered_call_tool
+```
+
+**4. ASGI middleware that reads the header:**
+
+```python
+def _create_disable_aware_app(self, original_app):
+    async def disable_aware_app(scope, receive, send):
+        if scope["type"] == "http":
+            headers = dict(scope.get("headers", []))
+            raw = headers.get(b"x-disable-tools", b"").decode("utf-8", errors="replace").strip().lower()
+            _disable_tools_flag.set(raw == "true")
+        return await original_app(scope, receive, send)
+    return disable_aware_app
+```
+
+**5. Wire both into `run_server` (same pattern as the existing concurrency limiter):**
+
+```python
+self._apply_disable_filtering()              # patches tool manager once; no-op if env var empty
+# ... existing auth wrapper ...
+app = self._create_disable_aware_app(app)    # reads X-Disable-Tools per request
+app = self._create_concurrency_limited_app(app, transport=transport, endpoint_path=endpoint_path)
+```
+
+## Out of scope
+
+- **Per-tool RBAC / per-user scopes.** The same middleware shape extends naturally — swap the
+  boolean flag for a scope set and the predicate for a membership check — without changing the
+  request contract or the env-var ownership model. SAF-29974 (architect's RBAC design) covers
+  that direction and is explicitly layered on top of this work, not a replacement.
+- **Dynamic reload of `DISABLE_TOOL_LIST`.** The list is read once at module load. Operators
+  change it via a server restart, which matches how every other server-side env var in this repo
+  behaves.
+
+## Testing
+
+### Existing suites
+All 414 non-e2e tests in the repo pass unchanged (core, config, data, playbook, studio,
+utilities, authentication). No behavior change for any consumer that doesn't opt in.
+
+### New tests — `safebreach_mcp_core/tests/test_disable_filtering.py`
+21 cases across 5 classes:
+
+**`TestParseDisableToolList`** — env var parsing
+- missing → empty
+- empty string → empty
+- valid JSON array → parsed as frozenset
+- blank names in the list → stripped
+- invalid JSON → logged + empty
+- JSON object instead of array → logged + empty
+- non-string elements in the array → logged + empty
+
+**`TestListToolsFiltering`**
+- no header (flag False) → all tools visible
+- flag True → configured names hidden
+- empty env var → flag True is a no-op (all tools visible)
+- tools not in the list are visible even when flag is on
+
+**`TestCallToolBlocking`**
+- flag False → call succeeds
+- flag True + name in list → `ToolError`
+- flag True + name NOT in list → call succeeds
+
+**`TestDisableAwareAsgiMiddleware`**
+- `x-disable-tools: true` sets the flag
+- `x-disable-tools: TRUE` also sets the flag (case-insensitive)
+- `x-disable-tools: false` clears the flag
+- missing header → flag defaults to False
+- garbage value (`"maybe"`) → flag defaults to False
+- non-http scope (websocket) → middleware passes through without touching the flag
+
+**`TestApplyDisableFilteringIdempotent`**
+- calling `_apply_disable_filtering` twice does not stack wrappers; filtering still works

--- a/prds/SAF-29865.md
+++ b/prds/SAF-29865.md
@@ -1,56 +1,20 @@
-# SAF-29865: Per-tool disable mechanism for AI actions opt-in
+# SAF-29865: Operator-pinned tool deny list + standard tool annotations
 
 ## Overview
 
+Two additive changes to safebreach-mcp. Both are no-ops for deployments
+that don't opt in.
+
 - **Task Type**: Feature (API contract — additive, fully backwards compatible)
-- **Purpose**: Let callers opt into hiding a server-configured list of tools for a single request
-  — without breaking any existing consumer.
-- **Target Consumer**: Initially the SafeBreach Internal MCP Proxy (SIMP), which decides per account
-  whether AI write actions are allowed (feature flag + customer consent) and asks the MCP server
-  to hide the write tools when they aren't. The mechanism is generic, so any MCP client can adopt it.
 - **Originating Request**: SAF-29865 — AI Agent: Support opt-in for AI related actions
+- **Scope (this repo)**: deploy-time operator pin list + tool annotations.
+  The customer-facing AI-actions gate (FF + per-account consent) is
+  enforced in `mcp-proxy` and does not touch this repo.
 
-## Design motivation — what changed from the first design round
+## Change 1 — `ToolAnnotations` on every tool
 
-The first iteration used an `X-MCP-Mode: read|readwrite` header where the _client_ declared the
-mode it wanted and the server filtered based on `readOnlyHint` annotations. Internal review
-pushed back on that shape: the **server's policy** (what counts as "off limits") was effectively
-being dictated by the client header, which inverts ownership of the decision.
-
-This design moves ownership to the right places:
-
-- **safebreach-mcp owns _what_ can be hidden** — the operator sets `DISABLE_TOOL_LIST` at deploy
-  time with the exact list of tool names that are eligible for gating. The server never relies on
-  the client to tell it which tools are "write tools."
-- **The caller (mcp-proxy) owns _when_ to hide them** — it flips the `X-Disable-Tools` header
-  based on its own policy decision (FF + consent), which is cached and refreshed on its existing
-  polling loop.
-- **Annotations are preserved** for every tool because they're still useful to downstream
-  consumers (Claude Desktop, Cursor, any MCP client) and they match the protocol spec — but they
-  no longer drive the server-side filter.
-
-## Problem
-
-Today every MCP tool is exposed unconditionally. A consumer that needs to hide specific tools on
-a per-request basis (e.g. when a customer hasn't opted in to AI actions) has no way to ask for a
-filtered view, and the server has no way to refuse a `tools/call` for one of those tools.
-
-We need a mechanism that:
-1. Lets an operator declare, at deploy time, the exact list of tool names that _may_ be hidden.
-2. Lets a caller signal per-request "apply your configured disable list to this one."
-3. Filters those names out of `tools/list` responses for that request.
-4. Refuses `tools/call` invocations of those names for that request (defense in depth).
-5. **Does not change behavior for any existing consumer that doesn't send the signal, or on
-   any deployment that doesn't configure the env var.**
-
-## Solution
-
-Two additive changes — both are no-ops for deployments that don't opt in.
-
-### Change 1 — Annotate every tool (unchanged in shape from the first design)
-
-Add MCP standard `ToolAnnotations` (from `mcp.types`) to every `@self.mcp.tool(...)` registration
-across all five servers.
+Adds standard MCP `ToolAnnotations` (from `mcp.types`) to every
+`@self.mcp.tool(...)` registration across all servers.
 
 ```python
 from mcp.types import ToolAnnotations
@@ -68,16 +32,17 @@ from mcp.types import ToolAnnotations
 )
 ```
 
-**Why keep annotations even though they no longer drive the server filter:**
-- They're the MCP spec's official metadata for tool behavior — any spec-compliant client
-  (Claude Desktop, Cursor, IDE extensions, OpenAI Apps SDK) can consume them without
-  SafeBreach-specific knowledge.
-- A client-side consumer (breach-genie, for example) can still use them to decide whether a tool
-  needs a UI confirmation panel, regardless of what the server gate decides.
-- They're pure metadata — they don't change tool behavior or call-site contracts, so they're
-  strictly additive for all consumers.
+**Why annotate:**
+- Spec-compliant clients (Claude Desktop, Cursor, IDE extensions, OpenAI
+  Apps SDK) consume them without SafeBreach-specific knowledge.
+- mcp-proxy uses them to populate its write-tool deny set via FastMCP's
+  public `mcp.list_tools()` API — no hardcoded list, no string matching
+  on names.
+- breach-genie's per-action approval flow reads them to decide which
+  visible tools need a UI confirmation panel.
+- Pure metadata: doesn't change tool behavior or call-site contracts.
 
-**Tool classification shipped in this PR:**
+**Classification shipped:**
 
 | Server | Tools | `readOnlyHint` | `destructiveHint` |
 |--------|-------|:---:|:---:|
@@ -85,235 +50,138 @@ from mcp.types import ToolAnnotations
 | Data | all 15 `get_*` tools | True | — |
 | Utilities | `convert_datetime_to_epoch`, `convert_epoch_to_datetime` | True | — |
 | Playbook | `get_playbook_attacks`, `get_playbook_attack_details` | True | — |
-| Studio | `validate_studio_code`, `get_all_studio_attacks`, `get_studio_attack_source`, `get_studio_attack_latest_result`, `create_new_studio_attack` | True | — |
-| Studio | `save_studio_attack_draft`, `update_studio_attack_draft` | False | False (additive write) |
-| Studio | `run_studio_attack`, `set_studio_attack_status`, `run_scenario` | False | True (destructive) |
+| Studio (reads) | `validate_studio_code`, `get_all_studio_attacks`, `get_studio_attack_source`, `get_studio_attack_latest_result` | True | — |
+| Studio (writes, non-destructive) | `save_studio_attack_draft`, `update_studio_attack_draft`, `create_new_studio_attack` | False | False |
+| Studio (writes, destructive) | `run_studio_attack`, `set_studio_attack_status`, `run_scenario`, `manage_test` | False | True |
 
-### Change 2 — Two filter layers in `SafeBreachMCPBase`: `DISABLE_TOOL_LIST` (absolute deny) + `X-Disable-Tools` header (write-tool gate)
+## Change 2 — `DISABLE_TOOL_LIST` deny list in `SafeBreachMCPBase`
 
-The filter has **two independent layers** that compose. The deny list trumps everything; the
-write-tool gate sits below it and only affects tools that are not deny-listed.
+A single deploy-time deny list. Configured via env var, re-read on every
+server start. Used by operators only — the customer-facing AI-actions gate
+lives in mcp-proxy.
 
-#### Layer 1 — `DISABLE_TOOL_LIST` (operator-owned, absolute)
-
-Environment variable set at server startup:
+### Configuration
 
 ```bash
-DISABLE_TOOL_LIST='["save_studio_attack_draft","update_studio_attack_draft","run_studio_attack","set_studio_attack_status","run_scenario"]'
+DISABLE_TOOL_LIST='["save_studio_attack_draft","run_studio_attack",...]'
 ```
 
-- JSON array of tool names, parsed once at module load into a `frozenset`.
-- Invalid JSON, wrong shape, or non-string elements → logged and treated as empty.
-- Tools whose names appear here are **always** stripped from `tools/list` and rejected by
-  `tools/call`, regardless of header, FF, or consent. The only way to re-enable a tool is to
-  remove it from the env var and restart the server.
-- Empty / missing env var → Layer 1 is a no-op.
+- JSON array of tool names.
+- Invalid JSON, wrong shape, or non-string elements → logged and treated as
+  empty (fail-open on parse error matches the no-env-var behavior).
+- Empty / missing env var → filter is a no-op.
 
-#### Layer 2 — `X-Disable-Tools` header (write-tool gate)
+### Behavior
 
-Per-request HTTP header read by ASGI middleware in `SafeBreachMCPBase`:
+`_install_disable_filtering` runs once at the start of `run_server`:
 
-```
-X-Disable-Tools: true
-```
-
-- Only the literal `"true"` (case-insensitive) closes the gate. Anything else opens it.
-- The middleware stashes the decoded boolean into a `ContextVar` consumed by the tool-manager
-  wrappers.
-- When the gate is **closed** (header is `"true"`):
-  - `tools/list` additionally filters out any tool whose annotation `readOnlyHint != True`
-  - `tools/call` additionally rejects any non-deny-listed tool whose annotation
-    `readOnlyHint != True` with a `ToolError` referencing the "AI actions are not enabled"
-    message
-  - Tools without annotations fail safe — treated as write
-- When the gate is **open** (no header, or `false`/anything-else):
-  - `tools/list` and `tools/call` operate normally on Layer-1-surviving tools
-
-#### Combined truth table
-
-`DISABLE_TOOL_LIST = ["banned"]`. Three example tools — `banned` (write, deny-listed),
-`writable` (write, not deny-listed), `safe` (read-only).
-
-| `X-Disable-Tools` | `banned` | `writable` | `safe` |
-|---|:---:|:---:|:---:|
-| absent (gate open) | hidden / blocked | visible / runs | visible / runs |
-| `true` (gate closed) | hidden / blocked | hidden / blocked | visible / runs |
-
-`banned` is unreachable in every state. `writable` becomes reachable only when the gate opens.
-`safe` is always reachable.
-
-#### Who sends the header
-
-In this deployment topology, SIMP is the sole sender of `X-Disable-Tools`. It builds the gate
-state from the account's feature flag (`feature.performActionsByAiAgent`, content-manager KB)
-and consent setting (`enableAiAgentActions`, Configuration service), refreshes on the existing
-5-minute polling cycle, and injects `X-Disable-Tools: true` on every outgoing MCP forward when
-either input is missing/false. See the mcp-proxy PR for the counterpart.
-
-#### How `breach-genie` sees the catalog
-
-breach-genie's `MCPClient` calls `tools/list` per session through SIMP. The catalog it receives
-is the **post-filter** result — both layers have already been applied at safebreach-mcp before
-SIMP forwards the response back. This means:
-
-- breach-genie's LLM never knows about deny-listed tools (Layer 1).
-- breach-genie's LLM never knows about write tools when the gate is closed (Layer 2).
-- breach-genie's `requireToolApproval` (mastra 1.5.0) can still wrap any visible write tool with
-  per-call human approval — that's an additive client-side defense; it does not affect the
-  server-side filter.
-
-#### Why two layers and not one
-
-A single switch can't satisfy both requirements:
-
-- **Deny list (Layer 1) without a gate**: would force operators to redeploy to enable / disable
-  AI actions for an account. Too coarse.
-- **Gate (Layer 2) without a deny list**: once the gate opens, every write tool — including the
-  most dangerous ones — becomes reachable. Until SAF-29974 (per-user RBAC + auditing) ships,
-  some tools should remain unreachable even on accounts that have opted into AI actions.
-
-Two layers let the operator carve out a hard-no list (deny) while still gating the
-account-level opt-in (gate). When RBAC + auditing ship, operators remove tools from the deny
-list as they become safe to expose; the gate continues to control the account-level switch.
-
-#### Defense in depth
-
-Filtering happens on both `tools/list` (well-behaved clients never see the filtered tools) and
-`tools/call` (server refuses execution for stale or misbehaving clients that try anyway).
-
-### Changes to `safebreach_mcp_core/safebreach_base.py`
-
-**1. Parse the env var once at module load:**
+1. Re-reads `DISABLE_TOOL_LIST` from the environment and parses it via
+   `_parse_disable_tool_list`.
+2. Wraps the FastMCP tool manager's `list_tools` and `call_tool`:
 
 ```python
-def _parse_disable_tool_list() -> frozenset[str]:
-    raw = os.environ.get('DISABLE_TOOL_LIST', '').strip()
-    if not raw:
-        return frozenset()
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.error(f"Invalid DISABLE_TOOL_LIST JSON, ignoring: {exc}")
-        return frozenset()
-    if not isinstance(parsed, list) or not all(isinstance(n, str) for n in parsed):
-        logger.error("DISABLE_TOOL_LIST must be a JSON array of strings, ignoring")
-        return frozenset()
-    return frozenset(n for n in parsed if n)
+def filtered_list_tools():
+    tools = original_list_tools()
+    if deny_list:
+        tools = [t for t in tools if t.name not in deny_list]
+    return tools
 
-_DISABLE_TOOL_LIST: frozenset[str] = _parse_disable_tool_list()
+async def filtered_call_tool(name, arguments, ...):
+    if name in deny_list:
+        raise ToolError(
+            f"Tool '{name}' is not available. "
+            "This tool has been disabled by the server administrator."
+        )
+    return await original_call_tool(name, arguments, ...)
 ```
 
-**2. Per-request ContextVar for the header's decoded value:**
+Defense in depth: filtering happens on both `tools/list` (well-behaved
+clients never see hidden tools) and `tools/call` (refuses execution for
+stale or misbehaving clients).
 
-```python
-_disable_tools_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    'disable_tools_flag', default=False
-)
+### Why re-read on every install (not module-level)
+
+Earlier rounds parsed the env var **once at module import time**. That
+prevented changing the deny list at runtime — required forking a new
+Python interpreter, not just restarting the server task. Re-reading
+inside `_install_disable_filtering` lets an operator change the deny
+list with a server restart (no full Python relaunch needed).
+
+## Architecture in context
+
+```
+┌──────────────────────────────────────────────────┐
+│  safebreach-mcp                                  │
+│  - reads DISABLE_TOOL_LIST at server start       │
+│  - hides listed tools forever (until restart)    │
+│  - operator deploy-time pins only                │
+│  - emits ToolAnnotations on every tool           │
+└──────────────────────────────────────────────────┘
+       ▲
+       │ MCP traffic
+       │
+┌──────────────────────────────────────────────────┐
+│  Direct consumers (Claude Desktop, Cursor, …)    │
+│  see the post-pin catalog. Done.                 │
+└──────────────────────────────────────────────────┘
+
+OR via SIMP:
+
+┌──────────────────────────────────────────────────┐
+│  mcp-proxy (SIMP)                                │
+│  Adds the AI-actions gate on top:                │
+│  - polls FF + per-account consent                │
+│  - filters tools/list further on the wire        │
+│  - rejects tools/call for write tools when gate  │
+│    is closed (JSON-RPC -32602)                   │
+│  - in-memory flag, no restart on flip            │
+│  Discovers write tools via mcp.list_tools()      │
+│  reading the readOnlyHint annotations.           │
+└──────────────────────────────────────────────────┘
+       ▲
+       │
+┌──────────────────────────────────────────────────┐
+│  breach-genie (mastra MCPClient)                 │
+└──────────────────────────────────────────────────┘
 ```
 
-**3. Tool-manager wrapping (idempotent, short-circuits when the list is empty):**
-
-```python
-def _apply_disable_filtering(self) -> None:
-    if self._disable_filtering_applied:
-        return
-    self._disable_filtering_applied = True
-    if not _DISABLE_TOOL_LIST:
-        logger.info('DISABLE_TOOL_LIST is empty; tool-disable filtering is inert')
-        return
-
-    from mcp.server.fastmcp.exceptions import ToolError
-    tool_manager = self.mcp._tool_manager
-    original_list_tools = tool_manager.list_tools
-    original_call_tool = tool_manager.call_tool
-
-    def filtered_list_tools():
-        tools = original_list_tools()
-        if _disable_tools_flag.get():
-            return [t for t in tools if t.name not in _DISABLE_TOOL_LIST]
-        return tools
-
-    async def filtered_call_tool(name, arguments, context=None, convert_result=False):
-        if _disable_tools_flag.get() and name in _DISABLE_TOOL_LIST:
-            raise ToolError(
-                f"Tool '{name}' is not available. "
-                "AI actions are not enabled for this account. "
-                "Please contact your administrator to enable the 'Perform Actions by AI Agent' setting."
-            )
-        return await original_call_tool(name, arguments, context=context, convert_result=convert_result)
-
-    tool_manager.list_tools = filtered_list_tools
-    tool_manager.call_tool = filtered_call_tool
-```
-
-**4. ASGI middleware that reads the header:**
-
-```python
-def _create_disable_aware_app(self, original_app):
-    async def disable_aware_app(scope, receive, send):
-        if scope["type"] == "http":
-            headers = dict(scope.get("headers", []))
-            raw = headers.get(b"x-disable-tools", b"").decode("utf-8", errors="replace").strip().lower()
-            _disable_tools_flag.set(raw == "true")
-        return await original_app(scope, receive, send)
-    return disable_aware_app
-```
-
-**5. Wire both into `run_server` (same pattern as the existing concurrency limiter):**
-
-```python
-self._apply_disable_filtering()              # patches tool manager once; no-op if env var empty
-# ... existing auth wrapper ...
-app = self._create_disable_aware_app(app)    # reads X-Disable-Tools per request
-app = self._create_concurrency_limited_app(app, transport=transport, endpoint_path=endpoint_path)
-```
+safebreach-mcp's contract is identical regardless of who's calling it.
 
 ## Out of scope
 
-- **Per-tool RBAC / per-user scopes.** The same middleware shape extends naturally — swap the
-  boolean flag for a scope set and the predicate for a membership check — without changing the
-  request contract or the env-var ownership model. SAF-29974 (architect's RBAC design) covers
-  that direction and is explicitly layered on top of this work, not a replacement.
-- **Dynamic reload of `DISABLE_TOOL_LIST`.** The list is read once at module load. Operators
-  change it via a server restart, which matches how every other server-side env var in this repo
-  behaves.
+- **Per-tool RBAC / per-user scopes.** SAF-29974 (architect's RBAC design)
+  covers per-user scoping and is layered on top of this work, not a
+  replacement.
+- **Dynamic reload of `DISABLE_TOOL_LIST` without restart.** Captured at
+  server-start time. Changing it requires restarting that server. Fine
+  for the intended use case (operator deploy-time pins).
+- **Customer-facing AI-actions gate.** Enforced at the proxy edge in
+  mcp-proxy and takes effect on the next request without any restart.
+  See SAF-29865 in `mcp-proxy`.
 
 ## Testing
 
 ### Existing suites
-All 414 non-e2e tests in the repo pass unchanged (core, config, data, playbook, studio,
-utilities, authentication). No behavior change for any consumer that doesn't opt in.
+All 1085 non-e2e tests in the repo pass unchanged. No behavior change for
+any consumer that doesn't opt in.
 
 ### New tests — `safebreach_mcp_core/tests/test_disable_filtering.py`
-21 cases across 5 classes:
+
+12 cases across 2 classes.
 
 **`TestParseDisableToolList`** — env var parsing
 - missing → empty
 - empty string → empty
 - valid JSON array → parsed as frozenset
-- blank names in the list → stripped
+- blank names → stripped
 - invalid JSON → logged + empty
 - JSON object instead of array → logged + empty
-- non-string elements in the array → logged + empty
+- non-string elements → logged + empty
 
-**`TestListToolsFiltering`**
-- no header (flag False) → all tools visible
-- flag True → configured names hidden
-- empty env var → flag True is a no-op (all tools visible)
-- tools not in the list are visible even when flag is on
-
-**`TestCallToolBlocking`**
-- flag False → call succeeds
-- flag True + name in list → `ToolError`
-- flag True + name NOT in list → call succeeds
-
-**`TestDisableAwareAsgiMiddleware`**
-- `x-disable-tools: true` sets the flag
-- `x-disable-tools: TRUE` also sets the flag (case-insensitive)
-- `x-disable-tools: false` clears the flag
-- missing header → flag defaults to False
-- garbage value (`"maybe"`) → flag defaults to False
-- non-http scope (websocket) → middleware passes through without touching the flag
-
-**`TestApplyDisableFilteringIdempotent`**
-- calling `_apply_disable_filtering` twice does not stack wrappers; filtering still works
+**`TestDenyList`** — runtime filtering
+- listed tool hidden from `tools/list`
+- listed tool call raises `ToolError`
+- empty deny list → all tools visible (passthrough)
+- unlisted tool calls succeed even when other tools are denied
+- env-var change between two `_install_disable_filtering` calls takes
+  effect (proves the restart-with-new-value contract is sound)

--- a/safebreach_mcp_config/config_server.py
+++ b/safebreach_mcp_config/config_server.py
@@ -13,6 +13,7 @@ from typing import Optional
 # Add parent directory to path to import core components
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from mcp.types import ToolAnnotations
 from safebreach_mcp_core import SafeBreachMCPBase
 from .config_functions import (
     sb_get_console_simulators,
@@ -40,6 +41,7 @@ class SafeBreachConfigServer(SafeBreachMCPBase):
         
         @self.mcp.tool(
             name="get_console_simulators",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered list of Safebreach simulators linked to a given Safebreach management console.
 Supports filtering by status, name, labels, OS type, and critical status. Results are ordered by name (ascending) by default.
 Parameters: console (required), status_filter ('connected'/'disconnected'/'enabled'/'disabled'/None), name_filter (partial name match), 
@@ -74,6 +76,7 @@ label_filter (partial label match), os_type_filter (OS type match), critical_onl
         
         @self.mcp.tool(
             name="get_simulator_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="Gets the full details of a specific Safebreach simulator and the host on which it is running"
         )
         async def get_simulator_details_tool(simulator_id: str, console: str = "default") -> dict:
@@ -87,6 +90,7 @@ label_filter (partial label match), os_type_filter (OS type match), critical_onl
 
         @self.mcp.tool(
             name="get_scenarios",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered and paginated list of SafeBreach scenarios for a given console.
 Scenarios are multi-step attack workflows. Each scenario includes metadata about its type (OOB/custom),
 category, readiness status, and step count. Results are paginated (10 per page) and ordered by name ascending by default.
@@ -128,6 +132,7 @@ order_direction ('asc'/'desc')"""
 
         @self.mcp.tool(
             name="get_scenario_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Gets the full details of a specific SafeBreach scenario by its UUID.
 Returns the complete scenario payload including all steps with attack filters, system filters,
 target/attacker filters, phases, actions, and edges. Also includes resolved category names.

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -35,19 +35,12 @@ from .safebreach_auth import SafeBreachAuth
 
 logger = logging.getLogger(__name__)
 
-# Per-request flag indicating whether the caller (mcp-proxy) wants destructive
-# (write) tools hidden. Set from the X-Disable-Tools request header by the
-# ASGI middleware below; consumed by the tool manager wrappers. Note this
-# only affects tools whose annotation says `readOnlyHint != True` AND that
-# are NOT already in DISABLE_TOOL_LIST (the deny list trumps the gate).
-_disable_tools_flag: contextvars.ContextVar[bool] = contextvars.ContextVar('disable_tools_flag', default=False)
-
 # Server-wide absolute deny list. Configured via the DISABLE_TOOL_LIST env
-# var at startup — expected format is a JSON array of tool names, e.g.
-# '["save_studio_attack_draft","run_studio_attack"]'. Tools whose names appear
-# here are stripped from `tools/list` and rejected by `tools/call` regardless
-# of any per-request header, FF, or account setting. The only way to re-enable
-# a tool is to remove it from the env var and restart the server.
+# var (JSON array of tool names, e.g. '["save_studio_attack_draft"]'). Tools
+# whose names appear here are stripped from `tools/list` and rejected by
+# `tools/call`. The env var is read fresh on every server start, so the
+# operator (mcp-proxy in the SaaS deployment) can update it and restart the
+# server to change which tools are gated.
 def _parse_disable_tool_list(raw: Optional[str]) -> frozenset[str]:
     raw = (raw or '').strip()
     if not raw:
@@ -61,8 +54,6 @@ def _parse_disable_tool_list(raw: Optional[str]) -> frozenset[str]:
         logger.error("DISABLE_TOOL_LIST must be a JSON array of strings, ignoring")
         return frozenset()
     return frozenset(n for n in parsed if n)
-
-_DISABLE_TOOL_LIST: frozenset[str] = _parse_disable_tool_list(os.environ.get('DISABLE_TOOL_LIST'))
 
 # Concurrency limiter state — shared across all server instances
 _mcp_session_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar('mcp_session_id', default=None)
@@ -142,70 +133,37 @@ class SafeBreachMCPBase:
         self._cache.clear()
 
     def _install_disable_filtering(self, app):
-        """Install two independent filter layers and return the app wrapped
-        with the X-Disable-Tools header reader.
-
-        Layer 1 — DISABLE_TOOL_LIST (absolute deny):
-            tools whose names appear in DISABLE_TOOL_LIST are always stripped
-            from list_tools and rejected by call_tool, regardless of header.
-
-        Layer 2 — write-tool gate (header-driven):
-            when `X-Disable-Tools: true` is set on the request, write tools
-            (annotation `readOnlyHint != True`) are also stripped / rejected.
-            Read-only tools always pass.
-
-        SIMP sets the header per-request based on the account's FF + consent
-        state. Combined effect: deny-list tools are unreachable forever; other
-        write tools are gated by the FF + consent; read tools are always
-        available."""
+        """Wrap the tool manager so any tool whose name is in DISABLE_TOOL_LIST
+        is hidden from `tools/list` and rejected by `tools/call`. The env var
+        is re-read on every install (every server start), so a restart with a
+        new env-var value takes effect for the new instance. Returns `app`
+        unchanged."""
         from mcp.server.fastmcp.exceptions import ToolError
+        deny_list = _parse_disable_tool_list(os.environ.get('DISABLE_TOOL_LIST'))
         tool_manager = self.mcp._tool_manager
         original_list_tools = tool_manager.list_tools
         original_call_tool = tool_manager.call_tool
 
-        def _is_read_only(tool) -> bool:
-            return getattr(getattr(tool, 'annotations', None), 'readOnlyHint', None) is True
-
         def filtered_list_tools():
             tools = original_list_tools()
-            if _DISABLE_TOOL_LIST:
-                tools = [t for t in tools if t.name not in _DISABLE_TOOL_LIST]
-            if _disable_tools_flag.get():
-                tools = [t for t in tools if _is_read_only(t)]
+            if deny_list:
+                tools = [t for t in tools if t.name not in deny_list]
             return tools
 
         async def filtered_call_tool(name, arguments, context=None, convert_result=False):
-            if name in _DISABLE_TOOL_LIST:
+            if name in deny_list:
                 logger.warning("Blocked deny-listed tool call: '%s'", name)
                 raise ToolError(
                     f"Tool '{name}' is not available. "
                     "This tool has been disabled by the server administrator."
                 )
-            if _disable_tools_flag.get():
-                tool = tool_manager.get_tool(name)
-                if tool is not None and not _is_read_only(tool):
-                    logger.warning("Blocked write tool while gate closed: '%s'", name)
-                    raise ToolError(
-                        f"Tool '{name}' is not available. "
-                        "AI actions are not enabled for this account."
-                    )
             return await original_call_tool(name, arguments, context=context, convert_result=convert_result)
 
         tool_manager.list_tools = filtered_list_tools
         tool_manager.call_tool = filtered_call_tool
 
-        async def disable_aware_app(scope, receive, send):
-            if scope["type"] == "http":
-                headers = dict(scope.get("headers", []))
-                raw = headers.get(b"x-disable-tools", b"").decode("utf-8", errors="replace").strip().lower()
-                _disable_tools_flag.set(raw == "true")
-            return await app(scope, receive, send)
-
-        logger.info(
-            'Tool-disable filtering installed (deny list: %d, write gate: header-driven)',
-            len(_DISABLE_TOOL_LIST),
-        )
-        return disable_aware_app
+        logger.info('Tool-disable filtering installed (deny list: %d)', len(deny_list))
+        return app
 
     def request_shutdown(self) -> None:
         """Signal the uvicorn server to exit gracefully.
@@ -278,8 +236,8 @@ class SafeBreachMCPBase:
         else:
             logger.info("🏠 Local-only server - no authentication wrapper applied")
 
-        # Install X-Disable-Tools support (tool-manager wrap + ASGI middleware).
-        # No-op when DISABLE_TOOL_LIST is empty — returns `app` unchanged.
+        # Wrap the tool manager so DISABLE_TOOL_LIST entries are hidden from
+        # tools/list and rejected by tools/call. Returns `app` unchanged.
         app = self._install_disable_filtering(app)
 
         # Wrap with concurrency limiter (applies to all servers)

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -35,6 +35,35 @@ from .safebreach_auth import SafeBreachAuth
 
 logger = logging.getLogger(__name__)
 
+# Per-request flag indicating whether the caller (mcp-proxy) wants destructive
+# (write) tools hidden. Set from the X-Disable-Tools request header by the
+# ASGI middleware below; consumed by the tool manager wrappers. Note this
+# only affects tools whose annotation says `readOnlyHint != True` AND that
+# are NOT already in DISABLE_TOOL_LIST (the deny list trumps the gate).
+_disable_tools_flag: contextvars.ContextVar[bool] = contextvars.ContextVar('disable_tools_flag', default=False)
+
+# Server-wide absolute deny list. Configured via the DISABLE_TOOL_LIST env
+# var at startup — expected format is a JSON array of tool names, e.g.
+# '["save_studio_attack_draft","run_studio_attack"]'. Tools whose names appear
+# here are stripped from `tools/list` and rejected by `tools/call` regardless
+# of any per-request header, FF, or account setting. The only way to re-enable
+# a tool is to remove it from the env var and restart the server.
+def _parse_disable_tool_list(raw: Optional[str]) -> frozenset[str]:
+    raw = (raw or '').strip()
+    if not raw:
+        return frozenset()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.error(f"Invalid DISABLE_TOOL_LIST JSON, ignoring: {exc}")
+        return frozenset()
+    if not isinstance(parsed, list) or not all(isinstance(n, str) for n in parsed):
+        logger.error("DISABLE_TOOL_LIST must be a JSON array of strings, ignoring")
+        return frozenset()
+    return frozenset(n for n in parsed if n)
+
+_DISABLE_TOOL_LIST: frozenset[str] = _parse_disable_tool_list(os.environ.get('DISABLE_TOOL_LIST'))
+
 # Concurrency limiter state — shared across all server instances
 _mcp_session_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar('mcp_session_id', default=None)
 # Stores (semaphore, creation_timestamp) tuples to enable stale entry cleanup
@@ -112,6 +141,72 @@ class SafeBreachMCPBase:
         """Clear all cache data."""
         self._cache.clear()
 
+    def _install_disable_filtering(self, app):
+        """Install two independent filter layers and return the app wrapped
+        with the X-Disable-Tools header reader.
+
+        Layer 1 — DISABLE_TOOL_LIST (absolute deny):
+            tools whose names appear in DISABLE_TOOL_LIST are always stripped
+            from list_tools and rejected by call_tool, regardless of header.
+
+        Layer 2 — write-tool gate (header-driven):
+            when `X-Disable-Tools: true` is set on the request, write tools
+            (annotation `readOnlyHint != True`) are also stripped / rejected.
+            Read-only tools always pass.
+
+        SIMP sets the header per-request based on the account's FF + consent
+        state. Combined effect: deny-list tools are unreachable forever; other
+        write tools are gated by the FF + consent; read tools are always
+        available."""
+        from mcp.server.fastmcp.exceptions import ToolError
+        tool_manager = self.mcp._tool_manager
+        original_list_tools = tool_manager.list_tools
+        original_call_tool = tool_manager.call_tool
+
+        def _is_read_only(tool) -> bool:
+            return getattr(getattr(tool, 'annotations', None), 'readOnlyHint', None) is True
+
+        def filtered_list_tools():
+            tools = original_list_tools()
+            if _DISABLE_TOOL_LIST:
+                tools = [t for t in tools if t.name not in _DISABLE_TOOL_LIST]
+            if _disable_tools_flag.get():
+                tools = [t for t in tools if _is_read_only(t)]
+            return tools
+
+        async def filtered_call_tool(name, arguments, context=None, convert_result=False):
+            if name in _DISABLE_TOOL_LIST:
+                logger.warning("Blocked deny-listed tool call: '%s'", name)
+                raise ToolError(
+                    f"Tool '{name}' is not available. "
+                    "This tool has been disabled by the server administrator."
+                )
+            if _disable_tools_flag.get():
+                tool = tool_manager.get_tool(name)
+                if tool is not None and not _is_read_only(tool):
+                    logger.warning("Blocked write tool while gate closed: '%s'", name)
+                    raise ToolError(
+                        f"Tool '{name}' is not available. "
+                        "AI actions are not enabled for this account."
+                    )
+            return await original_call_tool(name, arguments, context=context, convert_result=convert_result)
+
+        tool_manager.list_tools = filtered_list_tools
+        tool_manager.call_tool = filtered_call_tool
+
+        async def disable_aware_app(scope, receive, send):
+            if scope["type"] == "http":
+                headers = dict(scope.get("headers", []))
+                raw = headers.get(b"x-disable-tools", b"").decode("utf-8", errors="replace").strip().lower()
+                _disable_tools_flag.set(raw == "true")
+            return await app(scope, receive, send)
+
+        logger.info(
+            'Tool-disable filtering installed (deny list: %d, write gate: header-driven)',
+            len(_DISABLE_TOOL_LIST),
+        )
+        return disable_aware_app
+
     def request_shutdown(self) -> None:
         """Signal the uvicorn server to exit gracefully.
 
@@ -182,6 +277,10 @@ class SafeBreachMCPBase:
             self._log_external_binding_warning(port)
         else:
             logger.info("🏠 Local-only server - no authentication wrapper applied")
+
+        # Install X-Disable-Tools support (tool-manager wrap + ASGI middleware).
+        # No-op when DISABLE_TOOL_LIST is empty — returns `app` unchanged.
+        app = self._install_disable_filtering(app)
 
         # Wrap with concurrency limiter (applies to all servers)
         app = self._create_concurrency_limited_app(app, transport=transport, endpoint_path=endpoint_path)

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -580,29 +580,9 @@ class SafeBreachMCPBase:
                 )
 
                 real_session_id = None
-                response_started = False
 
                 async def cleanup_send(message):
-                    nonlocal real_session_id, response_started
-
-                    # ASGI invariant: at most one `http.response.start` per
-                    # response. When uvicorn force-exits an in-flight SSE
-                    # (e.g. mcp-proxy restarts the server on an AI-actions
-                    # gate flip), starlette's exception handler tries to
-                    # render a 500 by emitting a second `response.start` —
-                    # which crashes h11 with `Expected
-                    # 'http.response.body', got 'http.response.start'`.
-                    # Drop the duplicate so the original SSE just
-                    # terminates.
-                    if message.get("type") == "http.response.start":
-                        if response_started:
-                            logger.debug(
-                                f"Suppressing duplicate http.response.start for session "
-                                f"{(real_session_id or middleware_session_id)[:8]}..."
-                            )
-                            return
-                        response_started = True
-
+                    nonlocal real_session_id
                     await send(message)
 
                     # Capture the real session_id from FastMCP's endpoint event

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -138,17 +138,18 @@ class SafeBreachMCPBase:
         is re-read on every install (every server start), so a restart with a
         new env-var value takes effect for the new instance. Returns `app`
         unchanged."""
-        from mcp.server.fastmcp.exceptions import ToolError
         deny_list = _parse_disable_tool_list(os.environ.get('DISABLE_TOOL_LIST'))
+        if not deny_list:
+            logger.info('Tool-disable filtering installed (deny list: 0)')
+            return app
+
+        from mcp.server.fastmcp.exceptions import ToolError
         tool_manager = self.mcp._tool_manager
         original_list_tools = tool_manager.list_tools
         original_call_tool = tool_manager.call_tool
 
         def filtered_list_tools():
-            tools = original_list_tools()
-            if deny_list:
-                tools = [t for t in tools if t.name not in deny_list]
-            return tools
+            return [t for t in original_list_tools() if t.name not in deny_list]
 
         async def filtered_call_tool(name, arguments, context=None, convert_result=False):
             if name in deny_list:

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -580,9 +580,29 @@ class SafeBreachMCPBase:
                 )
 
                 real_session_id = None
+                response_started = False
 
                 async def cleanup_send(message):
-                    nonlocal real_session_id
+                    nonlocal real_session_id, response_started
+
+                    # ASGI invariant: at most one `http.response.start` per
+                    # response. When uvicorn force-exits an in-flight SSE
+                    # (e.g. mcp-proxy restarts the server on an AI-actions
+                    # gate flip), starlette's exception handler tries to
+                    # render a 500 by emitting a second `response.start` —
+                    # which crashes h11 with `Expected
+                    # 'http.response.body', got 'http.response.start'`.
+                    # Drop the duplicate so the original SSE just
+                    # terminates.
+                    if message.get("type") == "http.response.start":
+                        if response_started:
+                            logger.debug(
+                                f"Suppressing duplicate http.response.start for session "
+                                f"{(real_session_id or middleware_session_id)[:8]}..."
+                            )
+                            return
+                        response_started = True
+
                     await send(message)
 
                     # Capture the real session_id from FastMCP's endpoint event

--- a/safebreach_mcp_core/tests/test_disable_filtering.py
+++ b/safebreach_mcp_core/tests/test_disable_filtering.py
@@ -1,0 +1,271 @@
+"""Tests for SAF-29865 tool-disable filtering — two independent layers:
+
+  Layer 1 (DISABLE_TOOL_LIST): server-wide absolute deny. Listed tools are
+    always hidden / always rejected, regardless of header.
+
+  Layer 2 (write-tool gate): triggered by `X-Disable-Tools: true` header.
+    When the gate is closed, tools whose annotation `readOnlyHint != True`
+    are hidden / rejected. Read-only tools always pass.
+
+The two layers compose: a deny-listed tool is unreachable forever; a non-
+deny-listed write tool becomes reachable iff the gate opens (mcp-proxy
+opens it when the account FF + consent are both ON). breach-genie sees
+the post-filtered catalog."""
+
+import asyncio
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mcp.server.fastmcp.exceptions import ToolError
+from safebreach_mcp_core import safebreach_base as mod
+
+
+def _make_tool(name: str, read_only: bool = False):
+    """A fake MCP tool with an `annotations.readOnlyHint`. Default is write."""
+    return SimpleNamespace(name=name, annotations=SimpleNamespace(readOnlyHint=read_only))
+
+
+def _make_unannotated_tool(name: str):
+    """A tool without annotations — fails safe to 'write' under Layer 2."""
+    return SimpleNamespace(name=name, annotations=None)
+
+
+async def _noop_app(scope, receive, send):
+    pass
+
+
+def _build_base_with_tools(tools_by_name: dict):
+    """Construct a SafeBreachMCPBase, attach a fake tool manager, install
+    the filter, return the wrapped app + the base. Caller monkeypatches
+    `_DISABLE_TOOL_LIST` and sets `_disable_tools_flag` to drive scenarios."""
+    with patch.object(mod, "SafeBreachAuth"):
+        base = mod.SafeBreachMCPBase("test-server")
+
+    fake_manager = MagicMock()
+    fake_manager.list_tools.side_effect = lambda: list(tools_by_name.values())
+    fake_manager.get_tool.side_effect = lambda name: tools_by_name.get(name)
+
+    async def call_tool(name, arguments, context=None, convert_result=False):
+        return {"executed": name}
+
+    fake_manager.call_tool.side_effect = call_tool
+    base.mcp._tool_manager = fake_manager
+    wrapped = base._install_disable_filtering(_noop_app)
+    return base, wrapped
+
+
+class TestParseDisableToolList:
+    """Pure parser — no env-var juggling needed."""
+
+    def test_none_is_empty(self):
+        assert mod._parse_disable_tool_list(None) == frozenset()
+
+    def test_empty_string_is_empty(self):
+        assert mod._parse_disable_tool_list('') == frozenset()
+
+    def test_valid_json_array_is_parsed(self):
+        assert mod._parse_disable_tool_list('["save_x","run_y"]') == frozenset({"save_x", "run_y"})
+
+    def test_blank_names_are_stripped(self):
+        assert mod._parse_disable_tool_list('["run_y",""]') == frozenset({"run_y"})
+
+    def test_invalid_json_is_ignored(self):
+        assert mod._parse_disable_tool_list('not-json') == frozenset()
+
+    def test_non_array_json_is_ignored(self):
+        assert mod._parse_disable_tool_list('{"save":"x"}') == frozenset()
+
+    def test_non_string_elements_are_ignored(self):
+        assert mod._parse_disable_tool_list('["ok", 42]') == frozenset()
+
+
+class TestDenyListLayer:
+    """Layer 1: DISABLE_TOOL_LIST is absolute — listed tools are unreachable
+    regardless of any header / flag state."""
+
+    def test_listed_tool_hidden_with_gate_closed(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({
+            "banned": _make_tool("banned", read_only=False),
+            "safe": _make_tool("safe", read_only=True),
+        })
+        mod._disable_tools_flag.set(True)
+
+        names = [t.name for t in base.mcp._tool_manager.list_tools()]
+        assert names == ["safe"]
+
+    def test_listed_tool_hidden_with_gate_open(self, monkeypatch):
+        """Even when the gate is open (FF + consent on), deny-listed tools stay hidden."""
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({
+            "banned": _make_tool("banned", read_only=False),
+            "writable": _make_tool("writable", read_only=False),
+            "safe": _make_tool("safe", read_only=True),
+        })
+        mod._disable_tools_flag.set(False)
+
+        names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
+        assert names == ["safe", "writable"]
+
+    def test_listed_tool_call_blocked_with_gate_closed(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({"banned": _make_tool("banned")})
+        mod._disable_tools_flag.set(True)
+
+        with pytest.raises(ToolError, match="disabled by the server administrator"):
+            asyncio.run(base.mcp._tool_manager.call_tool("banned", {}))
+
+    def test_listed_tool_call_blocked_with_gate_open(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({"banned": _make_tool("banned")})
+        mod._disable_tools_flag.set(False)
+
+        with pytest.raises(ToolError, match="disabled by the server administrator"):
+            asyncio.run(base.mcp._tool_manager.call_tool("banned", {}))
+
+
+class TestWriteGateLayer:
+    """Layer 2: write tools (`readOnlyHint != True`) are visible iff the gate
+    is open. The gate is closed when X-Disable-Tools: true is on the request."""
+
+    def test_gate_closed_hides_writes_keeps_reads(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({
+            "writable": _make_tool("writable", read_only=False),
+            "safe": _make_tool("safe", read_only=True),
+        })
+        mod._disable_tools_flag.set(True)
+
+        names = [t.name for t in base.mcp._tool_manager.list_tools()]
+        assert names == ["safe"]
+
+    def test_gate_open_shows_writes_and_reads(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({
+            "writable": _make_tool("writable", read_only=False),
+            "safe": _make_tool("safe", read_only=True),
+        })
+        mod._disable_tools_flag.set(False)
+
+        names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
+        assert names == ["safe", "writable"]
+
+    def test_gate_closed_blocks_write_call(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({"writable": _make_tool("writable", read_only=False)})
+        mod._disable_tools_flag.set(True)
+
+        with pytest.raises(ToolError, match="AI actions are not enabled"):
+            asyncio.run(base.mcp._tool_manager.call_tool("writable", {}))
+
+    def test_gate_closed_allows_read_call(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({"safe": _make_tool("safe", read_only=True)})
+        mod._disable_tools_flag.set(True)
+
+        result = asyncio.run(base.mcp._tool_manager.call_tool("safe", {}))
+        assert result == {"executed": "safe"}
+
+    def test_gate_open_allows_write_call(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({"writable": _make_tool("writable", read_only=False)})
+        mod._disable_tools_flag.set(False)
+
+        result = asyncio.run(base.mcp._tool_manager.call_tool("writable", {}))
+        assert result == {"executed": "writable"}
+
+    def test_unannotated_tool_treated_as_write(self, monkeypatch):
+        """A tool without annotations fails safe — gate hides it."""
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
+        base, _ = _build_base_with_tools({"unknown": _make_unannotated_tool("unknown")})
+        mod._disable_tools_flag.set(True)
+
+        names = [t.name for t in base.mcp._tool_manager.list_tools()]
+        assert names == []
+
+        with pytest.raises(ToolError, match="AI actions are not enabled"):
+            asyncio.run(base.mcp._tool_manager.call_tool("unknown", {}))
+
+
+class TestLayerComposition:
+    """Both layers active at once: deny list trumps the gate, gate trumps read."""
+
+    def test_deny_list_plus_closed_gate_keeps_only_unlisted_reads(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({
+            "banned": _make_tool("banned", read_only=True),   # listed → hidden even though read-only
+            "writable": _make_tool("writable", read_only=False),  # not listed, write → hidden by gate
+            "safe": _make_tool("safe", read_only=True),        # not listed, read → visible
+        })
+        mod._disable_tools_flag.set(True)
+
+        names = [t.name for t in base.mcp._tool_manager.list_tools()]
+        assert names == ["safe"]
+
+    def test_deny_list_plus_open_gate_shows_all_unlisted(self, monkeypatch):
+        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
+        base, _ = _build_base_with_tools({
+            "banned": _make_tool("banned", read_only=False),
+            "writable": _make_tool("writable", read_only=False),
+            "safe": _make_tool("safe", read_only=True),
+        })
+        mod._disable_tools_flag.set(False)
+
+        names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
+        assert names == ["safe", "writable"]
+
+
+class TestDisableAwareAsgiMiddleware:
+    """The ASGI wrap reads X-Disable-Tools per request into _disable_tools_flag."""
+
+    def _run_middleware(self, headers):
+        captured = {}
+
+        async def downstream(scope, receive, send):
+            captured["flag"] = mod._disable_tools_flag.get()
+
+        with patch.object(mod, "SafeBreachAuth"):
+            base = mod.SafeBreachMCPBase("test-server")
+        base.mcp._tool_manager = MagicMock(
+            list_tools=lambda: [], call_tool=lambda *a, **kw: None,
+            get_tool=lambda n: None,
+        )
+        wrapped = base._install_disable_filtering(downstream)
+
+        scope = {"type": "http", "headers": headers}
+        asyncio.run(wrapped(scope, lambda: None, lambda m: None))
+        return captured
+
+    @pytest.mark.parametrize('raw,expected_flag', [
+        (b"true",  True),
+        (b"TRUE",  True),
+        (b"false", False),
+        (b"maybe", False),
+        (b"",      False),
+    ])
+    def test_header_value_maps_to_flag(self, raw, expected_flag):
+        captured = self._run_middleware([(b"x-disable-tools", raw)])
+        assert captured["flag"] is expected_flag
+
+    def test_missing_header_defaults_to_false(self):
+        captured = self._run_middleware([])
+        assert captured["flag"] is False
+
+    def test_non_http_scope_passes_through(self):
+        called = {"hit": False}
+
+        async def downstream(scope, receive, send):
+            called["hit"] = True
+
+        with patch.object(mod, "SafeBreachAuth"):
+            base = mod.SafeBreachMCPBase("test-server")
+        base.mcp._tool_manager = MagicMock(
+            list_tools=lambda: [], call_tool=lambda *a, **kw: None,
+            get_tool=lambda n: None,
+        )
+        wrapped = base._install_disable_filtering(downstream)
+
+        asyncio.run(wrapped({"type": "websocket"}, lambda: None, lambda m: None))
+        assert called["hit"] is True

--- a/safebreach_mcp_core/tests/test_disable_filtering.py
+++ b/safebreach_mcp_core/tests/test_disable_filtering.py
@@ -1,16 +1,14 @@
-"""Tests for SAF-29865 tool-disable filtering — two independent layers:
+"""Tests for SAF-29865 tool-disable filtering.
 
-  Layer 1 (DISABLE_TOOL_LIST): server-wide absolute deny. Listed tools are
-    always hidden / always rejected, regardless of header.
+The deny list is read from the `DISABLE_TOOL_LIST` env var at server start.
+Listed tools are stripped from `tools/list` and rejected by `tools/call`
+inside this server.
 
-  Layer 2 (write-tool gate): triggered by `X-Disable-Tools: true` header.
-    When the gate is closed, tools whose annotation `readOnlyHint != True`
-    are hidden / rejected. Read-only tools always pass.
-
-The two layers compose: a deny-listed tool is unreachable forever; a non-
-deny-listed write tool becomes reachable iff the gate opens (mcp-proxy
-opens it when the account FF + consent are both ON). breach-genie sees
-the post-filtered catalog."""
+Scope: this layer is the operator's deploy-time pin — set the env var when
+launching safebreach-mcp to permanently hide tools regardless of caller.
+The SAF-29865 AI-actions gate (FF + consent) is enforced separately in the
+mcp-proxy gateway by filtering tools/list responses and rejecting
+tools/call requests at the proxy edge — see mcp-proxy's `gateway.py`."""
 
 import asyncio
 
@@ -22,24 +20,13 @@ from mcp.server.fastmcp.exceptions import ToolError
 from safebreach_mcp_core import safebreach_base as mod
 
 
-def _make_tool(name: str, read_only: bool = False):
-    """A fake MCP tool with an `annotations.readOnlyHint`. Default is write."""
-    return SimpleNamespace(name=name, annotations=SimpleNamespace(readOnlyHint=read_only))
-
-
-def _make_unannotated_tool(name: str):
-    """A tool without annotations — fails safe to 'write' under Layer 2."""
-    return SimpleNamespace(name=name, annotations=None)
-
-
-async def _noop_app(scope, receive, send):
-    pass
+def _make_tool(name: str):
+    return SimpleNamespace(name=name)
 
 
 def _build_base_with_tools(tools_by_name: dict):
     """Construct a SafeBreachMCPBase, attach a fake tool manager, install
-    the filter, return the wrapped app + the base. Caller monkeypatches
-    `_DISABLE_TOOL_LIST` and sets `_disable_tools_flag` to drive scenarios."""
+    the filter. Caller monkeypatches `_DISABLE_TOOL_LIST` to drive scenarios."""
     with patch.object(mod, "SafeBreachAuth"):
         base = mod.SafeBreachMCPBase("test-server")
 
@@ -52,8 +39,12 @@ def _build_base_with_tools(tools_by_name: dict):
 
     fake_manager.call_tool.side_effect = call_tool
     base.mcp._tool_manager = fake_manager
-    wrapped = base._install_disable_filtering(_noop_app)
-    return base, wrapped
+
+    async def _noop_app(scope, receive, send):
+        pass
+
+    base._install_disable_filtering(_noop_app)
+    return base
 
 
 class TestParseDisableToolList:
@@ -81,191 +72,57 @@ class TestParseDisableToolList:
         assert mod._parse_disable_tool_list('["ok", 42]') == frozenset()
 
 
-class TestDenyListLayer:
-    """Layer 1: DISABLE_TOOL_LIST is absolute — listed tools are unreachable
-    regardless of any header / flag state."""
+class TestDenyList:
+    """Listed tools are unreachable — hidden from list_tools, rejected by call_tool."""
 
-    def test_listed_tool_hidden_with_gate_closed(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({
-            "banned": _make_tool("banned", read_only=False),
-            "safe": _make_tool("safe", read_only=True),
+    def test_listed_tool_hidden(self, monkeypatch):
+        monkeypatch.setenv('DISABLE_TOOL_LIST', '["banned"]')
+        base = _build_base_with_tools({
+            "banned": _make_tool("banned"),
+            "safe": _make_tool("safe"),
         })
-        mod._disable_tools_flag.set(True)
 
         names = [t.name for t in base.mcp._tool_manager.list_tools()]
         assert names == ["safe"]
 
-    def test_listed_tool_hidden_with_gate_open(self, monkeypatch):
-        """Even when the gate is open (FF + consent on), deny-listed tools stay hidden."""
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({
-            "banned": _make_tool("banned", read_only=False),
-            "writable": _make_tool("writable", read_only=False),
-            "safe": _make_tool("safe", read_only=True),
-        })
-        mod._disable_tools_flag.set(False)
-
-        names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
-        assert names == ["safe", "writable"]
-
-    def test_listed_tool_call_blocked_with_gate_closed(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({"banned": _make_tool("banned")})
-        mod._disable_tools_flag.set(True)
+    def test_listed_tool_call_blocked(self, monkeypatch):
+        monkeypatch.setenv('DISABLE_TOOL_LIST', '["banned"]')
+        base = _build_base_with_tools({"banned": _make_tool("banned")})
 
         with pytest.raises(ToolError, match="disabled by the server administrator"):
             asyncio.run(base.mcp._tool_manager.call_tool("banned", {}))
 
-    def test_listed_tool_call_blocked_with_gate_open(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({"banned": _make_tool("banned")})
-        mod._disable_tools_flag.set(False)
-
-        with pytest.raises(ToolError, match="disabled by the server administrator"):
-            asyncio.run(base.mcp._tool_manager.call_tool("banned", {}))
-
-
-class TestWriteGateLayer:
-    """Layer 2: write tools (`readOnlyHint != True`) are visible iff the gate
-    is open. The gate is closed when X-Disable-Tools: true is on the request."""
-
-    def test_gate_closed_hides_writes_keeps_reads(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({
-            "writable": _make_tool("writable", read_only=False),
-            "safe": _make_tool("safe", read_only=True),
+    def test_empty_deny_list_is_passthrough(self, monkeypatch):
+        monkeypatch.delenv('DISABLE_TOOL_LIST', raising=False)
+        base = _build_base_with_tools({
+            "writable": _make_tool("writable"),
+            "safe": _make_tool("safe"),
         })
-        mod._disable_tools_flag.set(True)
-
-        names = [t.name for t in base.mcp._tool_manager.list_tools()]
-        assert names == ["safe"]
-
-    def test_gate_open_shows_writes_and_reads(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({
-            "writable": _make_tool("writable", read_only=False),
-            "safe": _make_tool("safe", read_only=True),
-        })
-        mod._disable_tools_flag.set(False)
 
         names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
         assert names == ["safe", "writable"]
 
-    def test_gate_closed_blocks_write_call(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({"writable": _make_tool("writable", read_only=False)})
-        mod._disable_tools_flag.set(True)
-
-        with pytest.raises(ToolError, match="AI actions are not enabled"):
-            asyncio.run(base.mcp._tool_manager.call_tool("writable", {}))
-
-    def test_gate_closed_allows_read_call(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({"safe": _make_tool("safe", read_only=True)})
-        mod._disable_tools_flag.set(True)
+    def test_unlisted_tool_call_passes(self, monkeypatch):
+        monkeypatch.setenv('DISABLE_TOOL_LIST', '["banned"]')
+        base = _build_base_with_tools({"safe": _make_tool("safe")})
 
         result = asyncio.run(base.mcp._tool_manager.call_tool("safe", {}))
         assert result == {"executed": "safe"}
 
-    def test_gate_open_allows_write_call(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({"writable": _make_tool("writable", read_only=False)})
-        mod._disable_tools_flag.set(False)
-
-        result = asyncio.run(base.mcp._tool_manager.call_tool("writable", {}))
-        assert result == {"executed": "writable"}
-
-    def test_unannotated_tool_treated_as_write(self, monkeypatch):
-        """A tool without annotations fails safe — gate hides it."""
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset())
-        base, _ = _build_base_with_tools({"unknown": _make_unannotated_tool("unknown")})
-        mod._disable_tools_flag.set(True)
-
-        names = [t.name for t in base.mcp._tool_manager.list_tools()]
-        assert names == []
-
-        with pytest.raises(ToolError, match="AI actions are not enabled"):
-            asyncio.run(base.mcp._tool_manager.call_tool("unknown", {}))
-
-
-class TestLayerComposition:
-    """Both layers active at once: deny list trumps the gate, gate trumps read."""
-
-    def test_deny_list_plus_closed_gate_keeps_only_unlisted_reads(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({
-            "banned": _make_tool("banned", read_only=True),   # listed → hidden even though read-only
-            "writable": _make_tool("writable", read_only=False),  # not listed, write → hidden by gate
-            "safe": _make_tool("safe", read_only=True),        # not listed, read → visible
+    def test_deny_list_re_read_on_each_install(self, monkeypatch):
+        """Each call to _install_disable_filtering re-reads the env var, so a
+        server restart with a new value takes effect for the new instance."""
+        monkeypatch.setenv('DISABLE_TOOL_LIST', '["banned"]')
+        base = _build_base_with_tools({
+            "banned": _make_tool("banned"),
+            "safe": _make_tool("safe"),
         })
-        mod._disable_tools_flag.set(True)
+        assert [t.name for t in base.mcp._tool_manager.list_tools()] == ["safe"]
 
-        names = [t.name for t in base.mcp._tool_manager.list_tools()]
-        assert names == ["safe"]
-
-    def test_deny_list_plus_open_gate_shows_all_unlisted(self, monkeypatch):
-        monkeypatch.setattr(mod, '_DISABLE_TOOL_LIST', frozenset({"banned"}))
-        base, _ = _build_base_with_tools({
-            "banned": _make_tool("banned", read_only=False),
-            "writable": _make_tool("writable", read_only=False),
-            "safe": _make_tool("safe", read_only=True),
+        # Operator updates the env var (mcp-proxy on FF flip), then restarts → new install.
+        monkeypatch.setenv('DISABLE_TOOL_LIST', '[]')
+        base2 = _build_base_with_tools({
+            "banned": _make_tool("banned"),
+            "safe": _make_tool("safe"),
         })
-        mod._disable_tools_flag.set(False)
-
-        names = sorted(t.name for t in base.mcp._tool_manager.list_tools())
-        assert names == ["safe", "writable"]
-
-
-class TestDisableAwareAsgiMiddleware:
-    """The ASGI wrap reads X-Disable-Tools per request into _disable_tools_flag."""
-
-    def _run_middleware(self, headers):
-        captured = {}
-
-        async def downstream(scope, receive, send):
-            captured["flag"] = mod._disable_tools_flag.get()
-
-        with patch.object(mod, "SafeBreachAuth"):
-            base = mod.SafeBreachMCPBase("test-server")
-        base.mcp._tool_manager = MagicMock(
-            list_tools=lambda: [], call_tool=lambda *a, **kw: None,
-            get_tool=lambda n: None,
-        )
-        wrapped = base._install_disable_filtering(downstream)
-
-        scope = {"type": "http", "headers": headers}
-        asyncio.run(wrapped(scope, lambda: None, lambda m: None))
-        return captured
-
-    @pytest.mark.parametrize('raw,expected_flag', [
-        (b"true",  True),
-        (b"TRUE",  True),
-        (b"false", False),
-        (b"maybe", False),
-        (b"",      False),
-    ])
-    def test_header_value_maps_to_flag(self, raw, expected_flag):
-        captured = self._run_middleware([(b"x-disable-tools", raw)])
-        assert captured["flag"] is expected_flag
-
-    def test_missing_header_defaults_to_false(self):
-        captured = self._run_middleware([])
-        assert captured["flag"] is False
-
-    def test_non_http_scope_passes_through(self):
-        called = {"hit": False}
-
-        async def downstream(scope, receive, send):
-            called["hit"] = True
-
-        with patch.object(mod, "SafeBreachAuth"):
-            base = mod.SafeBreachMCPBase("test-server")
-        base.mcp._tool_manager = MagicMock(
-            list_tools=lambda: [], call_tool=lambda *a, **kw: None,
-            get_tool=lambda n: None,
-        )
-        wrapped = base._install_disable_filtering(downstream)
-
-        asyncio.run(wrapped({"type": "websocket"}, lambda: None, lambda m: None))
-        assert called["hit"] is True
+        assert sorted(t.name for t in base2.mcp._tool_manager.list_tools()) == ["banned", "safe"]

--- a/safebreach_mcp_data/data_server.py
+++ b/safebreach_mcp_data/data_server.py
@@ -12,6 +12,7 @@ from typing import Optional
 # Add parent directory to path to import core components
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from mcp.types import ToolAnnotations
 from safebreach_mcp_core import SafeBreachMCPBase
 from safebreach_mcp_core.datetime_utils import normalize_timestamp
 from .data_functions import (
@@ -51,6 +52,7 @@ class SafeBreachDataServer(SafeBreachMCPBase):
         
         @self.mcp.tool(
             name="get_tests_history",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered and paged history listing of tests executed on a given Safebreach management console.
 Supports filtering by test type (validate/propagate), time windows, status, and name patterns. Results are ordered by end time (newest first) by default.
 Parameters: console (required), page_number (default 0), test_type ('validate'/'propagate'/None), \
@@ -86,6 +88,7 @@ Accepts both epoch timestamps and ISO 8601 strings for date parameters."""
         
         @self.mcp.tool(
             name="get_test_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns the full details for a specific test by id executed on a given Safebreach management console.
 Always includes simulation status counts (missed, stopped, prevented, detected, logged, no-result, inconsistent) at no extra cost.
 Optionally includes drift count via include_drift_count parameter.
@@ -100,6 +103,7 @@ WARNING: include_drift_count=True may take a significant amount of time for larg
         
         @self.mcp.tool(
             name="get_test_simulations",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered and paged listing of simulations executed in the context of a specific test by id on a given Safebreach management console.
 Supports filtering by status, time windows, playbook attack ID, playbook attack name patterns, and drift analysis. Results are ordered by execution time (newest first) by default.
 Each simulation includes a drift_tracking_code — a lineage identifier grouping all executions of the same \
@@ -139,6 +143,7 @@ get_simulation_result_drifts and get_simulation_status_drifts."""
         
         @self.mcp.tool(
             name="get_test_simulation_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns the full details of a specific simulation by id on a given Safebreach management console.
 Supports optional extensions for detailed analysis: MITRE ATT&CK techniques, basic attack logs by host from simulation events, and drift analysis information.
 When include_drift_info=True, returns drift_tracking_code for drifted simulations. Pass this code to \
@@ -165,6 +170,7 @@ For time-window-based drift trends, see get_simulation_result_drifts and get_sim
         
         @self.mcp.tool(
             name="get_security_controls_events",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered and paginated list of security control events for a specific test and simulation.
 These events represent the security controls (products) that SafeBreach was able to correlate to the malicious activity simulation.
 Supports filtering by product name, vendor name, security action, connector name, source host, and destination host.
@@ -199,6 +205,7 @@ connector_name_filter (partial match), source_host_filter (partial match), desti
         
         @self.mcp.tool(
             name="get_security_control_event_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns detailed information for a specific security control event.
 Provides comprehensive data to help SecOps engineers understand the causality between SafeBreach malicious activity simulation and the event emitted by the security control.
 Supports different verbosity levels for context-aware information density.
@@ -222,6 +229,7 @@ verbosity_level (default 'standard', options: 'minimal', 'standard', 'detailed',
         
         @self.mcp.tool(
             name="get_test_findings_counts",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns counts of findings by type for a specific test, with optional filtering by any attribute.
             Findings are the main data points identified by SafeBreach Propagate tests in the customer's environment.
             This function provides a summary view showing how many findings of each type were identified.
@@ -240,6 +248,7 @@ verbosity_level (default 'standard', options: 'minimal', 'standard', 'detailed',
         
         @self.mcp.tool(
             name="get_test_findings_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns detailed findings for a specific test with filtering and pagination by any attribute.
             Findings are the main data points identified by SafeBreach Propagate tests, similar to a Penetration Test report.
             This function provides the full details of findings with support for filtering by any attribute (type, source, severity, hostname, IP addresses, etc.).
@@ -260,6 +269,7 @@ verbosity_level (default 'standard', options: 'minimal', 'standard', 'detailed',
         
         @self.mcp.tool(
             name="get_test_drifts",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Analyzes drift between the given test and the most recent previous test with the same name.
             Compares simulation results to identify: (1) simulations exclusive to baseline test, (2) simulations exclusive to current test,
             (3) simulations with matching drift_tracking_code but different status values.
@@ -280,6 +290,7 @@ use get_simulation_result_drifts or get_simulation_status_drifts instead."""
 
         @self.mcp.tool(
             name="get_full_simulation_logs",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Retrieves comprehensive low-level execution logs for a specific simulation (~40KB detailed traces per node).
 
 IMPORTANT: Use this tool to diagnose why a simulation was stopped, failed, returned no-result, or produced unexpected results.
@@ -311,6 +322,7 @@ Note: Results are cached for 5 minutes. Use get_simulation_details with include_
 
         @self.mcp.tool(
             name="get_simulation_result_drifts",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns time-window-based simulation result drift analysis showing transitions between \
 blocked (FAIL) and not-blocked (SUCCESS) states.
 
@@ -394,6 +406,7 @@ WARNING: This endpoint has no server-side pagination. Large time windows (7+ day
 
         @self.mcp.tool(
             name="get_simulation_status_drifts",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns time-window-based simulation status drift analysis showing transitions between \
 security control final statuses (prevented, stopped, detected, logged, missed, inconsistent).
 
@@ -479,6 +492,7 @@ WARNING: This endpoint has no server-side pagination. Large time windows (7+ day
 
         @self.mcp.tool(
             name="get_security_control_drifts",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Analyze capability transitions for a specific security control over time. \
 Shows how a control's prevented/reported/logged/alerted capabilities changed within a time window.
 
@@ -617,6 +631,7 @@ Start with a narrow window (1-2 days) and widen only if needed."""
 
         @self.mcp.tool(
             name="get_simulation_lineage",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns the full chronological execution history (lineage) of a simulation across all \
 test runs, identified by its drift_tracking_code.
 
@@ -657,6 +672,7 @@ Parameters:
 
         @self.mcp.tool(
             name="get_peer_benchmark_score",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns the customer's security posture score compared to SafeBreach peers for a given time window.
 Wraps POST /api/data/v1/accounts/{account_id}/score (SAF-27621).
 

--- a/safebreach_mcp_playbook/playbook_server.py
+++ b/safebreach_mcp_playbook/playbook_server.py
@@ -12,6 +12,7 @@ from typing import Optional
 # Add parent directory to path to import core components
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from mcp.types import ToolAnnotations
 from safebreach_mcp_core import SafeBreachMCPBase
 from .playbook_functions import (
     sb_get_playbook_attacks,
@@ -37,6 +38,7 @@ class SafeBreachPlaybookServer(SafeBreachMCPBase):
         
         @self.mcp.tool(
             name="get_playbook_attacks",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns a filtered and paginated list of SafeBreach playbook attacks.
 Supports filtering by name, description, ID range, date ranges, MITRE ATT&CK techniques/tactics, and platform.
 Results are paginated with 10 items per page. Each attack includes attacker_platform and target_platform fields.
@@ -158,6 +160,7 @@ Valid platform values: ANY, AWS, AZURE, DOCKER, GCP, LINUX, MAC, MAILBOX, WEBAPP
         
         @self.mcp.tool(
             name="get_playbook_attack_details",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns detailed information for a specific SafeBreach playbook attack by ID.
 Supports verbosity options to include additional details like fix suggestions, tags, parameters, and MITRE ATT&CK data.
 Parameters: console (required), attack_id (required), include_fix_suggestions (default False),

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -13,6 +13,7 @@ from typing import Optional
 # Add parent directory to path to import core components
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from mcp.types import ToolAnnotations
 from safebreach_mcp_core import SafeBreachMCPBase
 from .studio_functions import (
     sb_validate_studio_code,
@@ -47,6 +48,7 @@ class SafeBreachStudioServer(SafeBreachMCPBase):
 
         @self.mcp.tool(
             name="validate_studio_code",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Validates custom Python attack code against SafeBreach Breach Studio requirements.
 
 This tool checks if the Python code contains the required main function signature
@@ -179,6 +181,7 @@ validate_studio_code(python_code=target_code, attacker_code=attacker_code, attac
 
         @self.mcp.tool(
             name="save_studio_attack_draft",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
             description="""Saves a custom Python attack as a draft in SafeBreach Breach Studio.
 
 This tool submits the provided Python code and metadata to create a new draft attack
@@ -273,6 +276,7 @@ the template code, then customize it. Always validate the code using validate_st
 
         @self.mcp.tool(
             name="get_all_studio_attacks",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Retrieves Studio attacks (both draft and published) from SafeBreach Breach Studio.
 
 Results are paginated with 10 items per page. Supports filtering by status, name, and creator.
@@ -358,6 +362,7 @@ get_all_studio_attacks(console="demo", page_number=0, status_filter="draft")"""
 
         @self.mcp.tool(
             name="update_studio_attack_draft",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
             description="""Updates an existing Studio draft attack in SafeBreach Breach Studio.
 
 This tool allows you to modify an existing draft attack's name, code, description, timeout, OS constraint, and parameters.
@@ -451,6 +456,7 @@ Note: Use get_all_studio_attacks to find the attack_id of attacks you want to up
 
         @self.mcp.tool(
             name="get_studio_attack_source",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Retrieves the source code for a Studio attack (target and optionally attacker scripts).
 
 This tool downloads the source code files for a specific attack, whether draft or published.
@@ -525,6 +531,7 @@ get_studio_attack_source(attack_id=10000298, console="demo")"""
 
         @self.mcp.tool(
             name="run_studio_attack",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
             description="""Runs a Studio draft attack on SafeBreach simulators.
 
 IMPORTANT: Always prefer explicit simulator selection over all_connected. Running on all
@@ -618,6 +625,7 @@ run_studio_attack(attack_id=10000298, all_connected=True, console="demo")"""
 
         @self.mcp.tool(
             name="get_studio_attack_latest_result",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Retrieves the latest execution results for a Studio attack by its playbook ID.
 
 This tool queries the execution history to find the most recent runs of a specific Studio attack,
@@ -806,6 +814,7 @@ get_studio_attack_latest_result(attack_id=10000291, console="demo", include_logs
 
         @self.mcp.tool(
             name="create_new_studio_attack",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Returns boilerplate template code and default parameters for creating a new custom attack.
 
 IMPORTANT: When creating a new attack from scratch, ALWAYS start by calling this tool first.
@@ -902,6 +911,7 @@ create_new_studio_attack(attack_type="exfil")"""
 
         @self.mcp.tool(
             name="set_studio_attack_status",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
             description="""Publish or unpublish a Studio attack, transitioning between DRAFT and PUBLISHED states.
 
 Status semantics:
@@ -984,6 +994,7 @@ set_studio_attack_status(attack_id=10000298, new_status="draft", console="demo")
 
         @self.mcp.tool(
             name="run_scenario",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
             description="""Executes a ready-to-run SafeBreach scenario on the platform.
 
 IMPORTANT: This tool triggers REAL attack simulations on simulators. Ensure the correct

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -815,7 +815,7 @@ get_studio_attack_latest_result(attack_id=10000291, console="demo", include_logs
 
         @self.mcp.tool(
             name="create_new_studio_attack",
-            annotations=ToolAnnotations(readOnlyHint=True),
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
             description="""Returns boilerplate template code and default parameters for creating a new custom attack.
 
 IMPORTANT: When creating a new attack from scratch, ALWAYS start by calling this tool first.
@@ -1382,6 +1382,7 @@ Example (3-turn workflow for non-ready scenarios):
 
         @self.mcp.tool(
             name="manage_test",
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
             description="""Manage a running test's lifecycle — pause, resume, or cancel.
 
 Use this tool to control tests that were queued via run_scenario. The test_id is the

--- a/safebreach_mcp_utilities/utilities_server.py
+++ b/safebreach_mcp_utilities/utilities_server.py
@@ -12,6 +12,7 @@ import logging
 # Add parent directory to path to import core components
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from mcp.types import ToolAnnotations
 from safebreach_mcp_core import SafeBreachMCPBase, convert_datetime_to_epoch, convert_epoch_to_datetime
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class SafeBreachUtilitiesServer(SafeBreachMCPBase):
         
         @self.mcp.tool(
             name="convert_datetime_to_epoch",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Converts a datetime string in ISO format to Unix epoch timestamp in MILLISECONDS.
 Returns timestamps in milliseconds format to match SafeBreach API expectations for date filtering parameters (start_date, end_date).
 Supports various ISO datetime formats including timezone information.
@@ -43,6 +45,7 @@ Parameters: datetime_str (required, ISO format string like '2024-01-15T10:30:00Z
 
         @self.mcp.tool(
             name="convert_epoch_to_datetime",
+            annotations=ToolAnnotations(readOnlyHint=True),
             description="""Converts a Unix epoch timestamp to ISO format datetime string.
 Accepts timestamps in both MILLISECONDS (SafeBreach API format) and seconds - auto-detects the format.
 Supports optional timezone specification for the output format. Useful for interpreting epoch timestamps from SafeBreach API responses.


### PR DESCRIPTION
## Summary

Two additive, opt-in changes:

1. **`ToolAnnotations` on every tool** — every `@self.mcp.tool(...)` registration now carries standard MCP [`ToolAnnotations`](https://modelcontextprotocol.io/specification/server/tools#tool-annotations) (`readOnlyHint`, `destructiveHint`). Spec-compliant clients consume them without SafeBreach-specific knowledge. Pure metadata — no behavior change.

2. **`DISABLE_TOOL_LIST` deny list in `SafeBreachMCPBase`** — a single deploy-time env var lets operators hide a set of tools. Filtering wraps the FastMCP tool manager's `list_tools` and `call_tool`, so denied tools are invisible *and* uninvocable. Empty / missing env var = no-op.

Both changes are no-ops for deployments that don't opt in.

## Annotation classification

| Server | Tools | `readOnlyHint` | `destructiveHint` |
|--------|-------|:---:|:---:|
| Config | `get_console_simulators`, `get_simulator_details`, `get_scenarios`, `get_scenario_details` | True | — |
| Data | all 15 `get_*` tools | True | — |
| Utilities | `convert_datetime_to_epoch`, `convert_epoch_to_datetime` | True | — |
| Playbook | `get_playbook_attacks`, `get_playbook_attack_details` | True | — |
| Studio (reads) | `validate_studio_code`, `get_all_studio_attacks`, `get_studio_attack_source`, `get_studio_attack_latest_result` | True | — |
| Studio (writes, non-destructive) | `save_studio_attack_draft`, `update_studio_attack_draft`, `create_new_studio_attack` | False | False |
| Studio (writes, destructive) | `run_studio_attack`, `set_studio_attack_status`, `run_scenario`, `manage_test` | False | True |

The README now has a short [Tool Annotations](README.md#tool-annotations) section explaining the read/write/destructive contract for future contributors.

## DISABLE_TOOL_LIST behavior

```bash
DISABLE_TOOL_LIST='["save_studio_attack_draft","run_studio_attack",...]'
```

- JSON array of tool names. Invalid JSON / wrong shape / non-string elements → logged + treated as empty (fail-open matches no-env-var behavior).
- Re-read on every server start (not module-level), so an operator can change the deny list with a server restart.

## Test plan

- All 1085 non-e2e tests pass unchanged.
- New `safebreach_mcp_core/tests/test_disable_filtering.py` — 12 cases across two classes:
  - `TestParseDisableToolList` — env var parsing (missing, empty, valid array, blank names, invalid JSON, wrong shape, non-string elements).
  - `TestDenyList` — runtime filtering (hidden in `tools/list`, `ToolError` on `tools/call`, passthrough when empty, env-var change between installs takes effect).
