### PR TITLE
SAF-29974: Per-user RBAC enforcement in MCP servers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,62 @@
+"""
+Root conftest.py — provides auth context for E2E tests (SAF-29974).
+
+E2E tests call tool functions directly (not through the MCP ASGI chain),
+so the _user_auth_artifacts ContextVar is not set by the middleware.
+This fixture reads the API token from the environment (same as set_env.sh)
+and sets the ContextVar so get_auth_headers_for_console() works.
+"""
+
+import os
+import pytest
+from safebreach_mcp_core.token_context import _user_auth_artifacts
+
+
+def _resolve_api_token(console: str):
+    """Resolve API token for a console from environment variables."""
+    token_key = f"{console.replace('-', '_')}_apitoken"
+    return os.environ.get(token_key) or os.environ.get('SB_API_KEY')
+
+
+@pytest.fixture(autouse=True, scope="session")
+def set_e2e_auth_context():
+    """Set auth ContextVar for E2E tests using the environment API token.
+
+    Session-scoped so it runs before class-scoped fixtures that call tool
+    functions (e.g., sample_test_id, sample_simulation_id).
+    """
+    console = os.environ.get('E2E_CONSOLE', 'default')
+    api_token = _resolve_api_token(console)
+
+    if not api_token:
+        yield
+        return
+
+    token = _user_auth_artifacts.set({"x-apitoken": api_token})
+    yield
+    _user_auth_artifacts.reset(token)
+
+
+@pytest.fixture
+def e2e_auth_for_console():
+    """Factory fixture: temporarily swap ContextVar to a different console's token.
+
+    Usage in tests that target a non-default console:
+        def test_something(self, e2e_auth_for_console):
+            with e2e_auth_for_console('staging'):
+                result = sb_some_tool(console='staging')
+    """
+    import contextlib
+
+    @contextlib.contextmanager
+    def _swap(console: str):
+        api_token = _resolve_api_token(console)
+        if not api_token:
+            pytest.skip(f"No API token found for console '{console}'")
+        old = _user_auth_artifacts.set({"x-apitoken": api_token})
+        try:
+            yield
+        finally:
+            _user_auth_artifacts.reset(old)
+
+    return _swap

--- a/prds/SAF-29974-support-rbac/prd.md
+++ b/prds/SAF-29974-support-rbac/prd.md
@@ -1,0 +1,379 @@
+# Per-User RBAC Enforcement in SafeBreach MCP Servers — SAF-29974
+
+## 1. Overview
+
+SafeBreach MCP servers previously used a single shared API key (`SB_API_KEY`) for all
+backend API calls. Every user — regardless of role — executed tool calls with the same
+admin-level credentials. This bypassed RBAC entirely: a restricted user could read
+simulation data they shouldn't have access to, and audit logs couldn't trace actions to
+individual users.
+
+This change makes MCP servers **RBAC-aware**: each tool call uses the requesting user's
+own auth credentials, so the backend (OPA at the ui-server) enforces per-user
+permissions. The shared API key is no longer used for tool calls in embedded mode.
+
+**Ticket**: [SAF-29974](https://safebreach.atlassian.net/browse/SAF-29974)
+**Type**: Feature
+**Priority**: High
+
+---
+
+## 2. Motivation
+
+### The Problem
+
+```
+User A (restricted) ──► MCP tool call ──► backend API (shared SB_API_KEY) ──► 200 OK
+User B (admin)       ──► MCP tool call ──► backend API (shared SB_API_KEY) ──► 200 OK
+```
+
+Both users get identical access because the backend sees the same credential. RBAC
+enforcement at OPA (ui-server) never evaluates the actual user's permissions.
+
+### The Goal
+
+```
+User A (restricted) ──► MCP tool call ──► backend API (User A's token) ──► 403 Forbidden
+User B (admin)       ──► MCP tool call ──► backend API (User B's token) ──► 200 OK
+```
+
+Each tool call carries the requesting user's auth credentials. OPA evaluates per-user
+permissions. Restricted users are denied access to resources outside their role.
+
+### Business Value
+
+1. Non-admin users gain MCP tool access with their native RBAC restrictions
+2. Backend audit logs trace actions to individual users (not a shared service account)
+3. Per-user cache isolation prevents cross-user data leakage
+
+---
+
+## 3. Deployment Modes
+
+SafeBreach MCP servers have two deployment modes. This change must preserve both.
+
+### Embedded Mode (inside SIMP/mcp-proxy)
+
+The MCP servers run as asyncio tasks inside the mcp-proxy (SIMP) process. SIMP is the
+gateway that sits between clients (AI agents, breach-genie) and the MCP servers.
+
+- SIMP forwards user auth headers (`x-apitoken`, `x-token`, `cookie`) on every request
+- Backend API calls route through `http://127.0.0.1:1990` (ui-server) where OPA
+  enforces per-user RBAC
+- `SAFEBREACH_LOCAL_ENV` is set by SIMP's `mcp_manager` — this is the signal that
+  embedded mode is active
+- **RBAC is enforced**: tool calls without valid user credentials are rejected
+
+### Standalone Mode (external deployment)
+
+The MCP server runs independently, connecting to a SafeBreach console via its external
+URL. Users connect directly (e.g., from Claude Desktop).
+
+- No SIMP gateway — no auth headers are forwarded
+- API keys come from environment variables or secret providers
+- `SAFEBREACH_LOCAL_ENV` is **not set**
+- **RBAC is not enforced**: tool calls use the shared API key from env vars
+
+### Mode Detection
+
+`get_auth_headers_for_console()` uses `SAFEBREACH_LOCAL_ENV` as the discriminator:
+
+```python
+if os.environ.get('SAFEBREACH_LOCAL_ENV'):
+    # Embedded mode — RBAC enforced, raise on missing auth
+    raise AuthenticationRequired(...)
+else:
+    # Standalone mode — fall back to env-var API key
+    return {'x-apitoken': get_secret_for_console(console)}
+```
+
+---
+
+## 4. Design
+
+### Auth Resolution Chain
+
+`get_auth_headers_for_console(console)` is the single entry point for all tool
+functions to obtain auth headers. It replaces direct calls to
+`get_secret_for_console()`.
+
+```
+1. _user_auth_artifacts ContextVar
+   └─ Set by ASGI middleware from request headers (works for streamable-http)
+
+2. MCP SDK request_ctx (mcp.server.lowlevel.server.request_ctx)
+   └─ Reads auth headers from the POST request that triggered the tool call
+   └─ Works for BOTH SSE and streamable-http (SDK sets it on the tool handler's task)
+
+3. Session store (_session_auth_artifacts[session_id])
+   └─ Defensive tertiary fallback keyed by MCP session ID
+
+4. Mode-dependent final fallback:
+   └─ Embedded (SAFEBREACH_LOCAL_ENV set): raise AuthenticationRequired
+   └─ Standalone (no SAFEBREACH_LOCAL_ENV): get_secret_for_console() → env-var API key
+```
+
+### Why Three Tiers?
+
+The SSE transport has an async context isolation issue: `SseServerTransport.connect_sse`
+uses `anyio.create_task_group()`. The tool handler runs in a different async context
+than the `/messages/` POST ASGI middleware, so `_user_auth_artifacts` ContextVar (tier
+1) is empty.
+
+The MCP SDK's `request_ctx` (tier 2) solves this: it IS set on the same task as the
+tool handler (`server.py:638-646`). The SDK passes the POST request via
+`ServerMessageMetadata(request_context=request)` through the message stream. The
+`_get_auth_from_mcp_request_ctx()` helper extracts auth headers from
+`request_ctx.get().request.headers`.
+
+The session store (tier 3) is a defensive fallback for edge cases.
+
+### Key Discovery: MCP SDK request_ctx
+
+The MCP Python SDK (v1.12.1) provides a `request_ctx` ContextVar at
+`mcp.server.lowlevel.server:105`. It holds a `RequestContext` whose `.request`
+attribute is the Starlette `Request` from the POST that triggered the tool call.
+
+For **SSE**: `request.query_params.get('session_id')` gives the session ID.
+For **streamable-http**: `request.headers.get('mcp-session-id')` gives the session ID.
+For **both**: `request.headers` contains the auth headers SIMP forwarded.
+
+This eliminates the need for any module-level global variable.
+
+---
+
+## 5. Approaches Considered
+
+### A. Headers-First ContextVar + MCP SDK request_ctx (chosen)
+
+Extract auth from ASGI headers on every request, with MCP SDK `request_ctx` as the
+primary fallback for SSE transport. No tool signature changes needed.
+
+- Pros: Minimal code changes, concurrency-safe, backward compatible
+- Cons: Depends on MCP SDK's `request_ctx` internal (guarded with try/except)
+
+### B. Explicit Token Parameter in Tool Functions
+
+Add `api_token: Optional[str]` to every tool function signature.
+
+- Pros: Explicit, no hidden state
+- Cons: Dozens of signature changes, exposes token in MCP protocol messages
+- **Rejected**: Too invasive, security concern
+
+### C. Per-User MCP Server Sessions
+
+Spawn dedicated MCP server instances per user with their token.
+
+- Pros: Zero code changes in tool functions
+- Cons: Massive resource overhead, port management, startup latency
+- **Rejected**: Does not scale
+
+### D. Module-Level Global Variable (_last_user_auth_bundle)
+
+Store the most recent user's auth bundle in a module-level variable as fallback when
+ContextVar doesn't propagate.
+
+- Pros: Simple, works for single-user scenarios
+- Cons: Cross-user credential contamination under concurrent sessions
+- **Implemented in Slice 4, replaced in Slice 6**: Used as an interim bridge for SSE
+  transport. Replaced by `request_ctx` approach once we discovered the SDK provides
+  per-request context to tool handlers.
+
+---
+
+## 6. Changes
+
+### 6.1. New Module: `safebreach_mcp_core/token_context.py`
+
+Central module for per-request auth context. Contains:
+
+| Function | Purpose |
+|----------|---------|
+| `_user_auth_artifacts` ContextVar | Per-request auth bundle (primary source) |
+| `_session_auth_artifacts` dict | Session-keyed backup store with TTL |
+| `extract_auth_bundle(scope)` | Extract auth headers from ASGI scope |
+| `_get_auth_from_mcp_request_ctx()` | Read auth from MCP SDK's `request_ctx` |
+| `_get_session_id_from_mcp_ctx()` | Extract session ID from `request_ctx` |
+| `get_cache_user_suffix()` | SHA-256 hash prefix for per-user cache keys |
+| `_keep_only_cookie()` | Cookie scrubbing (keep X-Token + __secure-Fgp only) |
+| `cleanup_stale_artifacts()` | TTL-based eviction (1 hour, runs every 10 minutes) |
+
+### 6.2. Modified: `safebreach_mcp_core/secret_utils.py`
+
+- `get_auth_headers_for_console(console)` — new function, 4-tier resolution chain
+- `check_rbac_response(response)` — replaces `raise_for_status()` with 403
+  `hint_to_llm` for LLM-friendly permission denial messages
+- `AuthenticationRequired` exception class
+- `get_secret_for_console()` unchanged — still used by startup paths and standalone mode
+
+### 6.3. Modified: `safebreach_mcp_core/safebreach_base.py`
+
+Extended `_create_concurrency_limited_app()` ASGI wrapper:
+
+- **All requests**: Headers-first auth bundle extraction via `extract_auth_bundle(scope)`
+- **SSE GET**: Stores bundle in `_session_auth_artifacts` under middleware session ID,
+  migrates to real session ID when captured from response body
+- **SSE POST**: Stores bundle in session store, sets ContextVar as fallback
+- **Streamable-HTTP**: Stores bundle in session store keyed by `Mcp-Session-Id` header
+- **Cleanup**: Evicts auth artifacts on SSE disconnect and via periodic TTL sweep
+
+### 6.4. Modified: `safebreach_mcp_core/environments_metadata.py`
+
+- `get_api_base_url()` priority reordered: `SAFEBREACH_LOCAL_ENV` > env vars
+- Unknown console names fall back to `'default'` entry in `SAFEBREACH_LOCAL_ENV`
+  (prevents OPA bypass via unknown console name)
+
+### 6.5. Tool Function Migration (all 4 server packages)
+
+All 33 tool functions migrated from:
+```python
+apitoken = get_secret_for_console(console)
+headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+```
+to:
+```python
+headers = {**get_auth_headers_for_console(console), "Content-Type": "application/json"}
+```
+
+All `raise_for_status()` calls replaced with `check_rbac_response()` (35 sites).
+
+| Package | Functions migrated | Cache keys updated |
+|---------|-------------------|-------------------|
+| `safebreach_mcp_data` | 10 | 8 |
+| `safebreach_mcp_config` | 7 | 6 |
+| `safebreach_mcp_studio` | 14 | 3 |
+| `safebreach_mcp_playbook` | 1 | 1 |
+| `safebreach_mcp_core` (suggestions) | 1 | 1 |
+
+### 6.6. Per-User Cache Keys
+
+All cache keys now include `get_cache_user_suffix()` — an 8-char SHA-256 hash of the
+most stable auth artifact (priority: `x-apitoken` > `x-token` > cookie value).
+
+Example: `tests_default` → `tests_default_a3f8b2c1`
+
+Returns empty string in standalone mode (no user context), preserving existing behavior.
+
+### 6.7. Dead Code Removed
+
+- `SafeBreachAuth` class removed from `SafeBreachMCPBase.__init__` — its
+  `get_base_url()` bypassed the RBAC gateway by resolving from `env['url']` directly
+
+---
+
+## 7. Cookie Handling
+
+### Scrubbing
+
+The incoming `cookie` header may contain dozens of cookies (analytics, CSRF, session
+IDs). The middleware scrubs it to keep only:
+
+- `X-Token` — the JWT (configurable via `SAFEBREACH_MCP_AUTH_COOKIE_NAME`)
+- `__secure-Fgp` — the user fingerprint cookie required for JWT validation
+
+### JWT Fingerprint
+
+The ui-server's JWT validation requires the `__secure-Fgp` cookie alongside the JWT.
+Without it, `x-token` auth returns 401. This was discovered during implementation and
+the cookie scrubbing was updated to preserve it.
+
+---
+
+## 8. Security Considerations
+
+### OPA Bypass via Unknown Console Name (Fixed)
+
+A caller could specify `console='anything'` in a tool call. If the console name wasn't
+in `SAFEBREACH_LOCAL_ENV`, `get_api_base_url()` fell through to direct-port env vars,
+bypassing OPA. Fixed: unknown console names fall back to the `'default'` entry.
+
+### Concurrency Safety
+
+The initial implementation used `_last_user_auth_bundle` (a module-level global) as
+fallback for SSE transport. This was a **cross-user credential contamination** bug:
+concurrent users would overwrite each other's credentials.
+
+Replaced with per-request auth extraction from the MCP SDK's `request_ctx`. Each tool
+call reads its own POST's headers — zero shared mutable state, zero race conditions.
+
+### Health Check Placeholder
+
+breach-genie's MCPClient health check uses `x-apitoken: internal-health-check` to pass
+SIMP's auth gate. This is safe because `listTools` doesn't make backend API calls.
+
+---
+
+## 9. Test Coverage
+
+### Unit Tests: `tests/test_auth_concurrency.py` (21 tests)
+
+| Category | Tests | Verifies |
+|----------|-------|----------|
+| `_get_auth_from_mcp_request_ctx` | 7 | Header extraction, cookie scrubbing, None guards |
+| `_get_session_id_from_mcp_ctx` | 4 | SSE query param, streamable-http header, precedence |
+| Concurrent session isolation | 2 | Two sessions with different tokens get own credentials |
+| `get_cache_user_suffix` | 3 | MCP fallback, empty context, ContextVar priority |
+| `_last_user_auth_bundle` removed | 1 | Variable no longer exists |
+| `get_auth_headers_for_console` | 4 | Embedded mode rejection, standalone fallback, copy safety |
+
+### Unit Tests: Existing suites updated
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| `tests/` (core + concurrency + environments) | 62 | Pass |
+| `safebreach_mcp_data/tests/` | 134 | Pass |
+| `safebreach_mcp_config/tests/` | 44 | Pass |
+| `safebreach_mcp_playbook/tests/` | 140 | Pass |
+| `safebreach_mcp_studio/tests/` | 330 | Pass |
+| **Total** | **710** | **All pass** |
+
+### Test Isolation Fix
+
+`test_environments_metadata.py` mutated the module-level `safebreach_envs` dict via
+`SAFEBREACH_LOCAL_ENV` re-imports. Other modules holding references to the dict saw
+stale entries, breaking E2E tests when run in the same pytest session. Fixed by
+snapshotting and restoring the dict in-place (clear + update) in setUp/tearDown.
+
+### E2E Tests (via mcp-proxy repo, both transports)
+
+| Test | User | Tool | Expected | SSE | Streamable |
+|------|------|------|----------|-----|------------|
+| No auth | none | — | 401 | Pass | Pass |
+| Tests_viewer | restricted | get_tests_history | success | Pass | Pass |
+| Admin | admin | get_test_simulations | success | Pass | Pass |
+| Integrations_reader | restricted | get_test_simulations | 403 | Pass | Pass |
+| **Same user +/-** | Tests_viewer | tests → OK, simulations → 403 | **per-endpoint RBAC** | Pass | Pass |
+| No auth (POST) | none | — | 401 | Pass | Pass |
+
+---
+
+## 10. Files Changed
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `safebreach_mcp_core/token_context.py` | +200 | New module: ContextVar, session store, MCP request_ctx helpers, cookie scrubbing |
+| `safebreach_mcp_core/secret_utils.py` | +60 | `get_auth_headers_for_console()`, `check_rbac_response()`, `AuthenticationRequired` |
+| `safebreach_mcp_core/safebreach_base.py` | +80 | Auth extraction in ASGI wrapper, session store writes, cleanup |
+| `safebreach_mcp_core/environments_metadata.py` | +30 | URL priority reorder, OPA bypass fix |
+| `safebreach_mcp_data/data_functions.py` | ~50 | 10 tool migrations + cache keys |
+| `safebreach_mcp_config/config_functions.py` | ~40 | 7 tool migrations + cache keys |
+| `safebreach_mcp_studio/studio_functions.py` | ~60 | 14 tool migrations + cache keys |
+| `safebreach_mcp_playbook/playbook_functions.py` | ~10 | 1 tool migration + cache key |
+| `safebreach_mcp_core/suggestions.py` | ~5 | 1 migration + cache key |
+| `conftest.py` | +62 | Root conftest with session-scoped ContextVar fixture for E2E |
+| `tests/test_auth_concurrency.py` | +290 | 21 concurrency safety tests |
+| `tests/test_environments_metadata.py` | +15 | Test isolation fix for safebreach_envs dict |
+
+---
+
+## 11. Known Limitations
+
+- **JWT expiry**: JWTs expire after 30 minutes. Long-running MCP sessions may hit 401
+  on tool calls after expiry. The client must reconnect with a fresh token.
+- **OPA subject `general`**: The `testsummaries` endpoint uses OPA subject `general`
+  which all roles have. Test listing cannot be restricted via OPA. Only endpoints with
+  specific subjects (`simulationResults`, `testResults`) have per-role enforcement.
+- **`AppController` in breach-genie**: The `/apps/:appName/stream` endpoint does not
+  yet thread user auth. Deferred until app streaming uses MCP tools.
+- **Cache key rotation**: JWTs rotate on re-login, causing cache misses for the same
+  user across sessions. This is acceptable — it's safer than sharing caches.

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -10,7 +10,7 @@ import logging
 from typing import Dict, List, Optional, Any
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console, check_rbac_response
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from .config_types import (
@@ -165,7 +165,7 @@ def _get_all_simulators_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
         
         logger.info(f"Fetching simulators from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         
         try:
             response_data = response.json()
@@ -312,7 +312,7 @@ def sb_get_simulator_details(simulator_id: str, console: str = "default") -> Dic
                     **get_auth_headers_for_console(console)}
 
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         
         try:
             response_data = response.json()
@@ -381,7 +381,7 @@ def _get_all_plans_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
 
         logger.info(f"Fetching custom plans from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         response_data = response.json()
         # Plans API wraps the list in {"data": [...]}
@@ -425,7 +425,7 @@ def _get_users_map_from_cache_or_api(console: str) -> Dict[int, str]:
 
         logger.info(f"Fetching users from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         response_data = response.json()
         users_list = response_data.get("data", []) if isinstance(response_data, dict) else response_data
@@ -469,7 +469,7 @@ def _get_assets_map_from_cache_or_api(console: str) -> Dict[int, Dict[str, str]]
 
         logger.info(f"Fetching assets from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         response_data = response.json()
         assets_list = response_data.get("data", []) if isinstance(response_data, dict) else response_data
@@ -515,7 +515,7 @@ def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
 
         logger.info(f"Fetching scenarios from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         scenarios = response.json()
 
@@ -556,7 +556,7 @@ def _get_categories_map_from_cache_or_api(console: str) -> Dict[int, str]:
 
         logger.info(f"Fetching scenario categories from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         categories_list = response.json()
         categories_map = {cat["id"]: cat["name"] for cat in categories_list}

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -10,7 +10,8 @@ import logging
 from typing import Dict, List, Optional, Any
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from .config_types import (
     get_minimal_simulator_mapping,
@@ -143,7 +144,7 @@ def _get_all_simulators_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     Returns:
         List of simulator dictionaries
     """
-    cache_key = f"simulators_{console}"
+    cache_key = f"simulators_{console}{get_cache_user_suffix()}"
 
     # Check cache first (only if caching is enabled)
     if is_caching_enabled("config"):
@@ -154,14 +155,13 @@ def _get_all_simulators_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     
     # Cache miss or expired - fetch from API using EXACT same pattern as original
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'config')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/config/v1/accounts/{account_id}/nodes?details=true&deleted=false&assets=true&impersonatedUsers=true&includeProxies=false&deployments=false"
 
         headers = {"Content-Type": "application/json",
-                    "x-apitoken": apitoken}
+                    **get_auth_headers_for_console(console)}
         
         logger.info(f"Fetching simulators from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -302,7 +302,6 @@ def sb_get_simulator_details(simulator_id: str, console: str = "default") -> Dic
     
     try:
         logger.info("Getting api key for console %s", console)
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'config')
         account_id = get_api_account_id(console)
 
@@ -310,7 +309,7 @@ def sb_get_simulator_details(simulator_id: str, console: str = "default") -> Dic
         api_url = f"{base_url}/api/config/v1/accounts/{account_id}/nodes/{simulator_id}"
 
         headers = {"Content-Type": "application/json",
-                    "x-apitoken": apitoken}
+                    **get_auth_headers_for_console(console)}
 
         response = requests.get(api_url, headers=headers, timeout=120)
         response.raise_for_status()
@@ -365,7 +364,7 @@ def _get_all_plans_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     Returns:
         List of full plan dictionaries
     """
-    cache_key = f"plans_{console}"
+    cache_key = f"plans_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("config"):
         cached = plans_cache.get(cache_key)
@@ -374,12 +373,11 @@ def _get_all_plans_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
             return cached
 
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'config')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/config/v2/accounts/{account_id}/plans?details=true"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         logger.info(f"Fetching custom plans from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -410,7 +408,7 @@ def _get_users_map_from_cache_or_api(console: str) -> Dict[int, str]:
     Returns:
         Dict mapping user ID (int) to user name (str)
     """
-    cache_key = f"users_{console}"
+    cache_key = f"users_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("config"):
         cached = users_cache.get(cache_key)
@@ -419,12 +417,11 @@ def _get_users_map_from_cache_or_api(console: str) -> Dict[int, str]:
             return cached
 
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'config')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/config/v1/accounts/{account_id}/users?details=false&deleted=true"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         logger.info(f"Fetching users from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -455,7 +452,7 @@ def _get_assets_map_from_cache_or_api(console: str) -> Dict[int, Dict[str, str]]
     Returns:
         Dict mapping asset ID (int) to {name, type} dict
     """
-    cache_key = f"assets_{console}"
+    cache_key = f"assets_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("config"):
         cached = assets_cache.get(cache_key)
@@ -464,12 +461,11 @@ def _get_assets_map_from_cache_or_api(console: str) -> Dict[int, Dict[str, str]]
             return cached
 
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'config')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/config/v1/accounts/{account_id}/assets"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         logger.info(f"Fetching assets from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -503,7 +499,7 @@ def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     Returns:
         List of full scenario dictionaries
     """
-    cache_key = f"scenarios_{console}"
+    cache_key = f"scenarios_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("config"):
         cached = scenarios_cache.get(cache_key)
@@ -512,11 +508,10 @@ def _get_all_scenarios_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
             return cached
 
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'playbook')
 
         api_url = f"{base_url}/api/content-manager/vLatest/scenarios"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         logger.info(f"Fetching scenarios from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -545,7 +540,7 @@ def _get_categories_map_from_cache_or_api(console: str) -> Dict[int, str]:
     Returns:
         Dict mapping category ID (int) to category name (str)
     """
-    cache_key = f"categories_{console}"
+    cache_key = f"categories_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("config"):
         cached = categories_cache.get(cache_key)
@@ -554,11 +549,10 @@ def _get_categories_map_from_cache_or_api(console: str) -> Dict[int, str]:
             return cached
 
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'playbook')
 
         api_url = f"{base_url}/api/content-manager/vLatest/scenarioCategories"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         logger.info(f"Fetching scenario categories from API for console '{console}'")
         response = requests.get(api_url, headers=headers, timeout=120)

--- a/safebreach_mcp_config/tests/test_config_functions.py
+++ b/safebreach_mcp_config/tests/test_config_functions.py
@@ -26,9 +26,17 @@ from safebreach_mcp_config.config_functions import (
     clear_categories_cache,
     clear_plans_cache,
 )
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 
 class TestConfigFunctions:
     """Test suite for config functions."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
     
     def setup_method(self):
         """Setup for each test method."""
@@ -95,12 +103,10 @@ class TestConfigFunctions:
     @patch('safebreach_mcp_config.config_functions._get_assets_map_from_cache_or_api', return_value={})
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_get_all_simulators_from_cache_or_api_success(self, mock_get, mock_secret, mock_account_id, mock_base_url, mock_assets, mock_api_response):
+    def test_get_all_simulators_from_cache_or_api_success(self, mock_get, mock_account_id, mock_base_url, mock_assets, mock_api_response):
         """Test successful retrieval of simulators from API."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = mock_api_response
         mock_response.status_code = 200
@@ -117,15 +123,13 @@ class TestConfigFunctions:
 
         # Verify API was called
         mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_get_all_simulators_from_cache(self, mock_get, mock_secret, mock_cache_enabled, mock_simulator_data):
+    def test_get_all_simulators_from_cache(self, mock_get, mock_cache_enabled, mock_simulator_data):
         """Test retrieval of simulators from cache when caching is enabled."""
         # Setup cache
-        cache_key = "simulators_test-console"
+        cache_key = f"simulators_test-console{get_cache_user_suffix()}"
         simulators_cache.set(cache_key, mock_simulator_data)
 
         # Test
@@ -137,20 +141,17 @@ class TestConfigFunctions:
 
         # Verify API was NOT called
         mock_get.assert_not_called()
-        mock_secret.assert_not_called()
     
     @patch('safebreach_mcp_config.config_functions._get_assets_map_from_cache_or_api', return_value={})
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_get_all_simulators_cache_miss_fetches_api(self, mock_get, mock_secret, mock_account_id, mock_base_url, mock_cache_enabled, mock_assets, mock_api_response):
+    def test_get_all_simulators_cache_miss_fetches_api(self, mock_get, mock_account_id, mock_base_url, mock_cache_enabled, mock_assets, mock_api_response):
         """Test that cache miss (expired or empty) falls through to API fetch."""
         # Cache is empty (simulates expired/missing entry - TTLCache handles expiry internally)
 
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = mock_api_response
         mock_response.status_code = 200
@@ -165,7 +166,6 @@ class TestConfigFunctions:
 
         # Verify API was called due to cache miss
         mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     def test_apply_simulator_filters_status(self, mock_simulator_data):
         """Test status filtering."""
@@ -293,12 +293,10 @@ class TestConfigFunctions:
     
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_sb_get_simulator_details_success(self, mock_get, mock_secret, mock_account_id, mock_base_url):
+    def test_sb_get_simulator_details_success(self, mock_get, mock_account_id, mock_base_url):
         """Test successful simulator details retrieval."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": {
@@ -334,15 +332,12 @@ class TestConfigFunctions:
         assert "id" in result
         assert result["id"] == "sim1"
         mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_sb_get_simulator_details_error(self, mock_get, mock_secret, mock_account_id, mock_base_url):
+    def test_sb_get_simulator_details_error(self, mock_get, mock_account_id, mock_base_url):
         """Test error handling in simulator details retrieval."""
-        mock_secret.return_value = "test-token"
         mock_get.side_effect = Exception("API Error")
         
         # The function should now raise an exception
@@ -359,39 +354,13 @@ class TestConfigFunctions:
         # Should return error, not empty results
         assert "error" in result
         assert result["console"] == "unknown_console"
-        assert "not found" in result["error"]
-        assert "Available consoles:" in result["error"]
-        
+        assert "not found" in result["error"] or "No URL configured" in result["error"]
+
     def test_unknown_console_validation_simulator_details(self):
         """Test unknown console validation in sb_get_simulator_details."""
-        # Test sb_get_simulator_details - should raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_simulator_details(simulator_id="sim123", console="unknown_console")
-        assert "not found" in str(exc_info.value)
-    
-    @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
-    def test_secret_provider_failure_validation(self, mock_account_id, mock_base_url):
-        """Test that secret provider failures return proper error messages."""
-        from botocore.exceptions import ClientError
-        
-        # Mock ClientError for parameter not found
-        with patch('safebreach_mcp_config.config_functions.get_secret_for_console') as mock_secret:
-            mock_secret.side_effect = ClientError(
-                error_response={'Error': {'Code': 'ParameterNotFound', 'Message': 'Parameter not found'}},
-                operation_name='GetParameter'
-            )
-            
-            # Test sb_get_console_simulators
-            result = sb_get_console_simulators(console="test-console")
-            assert "error" in result
-            assert result.get("console") == "test-console"
-            assert "ParameterNotFound" in result["error"]
-            
-            # Test sb_get_simulator_details - should raise ClientError
-            with pytest.raises(ClientError) as exc_info:
-                sb_get_simulator_details(simulator_id="sim123", console="test-console")
-            assert "ParameterNotFound" in str(exc_info.value)
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
     
     def test_sb_get_simulator_details_empty_simulator_id(self):
         """Test validation for empty simulator_id parameter."""
@@ -504,6 +473,13 @@ MOCK_CATEGORIES_DATA = [
 class TestGetAllScenariosFromCacheOrApi:
     """Test _get_all_scenarios_from_cache_or_api function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def setup_method(self):
         clear_scenarios_cache()
         clear_categories_cache()
@@ -513,9 +489,8 @@ class TestGetAllScenariosFromCacheOrApi:
         clear_categories_cache()
 
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_api_call_success(self, mock_get, mock_secret, mock_base_url):
+    def test_api_call_success(self, mock_get, mock_base_url):
         mock_response = Mock()
         mock_response.json.return_value = MOCK_SCENARIO_DATA
         mock_response.status_code = 200
@@ -531,10 +506,9 @@ class TestGetAllScenariosFromCacheOrApi:
         assert '/api/content-manager/vLatest/scenarios' in str(mock_get.call_args)
 
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_cache_hit(self, mock_get, mock_secret, mock_cache_enabled):
-        scenarios_cache.set("scenarios_test-console", MOCK_SCENARIO_DATA)
+    def test_cache_hit(self, mock_get, mock_cache_enabled):
+        scenarios_cache.set(f"scenarios_test-console{get_cache_user_suffix()}", MOCK_SCENARIO_DATA)
 
         result = _get_all_scenarios_from_cache_or_api("test-console")
 
@@ -543,9 +517,8 @@ class TestGetAllScenariosFromCacheOrApi:
 
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_cache_miss_fetches_api(self, mock_get, mock_secret, mock_base_url, mock_cache_enabled):
+    def test_cache_miss_fetches_api(self, mock_get, mock_base_url, mock_cache_enabled):
         mock_response = Mock()
         mock_response.json.return_value = MOCK_SCENARIO_DATA
         mock_response.raise_for_status.return_value = None
@@ -557,9 +530,8 @@ class TestGetAllScenariosFromCacheOrApi:
         mock_get.assert_called_once()
 
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url):
+    def test_api_error_propagates(self, mock_get, mock_base_url):
         mock_get.side_effect = Exception("Connection timeout")
 
         with pytest.raises(Exception, match="Connection timeout"):
@@ -568,6 +540,13 @@ class TestGetAllScenariosFromCacheOrApi:
 
 class TestGetCategoriesMapFromCacheOrApi:
     """Test _get_categories_map_from_cache_or_api function."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def setup_method(self):
         clear_scenarios_cache()
@@ -578,9 +557,8 @@ class TestGetCategoriesMapFromCacheOrApi:
         clear_categories_cache()
 
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_returns_id_to_name_map(self, mock_get, mock_secret, mock_base_url):
+    def test_returns_id_to_name_map(self, mock_get, mock_base_url):
         mock_response = Mock()
         mock_response.json.return_value = MOCK_CATEGORIES_DATA
         mock_response.raise_for_status.return_value = None
@@ -594,10 +572,9 @@ class TestGetCategoriesMapFromCacheOrApi:
         assert result[4] == "Baseline Scenarios"
 
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_cache_hit(self, mock_get, mock_secret, mock_cache_enabled):
-        categories_cache.set("categories_test-console", {2: "Known Threats Series"})
+    def test_cache_hit(self, mock_get, mock_cache_enabled):
+        categories_cache.set(f"categories_test-console{get_cache_user_suffix()}", {2: "Known Threats Series"})
 
         result = _get_categories_map_from_cache_or_api("test-console")
 
@@ -605,9 +582,8 @@ class TestGetCategoriesMapFromCacheOrApi:
         mock_get.assert_not_called()
 
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url):
+    def test_api_error_propagates(self, mock_get, mock_base_url):
         mock_get.side_effect = Exception("API unreachable")
 
         with pytest.raises(Exception, match="API unreachable"):
@@ -768,6 +744,13 @@ class TestSbGetScenarios:
 class TestGetAllPlansFromCacheOrApi:
     """Test _get_all_plans_from_cache_or_api function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def setup_method(self):
         clear_plans_cache()
 
@@ -776,9 +759,8 @@ class TestGetAllPlansFromCacheOrApi:
 
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123456')
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_api_call_success_unwraps_data(self, mock_get, mock_secret, mock_base_url, mock_account):
+    def test_api_call_success_unwraps_data(self, mock_get, mock_base_url, mock_account):
         mock_response = Mock()
         mock_response.json.return_value = {"data": [{"id": 1, "name": "Plan 1"}]}
         mock_response.raise_for_status.return_value = None
@@ -795,7 +777,7 @@ class TestGetAllPlansFromCacheOrApi:
     @patch('safebreach_mcp_config.config_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_config.config_functions.requests.get')
     def test_cache_hit_skips_api(self, mock_get, mock_cache_enabled):
-        plans_cache.set("plans_test-console", [{"id": 99, "name": "Cached"}])
+        plans_cache.set(f"plans_test-console{get_cache_user_suffix()}", [{"id": 99, "name": "Cached"}])
 
         result = _get_all_plans_from_cache_or_api("test-console")
 
@@ -804,9 +786,8 @@ class TestGetAllPlansFromCacheOrApi:
 
     @patch('safebreach_mcp_config.config_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_config.config_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_config.config_functions.get_secret_for_console', return_value='test-token')
     @patch('safebreach_mcp_config.config_functions.requests.get')
-    def test_api_error_propagates(self, mock_get, mock_secret, mock_base_url, mock_account):
+    def test_api_error_propagates(self, mock_get, mock_base_url, mock_account):
         mock_get.side_effect = Exception("API unreachable")
 
         with pytest.raises(Exception, match="API unreachable"):

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -115,11 +115,11 @@ def get_api_base_url(console:str, endpoint:str) -> str:
                 service_url = console_config['urls'][endpoint]
                 full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
                 if lookup_name != console:
-                    logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV 'default' fallback)",
-                                console, endpoint, full_url)
+                    logger.debug("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV 'default' fallback)",
+                                 console, endpoint, full_url)
                 else:
-                    logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV urls)",
-                                console, endpoint, full_url)
+                    logger.debug("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV urls)",
+                                 console, endpoint, full_url)
                 return full_url
         except (ValueError, KeyError):
             continue
@@ -128,14 +128,14 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     env_var_name = f'{endpoint.upper()}_URL'
     env_url = os.getenv(env_var_name)
     if env_url:
-        logger.info("get_api_base_url('%s', '%s') → %s (from env var %s)", console, endpoint, env_url, env_var_name)
+        logger.debug("get_api_base_url('%s', '%s') → %s (from env var %s)", console, endpoint, env_url, env_var_name)
         return env_url
 
     # Priority 3: SAFEBREACH_LOCAL_ENV default URL fallback
     try:
         console_config = get_environment_by_name(console)
         default_url = f"https://{console_config['url']}"
-        logger.info("get_api_base_url('%s', '%s') → %s (from default url)", console, endpoint, default_url)
+        logger.debug("get_api_base_url('%s', '%s') → %s (from default url)", console, endpoint, default_url)
         return default_url
     except (ValueError, KeyError):
         raise ValueError(f"No URL configured for console '{console}', endpoint '{endpoint}'")

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -106,15 +106,23 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     """
     # Priority 1: SAFEBREACH_LOCAL_ENV service-specific URL (SAF-29974)
     # When running inside SIMP, mcp_manager sets these to the RBAC gateway URL.
-    try:
-        console_config = get_environment_by_name(console)
-        if 'urls' in console_config and endpoint in console_config['urls']:
-            service_url = console_config['urls'][endpoint]
-            full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
-            logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV urls)", console, endpoint, full_url)
-            return full_url
-    except (ValueError, KeyError):
-        pass
+    # If the exact console name isn't found, fall back to the 'default' entry —
+    # this prevents callers from bypassing OPA by specifying an unknown console name.
+    for lookup_name in (console, 'default'):
+        try:
+            console_config = get_environment_by_name(lookup_name)
+            if 'urls' in console_config and endpoint in console_config['urls']:
+                service_url = console_config['urls'][endpoint]
+                full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
+                if lookup_name != console:
+                    logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV 'default' fallback)",
+                                console, endpoint, full_url)
+                else:
+                    logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV urls)",
+                                console, endpoint, full_url)
+                return full_url
+        except (ValueError, KeyError):
+            continue
 
     # Priority 2: Per-service environment variables (standalone MCP server mode)
     env_var_name = f'{endpoint.upper()}_URL'

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -4,8 +4,10 @@ SafeBreach Environments Configuration
 This file contains metadata and configurations for Safebreach labs and AWS resources 
 in the scope of impact for SafeBreach MCP Servergi.
 '''
-import json, os
+import json, os, logging
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 safebreach_envs = {
     # Default example configurations:
@@ -109,6 +111,7 @@ def get_api_base_url(console:str, endpoint:str) -> str:
         if 'urls' in console_config and endpoint in console_config['urls']:
             service_url = console_config['urls'][endpoint]
             full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
+            logger.info("get_api_base_url('%s', '%s') → %s (from SAFEBREACH_LOCAL_ENV urls)", console, endpoint, full_url)
             return full_url
     except (ValueError, KeyError):
         pass
@@ -117,12 +120,14 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     env_var_name = f'{endpoint.upper()}_URL'
     env_url = os.getenv(env_var_name)
     if env_url:
+        logger.info("get_api_base_url('%s', '%s') → %s (from env var %s)", console, endpoint, env_url, env_var_name)
         return env_url
 
     # Priority 3: SAFEBREACH_LOCAL_ENV default URL fallback
     try:
         console_config = get_environment_by_name(console)
         default_url = f"https://{console_config['url']}"
+        logger.info("get_api_base_url('%s', '%s') → %s (from default url)", console, endpoint, default_url)
         return default_url
     except (ValueError, KeyError):
         raise ValueError(f"No URL configured for console '{console}', endpoint '{endpoint}'")

--- a/safebreach_mcp_core/environments_metadata.py
+++ b/safebreach_mcp_core/environments_metadata.py
@@ -89,12 +89,12 @@ def get_environment_by_name(name: str) -> dict:
 def get_api_base_url(console:str, endpoint:str) -> str:
     """
     Get the base URL for SafeBreach API for a given console and endpoint.
-    
-    Priority order:
-    1. Single-tenant mode: Environment variables (DATA_URL, CONFIG_URL, etc.)
-    2. Multi-tenant mode with service-specific URLs: console config 'urls[endpoint]'
-    3. Multi-tenant mode fallback: console config 'url' (default)
-    
+
+    Priority order (SAF-29974: reordered so SAFEBREACH_LOCAL_ENV wins over env vars):
+    1. SAFEBREACH_LOCAL_ENV service-specific URLs (set by mcp_manager in SIMP)
+    2. Per-service environment variables (DATA_URL, CONFIG_URL, etc.)
+    3. SAFEBREACH_LOCAL_ENV default URL fallback
+
     Args:
         console: Console name (e.g., 'demo-console', 'example-console')
         endpoint: Endpoint name can only be one of 'data', 'config', 'moves', 'queue', 'siem', 'playbook', 'orchestrator'
@@ -102,25 +102,30 @@ def get_api_base_url(console:str, endpoint:str) -> str:
     Returns:
         Base URL as a string
     """
-    # Priority 1: Single-tenant mode (environment variables)
+    # Priority 1: SAFEBREACH_LOCAL_ENV service-specific URL (SAF-29974)
+    # When running inside SIMP, mcp_manager sets these to the RBAC gateway URL.
+    try:
+        console_config = get_environment_by_name(console)
+        if 'urls' in console_config and endpoint in console_config['urls']:
+            service_url = console_config['urls'][endpoint]
+            full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
+            return full_url
+    except (ValueError, KeyError):
+        pass
+
+    # Priority 2: Per-service environment variables (standalone MCP server mode)
     env_var_name = f'{endpoint.upper()}_URL'
     env_url = os.getenv(env_var_name)
-
     if env_url:
         return env_url
-    
-    # Priority 2 & 3: Multi-tenant mode - get console configuration
-    console_config = get_environment_by_name(console)
-    
-    # Priority 2: Service-specific URL (new feature)
-    if 'urls' in console_config and endpoint in console_config['urls']:
-        service_url = console_config['urls'][endpoint]
-        full_url = f"https://{service_url}" if not service_url.startswith(('http://', 'https://')) else service_url
-        return full_url
-    
-    # Priority 3: Default fallback URL (backward compatibility)
-    default_url = f"https://{console_config['url']}"
-    return default_url
+
+    # Priority 3: SAFEBREACH_LOCAL_ENV default URL fallback
+    try:
+        console_config = get_environment_by_name(console)
+        default_url = f"https://{console_config['url']}"
+        return default_url
+    except (ValueError, KeyError):
+        raise ValueError(f"No URL configured for console '{console}', endpoint '{endpoint}'")
 
 def get_api_account_id(console: str) -> str:
     """

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -31,7 +31,8 @@ _parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _parent_dir not in sys.path:
     sys.path.insert(0, _parent_dir)
 from mcp_server_bug_423_hotfix import apply_patch
-from .safebreach_auth import SafeBreachAuth
+# SafeBreachAuth removed (SAF-29974): its get_base_url() bypasses the RBAC gateway.
+# Tool functions use get_auth_headers_for_console() + get_api_base_url() instead.
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,6 @@ class SafeBreachMCPBase:
             self.base_url = '/'
         
         self.mcp = FastMCP(server_name)
-        self.auth = SafeBreachAuth()
         self._cache = SafeBreachCache(name=f"{server_name}_base", maxsize=10, ttl=3600)
         self._uvicorn_server: Optional[Any] = None
     

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -671,6 +671,11 @@ class SafeBreachMCPBase:
 
             # Streamable HTTP — single endpoint, session identified by Mcp-Session-Id header
             if transport == 'streamable-http' and path == endpoint_path:
+                # Update module-level auth bundle for streamable-http (SAF-29974)
+                if bundle and ('x-token' in bundle or 'cookie' in bundle):
+                    import safebreach_mcp_core.token_context as _tc
+                    _tc._last_user_auth_bundle = bundle
+
                 headers_dict = dict(scope.get("headers", []))
                 session_id = headers_dict.get(b"mcp-session-id", b"").decode("utf-8", errors="replace")
 

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -600,8 +600,21 @@ class SafeBreachMCPBase:
                             break
 
                 if session_id:
-                    # Session store fallback for auth (SAF-29974): if headers-first
-                    # extraction found nothing, try the session store
+                    # Auth bundle propagation (SAF-29974):
+                    # The ContextVar set at the ASGI level does NOT propagate into
+                    # the FastMCP tool handler because SseServerTransport.connect_sse
+                    # uses asyncio.create_task(). Although Python 3.12 copies ContextVars
+                    # to new tasks, the /messages/ POST handler runs in a DIFFERENT task
+                    # than the SSE GET's create_task where the tool handler lives.
+                    # Solution: store the user's bundle in a module-level variable that
+                    # the tool handler can read regardless of async context.
+                    if bundle and ('x-token' in bundle or 'cookie' in bundle):
+                        from .token_context import _last_user_auth_bundle
+                        import safebreach_mcp_core.token_context as _tc
+                        _tc._last_user_auth_bundle = bundle
+                        _session_auth_artifacts[session_id] = (bundle, time.time())
+
+                    # Session store fallback for auth
                     if not bundle:
                         art_entry = _session_auth_artifacts.get(session_id)
                         if art_entry:

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -42,6 +42,12 @@ _session_semaphores: Dict[str, tuple[asyncio.Semaphore, float]] = {}
 _concurrency_limit = int(os.environ.get('SAFEBREACH_MCP_CONCURRENCY_LIMIT', '2'))
 _SEMAPHORE_MAX_AGE = 3600  # 1 hour — stale semaphores are cleaned up after this
 
+# Auth artifact propagation (SAF-29974)
+from .token_context import (  # noqa: E402
+    _user_auth_artifacts, _session_auth_artifacts,
+    extract_auth_bundle, cleanup_stale_artifacts, mask_artifacts
+)
+
 
 async def _cleanup_stale_semaphores() -> None:
     """Periodically remove SSE session semaphores older than _SEMAPHORE_MAX_AGE."""
@@ -56,6 +62,8 @@ async def _cleanup_stale_semaphores() -> None:
             _session_semaphores.pop(sid, None)
         if stale:
             logger.info(f"🧹 Cleaned up {len(stale)} stale SSE semaphore(s), {len(_session_semaphores)} remaining")
+        # Also clean up stale auth artifacts (SAF-29974)
+        cleanup_stale_artifacts(_SEMAPHORE_MAX_AGE)
 
 
 class SafeBreachMCPBase:
@@ -510,6 +518,11 @@ class SafeBreachMCPBase:
 
             path = scope.get("path", "/")
 
+            # Headers-first auth bundle extraction (SAF-29974)
+            bundle = extract_auth_bundle(scope)
+            if bundle:
+                _user_auth_artifacts.set(bundle)
+
             # SSE connection establishment — assign a new session ID
             if path.endswith("/sse"):
                 middleware_session_id = str(uuid.uuid4())
@@ -520,6 +533,11 @@ class SafeBreachMCPBase:
                     f"🆔 New SSE session: {middleware_session_id[:8]}... "
                     f"(limit={_concurrency_limit}, active_sessions={len(_session_semaphores)})"
                 )
+                # Stash auth bundle for SSE session resilience (SAF-29974)
+                if bundle:
+                    _session_auth_artifacts[middleware_session_id] = (bundle, time.time())
+                    logger.info(f"🔑 Auth artifacts for session {middleware_session_id[:8]}...: "
+                                f"{list(bundle.keys())}")
 
                 real_session_id = None
 
@@ -537,6 +555,10 @@ class SafeBreachMCPBase:
                             real_session_id = match.group(1)
                             _session_semaphores.pop(middleware_session_id, None)
                             _session_semaphores[real_session_id] = (sem, time.time())
+                            # Migrate auth artifacts alongside semaphore (SAF-29974)
+                            auth_entry = _session_auth_artifacts.pop(middleware_session_id, None)
+                            if auth_entry is not None:
+                                _session_auth_artifacts[real_session_id] = auth_entry
                             logger.info(
                                 f"🔄 Session migrated: {middleware_session_id[:8]}... "
                                 f"→ {real_session_id[:8]}..."
@@ -547,10 +569,11 @@ class SafeBreachMCPBase:
                                 f"— no session_id found (len={len(body)})"
                             )
 
-                    # Clean up semaphore when SSE connection ends
+                    # Clean up semaphore and auth artifacts when SSE connection ends
                     if message.get("type") == "http.response.body" and not message.get("more_body", False):
                         cleanup_id = real_session_id or middleware_session_id
                         _session_semaphores.pop(cleanup_id, None)
+                        _session_auth_artifacts.pop(cleanup_id, None)
                         logger.info(
                             f"🧹 Cleaned up session: {cleanup_id[:8]}... "
                             f"(migrated={'yes' if real_session_id else 'no'}, "
@@ -577,6 +600,16 @@ class SafeBreachMCPBase:
                             break
 
                 if session_id:
+                    # Session store fallback for auth (SAF-29974): if headers-first
+                    # extraction found nothing, try the session store
+                    if not bundle:
+                        art_entry = _session_auth_artifacts.get(session_id)
+                        if art_entry:
+                            _user_auth_artifacts.set(art_entry[0])
+                            logger.debug(
+                                f"🔑 Auth from session store for {session_id[:8]}..."
+                            )
+
                     # Lazy semaphore creation for sessions first seen via query string
                     if session_id not in _session_semaphores:
                         _session_semaphores[session_id] = (

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -600,18 +600,11 @@ class SafeBreachMCPBase:
                             break
 
                 if session_id:
-                    # Auth bundle propagation (SAF-29974):
-                    # The ContextVar set at the ASGI level does NOT propagate into
-                    # the FastMCP tool handler because SseServerTransport.connect_sse
-                    # uses asyncio.create_task(). Although Python 3.12 copies ContextVars
-                    # to new tasks, the /messages/ POST handler runs in a DIFFERENT task
-                    # than the SSE GET's create_task where the tool handler lives.
-                    # Solution: store the user's bundle in a module-level variable that
-                    # the tool handler can read regardless of async context.
+                    # Auth bundle propagation (SAF-29974 Slice 6):
+                    # Store the user's auth bundle in the session store so that
+                    # get_auth_headers_for_console() can look it up by session_id
+                    # via the MCP SDK's request_ctx (which IS available in tool handlers).
                     if bundle and ('x-token' in bundle or 'cookie' in bundle):
-                        from .token_context import _last_user_auth_bundle
-                        import safebreach_mcp_core.token_context as _tc
-                        _tc._last_user_auth_bundle = bundle
                         _session_auth_artifacts[session_id] = (bundle, time.time())
 
                     # Session store fallback for auth
@@ -671,13 +664,12 @@ class SafeBreachMCPBase:
 
             # Streamable HTTP — single endpoint, session identified by Mcp-Session-Id header
             if transport == 'streamable-http' and path == endpoint_path:
-                # Update module-level auth bundle for streamable-http (SAF-29974)
-                if bundle and ('x-token' in bundle or 'cookie' in bundle):
-                    import safebreach_mcp_core.token_context as _tc
-                    _tc._last_user_auth_bundle = bundle
-
                 headers_dict = dict(scope.get("headers", []))
                 session_id = headers_dict.get(b"mcp-session-id", b"").decode("utf-8", errors="replace")
+
+                # Store auth bundle in session store for streamable-http (SAF-29974 Slice 6)
+                if bundle and session_id:
+                    _session_auth_artifacts[session_id] = (bundle, time.time())
 
                 if not session_id:
                     # Initialize request — no session yet, pass through

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -99,6 +99,16 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     Non-tool callers (startup, health checks) should use get_secret_for_console() directly.
     """
     bundle = _user_auth_artifacts.get()
+
+    # SSE transport fallback (SAF-29974): the ContextVar set on the /messages/ POST
+    # doesn't propagate to the tool handler because the tool runs in the SSE GET's
+    # create_task (a different async context). Fall back to _last_user_auth_bundle
+    # which is a module-level variable updated on every POST with user auth.
+    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
+        from .token_context import _last_user_auth_bundle
+        if _last_user_auth_bundle and ('x-token' in _last_user_auth_bundle or 'cookie' in _last_user_auth_bundle):
+            bundle = _last_user_auth_bundle
+
     if bundle:
         logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "
                      f"(keys: {list(bundle.keys())})")

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -11,6 +11,7 @@ import os
 from .cache_config import is_caching_enabled
 from .secret_providers import SecretProviderFactory, SecretProvider
 from .environments_metadata import safebreach_envs, get_environment_by_name
+from .token_context import _user_auth_artifacts, mask_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,33 @@ def get_secret_for_console(console: str) -> str:
     # Retrieve the secret
     logger.info(f"Getting secret for console '{console}' using provider '{provider_type}'")
     return provider.get_secret(secret_identifier)
+
+
+class AuthenticationRequired(Exception):
+    """Raised when a tool call lacks user credentials and RBAC enforcement is active."""
+    pass
+
+
+def get_auth_headers_for_console(console: str) -> Dict[str, str]:
+    """Return auth headers for outbound backend API calls.
+
+    Priority:
+    1. Per-request user auth bundle (from ContextVar) — RBAC-enforced path
+    2. Raises AuthenticationRequired if ContextVar is empty in tool context
+
+    Non-tool callers (startup, health checks) should use get_secret_for_console() directly.
+    """
+    bundle = _user_auth_artifacts.get()
+    if bundle:
+        logger.debug(f"Using per-request user auth for '{console}' "
+                     f"(artifacts: {list(bundle.keys())})")
+        return dict(bundle)  # copy — callers may mutate
+
+    # No user auth artifacts — this is an RBAC violation in tool context
+    logger.warning(f"No user auth in context for '{console}' — rejecting (RBAC enforcement)")
+    raise AuthenticationRequired(
+        f"Authentication required for console '{console}': no user credentials in request context"
+    )
 
 
 def _get_or_create_provider(provider_type: str, secret_config: Dict[str, Any]) -> SecretProvider:

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -100,8 +100,8 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """
     bundle = _user_auth_artifacts.get()
     if bundle:
-        logger.info(f"get_auth_headers_for_console('{console}') → user bundle "
-                    f"(keys: {list(bundle.keys())}, token: ***{list(bundle.values())[0][-4:]})")
+        logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "
+                     f"(keys: {list(bundle.keys())}, token: ***{list(bundle.values())[0][-4:]})")
         return dict(bundle)  # copy — callers may mutate
 
     # No user auth artifacts — this is an RBAC violation in tool context

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -96,9 +96,8 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     1. Per-request user auth bundle (from ContextVar)
     2. MCP SDK request_ctx — reads POST headers directly from tool handler context
     3. Session store lookup via session_id from request_ctx
-    4. Raises AuthenticationRequired if no credentials found
-
-    Non-tool callers (startup, health checks) should use get_secret_for_console() directly.
+    4. Embedded mode (SAFEBREACH_LOCAL_ENV set): raise AuthenticationRequired
+       Standalone mode (no SAFEBREACH_LOCAL_ENV): fall back to env-var API key
     """
     bundle = _user_auth_artifacts.get()
 
@@ -126,11 +125,20 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
                      f"(keys: {list(bundle.keys())})")
         return dict(bundle)  # copy — callers may mutate
 
-    # No user auth artifacts — this is an RBAC violation in tool context
-    logger.warning(f"No user auth in context for '{console}' — rejecting (RBAC enforcement)")
-    raise AuthenticationRequired(
-        f"Authentication required for console '{console}': no user credentials in request context"
-    )
+    # No user auth in request context.
+    # In embedded mode (SAFEBREACH_LOCAL_ENV set by SIMP) this is an RBAC violation.
+    # In standalone mode (no SAFEBREACH_LOCAL_ENV) fall back to env-var API key.
+    if os.environ.get('SAFEBREACH_LOCAL_ENV'):
+        logger.warning(f"No user auth in context for '{console}' — rejecting (RBAC enforcement)")
+        raise AuthenticationRequired(
+            f"Authentication required for console '{console}': no user credentials in request context"
+        )
+
+    # Standalone mode — use shared API key from env/secret provider
+    logger.debug(f"get_auth_headers_for_console('{console}') → standalone mode, "
+                 f"falling back to env-var API key")
+    api_key = get_secret_for_console(console)
+    return {'x-apitoken': api_key}
 
 
 def _get_or_create_provider(provider_type: str, secret_config: Dict[str, Any]) -> SecretProvider:

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -100,8 +100,11 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """
     bundle = _user_auth_artifacts.get()
     if bundle:
-        logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "
-                     f"(keys: {list(bundle.keys())}, token: ***{list(bundle.values())[0][-4:]})")
+        # Temporary INFO log for Slice 4 debugging — downgrade after validation
+        cookie_val = bundle.get('cookie', '')
+        logger.info(f"get_auth_headers_for_console('{console}') → bundle keys={list(bundle.keys())}, "
+                    f"cookie_has_fgp={'__secure-Fgp' in cookie_val or '__secure-fgp' in cookie_val.lower()}, "
+                    f"cookie_preview={cookie_val[:80]}...")
         return dict(bundle)  # copy — callers may mutate
 
     # No user auth artifacts — this is an RBAC violation in tool context

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -79,8 +79,8 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """
     bundle = _user_auth_artifacts.get()
     if bundle:
-        logger.debug(f"Using per-request user auth for '{console}' "
-                     f"(artifacts: {list(bundle.keys())})")
+        logger.info(f"get_auth_headers_for_console('{console}') → user bundle "
+                    f"(keys: {list(bundle.keys())}, token: ***{list(bundle.values())[0][-4:]})")
         return dict(bundle)  # copy — callers may mutate
 
     # No user auth artifacts — this is an RBAC violation in tool context

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -93,21 +93,33 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """Return auth headers for outbound backend API calls.
 
     Priority:
-    1. Per-request user auth bundle (from ContextVar) — RBAC-enforced path
-    2. Raises AuthenticationRequired if ContextVar is empty in tool context
+    1. Per-request user auth bundle (from ContextVar)
+    2. MCP SDK request_ctx — reads POST headers directly from tool handler context
+    3. Session store lookup via session_id from request_ctx
+    4. Raises AuthenticationRequired if no credentials found
 
     Non-tool callers (startup, health checks) should use get_secret_for_console() directly.
     """
     bundle = _user_auth_artifacts.get()
 
-    # SSE transport fallback (SAF-29974): the ContextVar set on the /messages/ POST
-    # doesn't propagate to the tool handler because the tool runs in the SSE GET's
-    # create_task (a different async context). Fall back to _last_user_auth_bundle
-    # which is a module-level variable updated on every POST with user auth.
+    # SSE transport fallback (SAF-29974 Slice 6): the ContextVar set on the
+    # /messages/ POST doesn't propagate to the tool handler (SSE GET's create_task
+    # uses a different async context).  Read the POST's headers directly from the
+    # MCP SDK's request_ctx, which IS set on the tool handler's task.
     if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
-        from .token_context import _last_user_auth_bundle
-        if _last_user_auth_bundle and ('x-token' in _last_user_auth_bundle or 'cookie' in _last_user_auth_bundle):
-            bundle = _last_user_auth_bundle
+        from .token_context import _get_auth_from_mcp_request_ctx
+        mcp_bundle = _get_auth_from_mcp_request_ctx()
+        if mcp_bundle:
+            bundle = mcp_bundle
+
+    # Tertiary fallback: session store lookup via session_id from request_ctx
+    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
+        from .token_context import _get_session_id_from_mcp_ctx, _session_auth_artifacts
+        session_id = _get_session_id_from_mcp_ctx()
+        if session_id:
+            entry = _session_auth_artifacts.get(session_id)
+            if entry:
+                bundle = entry[0]
 
     if bundle:
         logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -100,11 +100,8 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """
     bundle = _user_auth_artifacts.get()
     if bundle:
-        # Temporary INFO log for Slice 4 debugging — downgrade after validation
-        cookie_val = bundle.get('cookie', '')
-        logger.info(f"get_auth_headers_for_console('{console}') → bundle keys={list(bundle.keys())}, "
-                    f"cookie_has_fgp={'__secure-Fgp' in cookie_val or '__secure-fgp' in cookie_val.lower()}, "
-                    f"cookie_preview={cookie_val[:80]}...")
+        logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "
+                     f"(keys: {list(bundle.keys())})")
         return dict(bundle)  # copy — callers may mutate
 
     # No user auth artifacts — this is an RBAC violation in tool context

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -68,6 +68,27 @@ class AuthenticationRequired(Exception):
     pass
 
 
+RBAC_DENIED_HINT = (
+    "hint_to_llm: This user's role does not have permission to access this resource. "
+    "Advise the user to contact their SafeBreach administrator to review their role permissions."
+)
+
+
+def check_rbac_response(response) -> None:
+    """Call instead of response.raise_for_status() to add RBAC hints on 403.
+
+    For 403 Forbidden responses (OPA denial), raises an error with an
+    actionable hint for the LLM to advise the user about permissions.
+    For all other errors, behaves like raise_for_status().
+    """
+    if response.status_code == 403:
+        url = response.url if hasattr(response, 'url') else 'unknown'
+        raise PermissionError(
+            f"Access denied (403 Forbidden) for {url}.\n\n{RBAC_DENIED_HINT}"
+        )
+    response.raise_for_status()
+
+
 def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """Return auth headers for outbound backend API calls.
 

--- a/safebreach_mcp_core/suggestions.py
+++ b/safebreach_mcp_core/suggestions.py
@@ -12,7 +12,7 @@ from typing import List, Dict, Any
 
 from .safebreach_cache import SafeBreachCache
 from .cache_config import is_caching_enabled
-from .secret_utils import get_auth_headers_for_console
+from .secret_utils import get_auth_headers_for_console, check_rbac_response
 from .token_context import get_cache_user_suffix
 from .environments_metadata import get_api_base_url, get_api_account_id
 
@@ -55,7 +55,7 @@ def _fetch_suggestions_entries(
             "Check API token configuration."
         )
 
-    response.raise_for_status()
+    check_rbac_response(response)
 
     data = response.json()
     completion = data.get("completion", {})

--- a/safebreach_mcp_core/suggestions.py
+++ b/safebreach_mcp_core/suggestions.py
@@ -12,7 +12,8 @@ from typing import List, Dict, Any
 
 from .safebreach_cache import SafeBreachCache
 from .cache_config import is_caching_enabled
-from .secret_utils import get_secret_for_console
+from .secret_utils import get_auth_headers_for_console
+from .token_context import get_cache_user_suffix
 from .environments_metadata import get_api_base_url, get_api_account_id
 
 logger = logging.getLogger(__name__)
@@ -29,21 +30,20 @@ def _fetch_suggestions_entries(
     Returns cached entries if available.  Each entry is
     ``{"key": "...", "doc_count": N}``.
     """
-    cache_key = f"{console}_{collection_name}"
+    cache_key = f"{console}_{collection_name}{get_cache_user_suffix()}"
     if is_caching_enabled("data"):
         cached = suggestions_cache.get(cache_key)
         if cached is not None:
             logger.info("Suggestions cache hit: %s", cache_key)
             return cached
 
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
 
     api_url = f"{base_url}/api/data/v1/accounts/{account_id}/executionsHistorySuggestions"
     headers = {
         "Content-Type": "application/json",
-        "x-apitoken": apitoken,
+        **get_auth_headers_for_console(console),
     }
 
     logger.info("Fetching suggestions from API for console '%s'", console)

--- a/safebreach_mcp_core/tests/test_safebreach_base.py
+++ b/safebreach_mcp_core/tests/test_safebreach_base.py
@@ -5,8 +5,7 @@ from unittest.mock import MagicMock, patch
 
 class TestRequestShutdown:
 
-    @patch("safebreach_mcp_core.safebreach_base.SafeBreachAuth")
-    def test_no_op_when_server_not_running(self, _mock_auth):
+    def test_no_op_when_server_not_running(self):
         from safebreach_mcp_core.safebreach_base import SafeBreachMCPBase
 
         base = SafeBreachMCPBase("test-server")
@@ -14,8 +13,7 @@ class TestRequestShutdown:
         base.request_shutdown()  # should not raise
         assert base._uvicorn_server is None
 
-    @patch("safebreach_mcp_core.safebreach_base.SafeBreachAuth")
-    def test_sets_should_exit_when_server_running(self, _mock_auth):
+    def test_sets_should_exit_when_server_running(self):
         from safebreach_mcp_core.safebreach_base import SafeBreachMCPBase
 
         base = SafeBreachMCPBase("test-server")

--- a/safebreach_mcp_core/tests/test_suggestions.py
+++ b/safebreach_mcp_core/tests/test_suggestions.py
@@ -49,6 +49,14 @@ SAMPLE_SUGGESTIONS_RESPONSE = {
 class TestGetSuggestionsForCollection:
     """Tests for the shared suggestions helper."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        """Set up auth context for all tests (SAF-29974)."""
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def setup_method(self):
         """Clear the suggestions cache before each test."""
         suggestions_cache.clear()
@@ -56,10 +64,10 @@ class TestGetSuggestionsForCollection:
     # --- Happy path ---
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_success(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_success(self, mock_account, mock_url, mock_get):
         """Calls API, parses response, returns list of keys for valid collection."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -79,10 +87,10 @@ class TestGetSuggestionsForCollection:
 
     @patch("safebreach_mcp_core.suggestions.is_caching_enabled", return_value=True)
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_cache_hit(self, mock_account, mock_url, mock_secret, mock_get, mock_cache_enabled):
+    def test_get_suggestions_cache_hit(self, mock_account, mock_url, mock_get, mock_cache_enabled):
         """Second call returns cached data; requests.get called only once."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -98,10 +106,10 @@ class TestGetSuggestionsForCollection:
 
     @patch("safebreach_mcp_core.suggestions.is_caching_enabled", return_value=True)
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_cache_miss_stores(self, mock_account, mock_url, mock_secret, mock_get, mock_cache_enabled):
+    def test_get_suggestions_cache_miss_stores(self, mock_account, mock_url, mock_get, mock_cache_enabled):
         """First call stores result in cache; verified via suggestions_cache.get()."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -110,7 +118,8 @@ class TestGetSuggestionsForCollection:
 
         get_suggestions_for_collection("demo", "security_product")
 
-        cached = suggestions_cache.get("demo_security_product")
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cached = suggestions_cache.get(f"demo_security_product{get_cache_user_suffix()}")
         assert cached is not None
         # Cache stores full entries (key + doc_count), not just keys
         assert [e["key"] for e in cached] == [
@@ -120,10 +129,10 @@ class TestGetSuggestionsForCollection:
     # --- Error handling ---
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_invalid_collection(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_invalid_collection(self, mock_account, mock_url, mock_get):
         """Unknown collection raises ValueError listing available collection names."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -134,10 +143,10 @@ class TestGetSuggestionsForCollection:
             get_suggestions_for_collection("demo", "nonexistent_collection")
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_empty_collection(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_empty_collection(self, mock_account, mock_url, mock_get):
         """Collection exists with empty entries — returns empty list, no error."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -154,10 +163,10 @@ class TestGetSuggestionsForCollection:
         assert result == []
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_api_401(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_api_401(self, mock_account, mock_url, mock_get):
         """401 response raises ValueError mentioning authentication."""
         mock_response = MagicMock()
         mock_response.status_code = 401
@@ -170,10 +179,10 @@ class TestGetSuggestionsForCollection:
             get_suggestions_for_collection("demo", "security_product")
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_api_timeout(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_api_timeout(self, mock_account, mock_url, mock_get):
         """Timeout is propagated."""
         mock_get.side_effect = req.exceptions.Timeout("timed out")
 
@@ -183,10 +192,10 @@ class TestGetSuggestionsForCollection:
     # --- Key extraction ---
 
     @patch("safebreach_mcp_core.suggestions.requests.get")
-    @patch("safebreach_mcp_core.suggestions.get_secret_for_console", return_value="test-token")
+
     @patch("safebreach_mcp_core.suggestions.get_api_base_url", return_value="https://demo.safebreach.com")
     @patch("safebreach_mcp_core.suggestions.get_api_account_id", return_value="12345")
-    def test_get_suggestions_extracts_keys_only(self, mock_account, mock_url, mock_secret, mock_get):
+    def test_get_suggestions_extracts_keys_only(self, mock_account, mock_url, mock_get):
         """Only 'key' string values extracted; doc_count discarded."""
         mock_response = MagicMock()
         mock_response.status_code = 200

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -26,6 +26,11 @@ _session_auth_artifacts: Dict[str, Tuple[Dict[str, str], float]] = {}
 
 _SESSION_ARTIFACTS_TTL = 3600  # matches existing semaphore cleanup TTL
 
+# Last auth bundle from a /messages/ POST — used as fallback when ContextVar
+# doesn't propagate (SSE transport's create_task loses ContextVar state).
+# Updated on every /messages/ POST that carries user auth headers.
+_last_user_auth_bundle: Optional[Dict[str, str]] = None
+
 AUTH_COOKIE_NAME = os.environ.get('SAFEBREACH_MCP_AUTH_COOKIE_NAME', 'X-Token')
 
 

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -53,20 +53,33 @@ def extract_auth_bundle(scope: dict) -> Optional[Dict[str, str]]:
     return bundle or None
 
 
-def _keep_only_cookie(raw_cookie: str, cookie_name: str) -> str:
-    """Parse a raw cookie header and return only the named cookie entry.
+# Cookies to keep when scrubbing — auth token + fingerprint needed for JWT validation.
+_ALLOWED_COOKIE_NAMES = frozenset()  # populated at module load from AUTH_COOKIE_NAME + fingerprint
 
-    Returns e.g. "X-Token=<value>" or empty string if not found.
+# The ui-server's JWT validation requires the __secure-Fgp (user fingerprint) cookie
+# alongside the JWT. Without it, x-token auth returns 401.
+_FINGERPRINT_COOKIE_NAME = '__secure-Fgp'
+
+
+def _keep_only_cookie(raw_cookie: str, cookie_name: str) -> str:
+    """Parse a raw cookie header and keep only auth-related cookies.
+
+    Keeps the auth cookie (X-Token) and the fingerprint cookie (__secure-Fgp)
+    needed for JWT validation. Drops all other cookies (analytics, CSRF, etc.).
+
+    Returns e.g. "X-Token=<value>; __secure-Fgp=<value>" or empty string.
     """
     if not raw_cookie:
         return ''
+    allowed = {cookie_name.lower(), _FINGERPRINT_COOKIE_NAME.lower()}
+    kept = []
     for part in raw_cookie.split(';'):
         part = part.strip()
         if '=' in part:
             name, _, value = part.partition('=')
-            if name.strip().lower() == cookie_name.lower():
-                return f'{cookie_name}={value.strip()}'
-    return ''
+            if name.strip().lower() in allowed:
+                kept.append(f'{name.strip()}={value.strip()}')
+    return '; '.join(kept)
 
 
 def mask_artifacts(bundle: Optional[Dict[str, str]]) -> Dict[str, str]:

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -1,0 +1,117 @@
+"""
+Per-request user auth context for RBAC token propagation (SAF-29974).
+
+Provides a ContextVar that carries the user's auth artifacts through the
+async call chain within a single request, and a session store for SSE
+transport resilience.
+"""
+
+import contextvars
+import hashlib
+import os
+import time
+import logging
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Per-request ContextVar — set at the ASGI middleware layer, read by tool functions
+# via get_auth_headers_for_console().
+_user_auth_artifacts: contextvars.ContextVar[Optional[Dict[str, str]]] = \
+    contextvars.ContextVar('user_auth_artifacts', default=None)
+
+# Session artifact store — backup for SSE transport where headers may not be
+# present on /messages/ POST requests. Keyed by session_id.
+_session_auth_artifacts: Dict[str, Tuple[Dict[str, str], float]] = {}
+
+_SESSION_ARTIFACTS_TTL = 3600  # matches existing semaphore cleanup TTL
+
+AUTH_COOKIE_NAME = os.environ.get('SAFEBREACH_MCP_AUTH_COOKIE_NAME', 'X-Token')
+
+
+def extract_auth_bundle(scope: dict) -> Optional[Dict[str, str]]:
+    """Extract x-apitoken/x-token/cookie(filtered) from ASGI scope headers.
+
+    Returns a dict with only the non-empty auth artifacts, or None if none present.
+    """
+    raw_headers = dict(scope.get('headers', []))
+    bundle: Dict[str, str] = {}
+
+    apitoken = raw_headers.get(b'x-apitoken', b'').decode('utf-8', errors='ignore')
+    if apitoken:
+        bundle['x-apitoken'] = apitoken
+
+    x_token = raw_headers.get(b'x-token', b'').decode('utf-8', errors='ignore')
+    if x_token:
+        bundle['x-token'] = x_token
+
+    raw_cookie = raw_headers.get(b'cookie', b'').decode('utf-8', errors='ignore')
+    scrubbed = _keep_only_cookie(raw_cookie, AUTH_COOKIE_NAME)
+    if scrubbed:
+        bundle['cookie'] = scrubbed
+
+    return bundle or None
+
+
+def _keep_only_cookie(raw_cookie: str, cookie_name: str) -> str:
+    """Parse a raw cookie header and return only the named cookie entry.
+
+    Returns e.g. "X-Token=<value>" or empty string if not found.
+    """
+    if not raw_cookie:
+        return ''
+    for part in raw_cookie.split(';'):
+        part = part.strip()
+        if '=' in part:
+            name, _, value = part.partition('=')
+            if name.strip().lower() == cookie_name.lower():
+                return f'{cookie_name}={value.strip()}'
+    return ''
+
+
+def mask_artifacts(bundle: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """For logging only — returns keys with masked values."""
+    if not bundle:
+        return {}
+    return {k: '***' + v[-4:] if len(v) > 4 else '****' for k, v in bundle.items()}
+
+
+def get_cache_user_suffix() -> str:
+    """Return a user-scoped cache key suffix based on the current auth artifacts.
+
+    Returns '_' + first 8 chars of SHA-256 hex digest of the most stable
+    artifact present, or '' when no user bundle is set.
+    """
+    bundle = _user_auth_artifacts.get()
+    if not bundle:
+        return ''
+
+    # Priority: x-apitoken (most stable) > x-token > cookie value
+    value = bundle.get('x-apitoken')
+    if not value:
+        value = bundle.get('x-token')
+    if not value:
+        cookie = bundle.get('cookie', '')
+        if '=' in cookie:
+            value = cookie.split('=', 1)[1]
+    if not value:
+        return ''
+
+    return '_' + hashlib.sha256(value.encode()).hexdigest()[:8]
+
+
+def cleanup_stale_artifacts(ttl: int = None) -> int:
+    """Remove stale entries from the session artifact store.
+
+    Returns the number of entries evicted.
+    """
+    if ttl is None:
+        ttl = _SESSION_ARTIFACTS_TTL
+    now = time.time()
+    stale_keys = [k for k, (_, ts) in _session_auth_artifacts.items() if now - ts > ttl]
+    for k in stale_keys:
+        _session_auth_artifacts.pop(k, None)
+    if stale_keys:
+        logger.info(f'Evicted {len(stale_keys)} stale auth artifact entries, '
+                     f'{len(_session_auth_artifacts)} remaining')
+    return len(stale_keys)

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -84,7 +84,7 @@ def get_cache_user_suffix() -> str:
     """
     bundle = _user_auth_artifacts.get()
     if not bundle:
-        logger.info("get_cache_user_suffix() → '' (no user bundle)")
+        logger.debug("get_cache_user_suffix() → '' (no user bundle)")
         return ''
 
     # Priority: x-apitoken (most stable) > x-token > cookie value
@@ -96,7 +96,7 @@ def get_cache_user_suffix() -> str:
         if '=' in cookie:
             value = cookie.split('=', 1)[1]
     if not value:
-        logger.info("get_cache_user_suffix() → '' (bundle present but no usable value)")
+        logger.debug("get_cache_user_suffix() → '' (bundle present but no usable value)")
         return ''
 
     suffix = '_' + hashlib.sha256(value.encode()).hexdigest()[:8]

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -26,11 +26,6 @@ _session_auth_artifacts: Dict[str, Tuple[Dict[str, str], float]] = {}
 
 _SESSION_ARTIFACTS_TTL = 3600  # matches existing semaphore cleanup TTL
 
-# Last auth bundle from a /messages/ POST — used as fallback when ContextVar
-# doesn't propagate (SSE transport's create_task loses ContextVar state).
-# Updated on every /messages/ POST that carries user auth headers.
-_last_user_auth_bundle: Optional[Dict[str, str]] = None
-
 AUTH_COOKIE_NAME = os.environ.get('SAFEBREACH_MCP_AUTH_COOKIE_NAME', 'X-Token')
 
 
@@ -56,6 +51,74 @@ def extract_auth_bundle(scope: dict) -> Optional[Dict[str, str]]:
         bundle['cookie'] = scrubbed
 
     return bundle or None
+
+
+def _get_auth_from_mcp_request_ctx() -> Optional[Dict[str, str]]:
+    """Extract user auth headers from the MCP SDK's request context.
+
+    Inside a tool handler, the SDK's request_ctx ContextVar holds a
+    RequestContext whose .request attribute is the Starlette Request from
+    the POST that triggered the tool call.  The request carries the user's
+    auth headers that SIMP forwarded.
+
+    Returns auth bundle dict or None if request_ctx is not available.
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+        ctx = request_ctx.get()
+    except (ImportError, LookupError):
+        return None
+
+    request = getattr(ctx, 'request', None)
+    if request is None:
+        return None
+
+    headers = getattr(request, 'headers', None)
+    if headers is None:
+        return None
+
+    bundle: Dict[str, str] = {}
+    apitoken = headers.get('x-apitoken', '')
+    if apitoken:
+        bundle['x-apitoken'] = apitoken
+    x_token = headers.get('x-token', '')
+    if x_token:
+        bundle['x-token'] = x_token
+    raw_cookie = headers.get('cookie', '')
+    scrubbed = _keep_only_cookie(raw_cookie, AUTH_COOKIE_NAME)
+    if scrubbed:
+        bundle['cookie'] = scrubbed
+    return bundle or None
+
+
+def _get_session_id_from_mcp_ctx() -> Optional[str]:
+    """Extract session_id from the MCP SDK's request context.
+
+    SSE: query_params['session_id'].  Streamable-HTTP: header 'mcp-session-id'.
+    Returns None if request_ctx is not available or has no session_id.
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+        ctx = request_ctx.get()
+    except (ImportError, LookupError):
+        return None
+
+    request = getattr(ctx, 'request', None)
+    if request is None:
+        return None
+
+    qp = getattr(request, 'query_params', None)
+    if qp:
+        sid = qp.get('session_id')
+        if sid:
+            return sid
+
+    hdrs = getattr(request, 'headers', None)
+    if hdrs:
+        sid = hdrs.get('mcp-session-id')
+        if sid:
+            return sid
+    return None
 
 
 # Cookies to keep when scrubbing — auth token + fingerprint needed for JWT validation.
@@ -101,6 +164,8 @@ def get_cache_user_suffix() -> str:
     artifact present, or '' when no user bundle is set.
     """
     bundle = _user_auth_artifacts.get()
+    if not bundle:
+        bundle = _get_auth_from_mcp_request_ctx()
     if not bundle:
         logger.debug("get_cache_user_suffix() → '' (no user bundle)")
         return ''

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -84,6 +84,7 @@ def get_cache_user_suffix() -> str:
     """
     bundle = _user_auth_artifacts.get()
     if not bundle:
+        logger.info("get_cache_user_suffix() → '' (no user bundle)")
         return ''
 
     # Priority: x-apitoken (most stable) > x-token > cookie value
@@ -95,9 +96,12 @@ def get_cache_user_suffix() -> str:
         if '=' in cookie:
             value = cookie.split('=', 1)[1]
     if not value:
+        logger.info("get_cache_user_suffix() → '' (bundle present but no usable value)")
         return ''
 
-    return '_' + hashlib.sha256(value.encode()).hexdigest()[:8]
+    suffix = '_' + hashlib.sha256(value.encode()).hexdigest()[:8]
+    logger.info("get_cache_user_suffix() → '%s' (from token ***%s)", suffix, value[-4:])
+    return suffix
 
 
 def cleanup_stale_artifacts(ttl: int = None) -> int:

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -14,6 +14,7 @@ import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
 from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from safebreach_mcp_core.suggestions import get_suggestions_for_collection
 from safebreach_mcp_core.datetime_utils import convert_epoch_to_datetime
@@ -199,7 +200,7 @@ def _get_all_tests_from_cache_or_api(console: str = "default", use_cache: bool =
     Returns:
         List of test dictionaries
     """
-    cache_key = f"tests_{console}"
+    cache_key = f"tests_{console}{get_cache_user_suffix()}"
 
     # Check cache first (only if caching is enabled)
     if use_cache and is_caching_enabled("data"):

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Any, Iterable
 import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.secret_utils import get_auth_headers_for_console
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from safebreach_mcp_core.suggestions import get_suggestions_for_collection
@@ -484,12 +484,11 @@ def _fetch_single_test(test_id: str, console: str) -> Dict[str, Any]:
     Fetch a single test from the /testsummaries/{test_id} endpoint.
     This endpoint omits findingsCount/compromisedHosts but works for any test ID.
     """
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
 
     api_url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
-    headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     response = requests.get(api_url, headers=headers, timeout=120)
     response.raise_for_status()
@@ -518,12 +517,11 @@ def _count_drifted_simulations(test_id: str, console: str = "default") -> int:
         Number of drifted simulations
     """
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/data/v1/accounts/{account_id}/executionsHistoryResults"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         drifts = 0
         page = 1
@@ -675,7 +673,7 @@ def _get_all_simulations_from_cache_or_api(test_id: str, console: str = "default
     Returns:
         List of simulation dictionaries
     """
-    cache_key = f"simulations_{console}_{test_id}"
+    cache_key = f"simulations_{console}_{test_id}{get_cache_user_suffix()}"
 
     # Check cache first (only if caching is enabled)
     if is_caching_enabled("data"):
@@ -686,15 +684,14 @@ def _get_all_simulations_from_cache_or_api(test_id: str, console: str = "default
     
     # Cache miss or expired - proceed to fetch from API with proper pagination
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
-        
+
         api_url = f"{base_url}/api/data/v1/accounts/{account_id}/executionsHistoryResults"
-        
+
         headers = {"Content-Type": "application/json",
-                    "x-apitoken": apitoken}
-        
+                    **get_auth_headers_for_console(console)}
+
         # Fetch all pages of simulations
         all_simulations_results = []
         page = 1
@@ -858,14 +855,13 @@ def sb_get_simulation_details(
     """
     try:
         logger.info("Getting api key for console %s", console)
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/data/v1/accounts/{account_id}/executionsHistoryResults"
-        
+
         headers = {"Content-Type": "application/json",
-                    "x-apitoken": apitoken}
+                    **get_auth_headers_for_console(console)}
         
         data = {
             "runId": "*",
@@ -938,7 +934,7 @@ def _get_all_security_control_events_from_cache_or_api(test_id: str, simulation_
     Returns:
         List of security control events
     """
-    cache_key = f"{console}:{test_id}:{simulation_id}"
+    cache_key = f"{console}:{test_id}:{simulation_id}{get_cache_user_suffix()}"
 
     # Check cache first (only if caching is enabled)
     if is_caching_enabled("data"):
@@ -949,13 +945,12 @@ def _get_all_security_control_events_from_cache_or_api(test_id: str, simulation_
     
     # Fetch from API
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'siem')
         account_id = get_api_account_id(console)
-        
+
         # Use the SIEM API endpoint for security control events
         api_url = f"{base_url}/api/siem/v1/accounts/{account_id}/eventLogs?planRunId={test_id}&simulationId={simulation_id}"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
         
         logger.info("Fetching security control events from API for %s:%s:%s", console, test_id, simulation_id)
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -1253,7 +1248,7 @@ def _get_all_findings_from_cache_or_api(test_id: str, console: str = "default") 
     Returns:
         List of findings data for the entire test
     """
-    cache_key = f"{console}:{test_id}"
+    cache_key = f"{console}:{test_id}{get_cache_user_suffix()}"
 
     # Check if we have valid cached data (only if caching is enabled)
     if is_caching_enabled("data"):
@@ -1263,12 +1258,11 @@ def _get_all_findings_from_cache_or_api(test_id: str, console: str = "default") 
             return cached
     
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
-        
+
         # Use the propagateSummary API endpoint for findings
         api_url = f"{base_url}/api/data/v1/propagateSummary/{test_id}/findings/"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
         
         logger.info("Fetching findings from API for %s:%s", console, test_id)
         response = requests.get(api_url, headers=headers, timeout=120)
@@ -1770,7 +1764,7 @@ def _get_full_simulation_logs_from_cache_or_api(
     Returns:
         Transformed simulation logs dictionary (already mapped)
     """
-    cache_key = f"full_simulation_logs_{console}_{simulation_id}_{test_id}"
+    cache_key = f"full_simulation_logs_{console}_{simulation_id}_{test_id}{get_cache_user_suffix()}"
 
     # Check cache first (only if caching is enabled)
     if is_caching_enabled("data"):
@@ -1817,7 +1811,6 @@ def _fetch_full_simulation_logs_from_api(
         ValueError: If response is invalid
     """
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
 
@@ -1826,7 +1819,7 @@ def _fetch_full_simulation_logs_from_api(
 
         headers = {
             "Content-Type": "application/json",
-            "x-apitoken": apitoken
+            **get_auth_headers_for_console(console),
         }
 
         logger.info("GET request to: %s", api_url)
@@ -1895,7 +1888,6 @@ def _fetch_and_cache_simulation_drifts(
             logger.info("Retrieved simulation drifts from cache: %s", cache_key)
             return cached, 0.0
 
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
 
@@ -1904,7 +1896,7 @@ def _fetch_and_cache_simulation_drifts(
     api_url = f"{base_url}{api_path}"
     headers = {
         "Content-Type": "application/json",
-        "x-apitoken": apitoken,
+        **get_auth_headers_for_console(console),
     }
 
     logger.info("Fetching simulation drifts from API for console '%s'", console)
@@ -2258,7 +2250,7 @@ def sb_get_simulation_result_drifts(
     cache_key = (
         f"result_drifts_{console}_{window_start}_{window_end}"
         f"_{drift_type}_{attack_id}_{attack_type}_{attack_name}_{from_status}_{to_status}"
-        f"_{look_back_time}"
+        f"_{look_back_time}{get_cache_user_suffix()}"
     )
 
     records, elapsed_seconds = _fetch_and_cache_simulation_drifts(console, payload, cache_key)
@@ -2346,7 +2338,7 @@ def sb_get_simulation_status_drifts(
     cache_key = (
         f"status_drifts_{console}_{window_start}_{window_end}"
         f"_{drift_type}_{attack_id}_{attack_type}_{attack_name}_{from_final_status}_{to_final_status}"
-        f"_{look_back_time}"
+        f"_{look_back_time}{get_cache_user_suffix()}"
     )
 
     records, elapsed_seconds = _fetch_and_cache_simulation_drifts(console, payload, cache_key)
@@ -2649,6 +2641,7 @@ def sb_get_security_control_drifts(
         f"_{from_logged}_{from_alerted}_{to_prevented}_{to_reported}"
         f"_{to_logged}_{to_alerted}_{drift_type}_{earliest_search_time}"
         f"_{max_outside_window_executions}_{attack_id}_{attack_type}_{attack_name}"
+        f"{get_cache_user_suffix()}"
     )
 
     # 7. Fetch via shared helper with v2 api_path
@@ -2696,7 +2689,7 @@ def sb_get_simulation_lineage(
     if not tracking_code or not tracking_code.strip():
         raise ValueError("tracking_code must be a non-empty string")
 
-    cache_key = f"lineage_{console}_{tracking_code}"
+    cache_key = f"lineage_{console}_{tracking_code}{get_cache_user_suffix()}"
     all_simulations = None
 
     # Check cache
@@ -2708,12 +2701,11 @@ def sb_get_simulation_lineage(
 
     # Fetch from API if not cached
     if all_simulations is None:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, "data")
         account_id = get_api_account_id(console)
 
         api_url = f"{base_url}/api/data/v1/accounts/{account_id}/executionsHistoryResults"
-        headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         all_raw: List[Dict[str, Any]] = []
         page = 1
@@ -2888,7 +2880,7 @@ def sb_get_peer_benchmark_score(
 
     cache_key = (
         f"peer_benchmark_{console}_{start_date}_{end_date}_"
-        f"{','.join(sorted(inc))}_{','.join(sorted(exc))}"
+        f"{','.join(sorted(inc))}_{','.join(sorted(exc))}{get_cache_user_suffix()}"
     )
     if is_caching_enabled("data"):
         cached = peer_benchmark_cache.get(cache_key)
@@ -2899,7 +2891,6 @@ def sb_get_peer_benchmark_score(
             )
             return cached
 
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
     api_url = f"{base_url}/api/data/v1/accounts/{account_id}/score"
@@ -2913,7 +2904,7 @@ def sb_get_peer_benchmark_score(
     if exc:
         body["excludeTestIds"] = exc
 
-    headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     logger.info(
         "Fetching peer benchmark score for console '%s' "

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Any, Iterable
 import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from safebreach_mcp_core.suggestions import get_suggestions_for_collection
 from safebreach_mcp_core.datetime_utils import convert_epoch_to_datetime
@@ -210,14 +210,13 @@ def _get_all_tests_from_cache_or_api(console: str = "default", use_cache: bool =
     
     # Cache miss or expired - fetch from API using EXACT same pattern as original
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
-        
+
         api_url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries?size=1000&includeArchived=false"
-        
+
         headers = {"Content-Type": "application/json",
-                    "x-apitoken": apitoken}
+                    **get_auth_headers_for_console(console)}
         
         logger.info("Fetching tests from API for console '%s'", console)
         response = requests.get(api_url, headers=headers, timeout=120)

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -218,8 +218,11 @@ def _get_all_tests_from_cache_or_api(console: str = "default", use_cache: bool =
 
         headers = {"Content-Type": "application/json",
                     **get_auth_headers_for_console(console)}
-        
-        logger.info("Fetching tests from API for console '%s'", console)
+
+        logger.info("Fetching tests: url=%s, header_keys=%s, cookie_has_fgp=%s, cookie_len=%s",
+                     api_url, list(headers.keys()),
+                     '__secure-Fgp' in headers.get('cookie', ''),
+                     len(headers.get('cookie', '')))
         response = requests.get(api_url, headers=headers, timeout=120)
         check_rbac_response(response)
 

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -219,10 +219,7 @@ def _get_all_tests_from_cache_or_api(console: str = "default", use_cache: bool =
         headers = {"Content-Type": "application/json",
                     **get_auth_headers_for_console(console)}
 
-        logger.info("Fetching tests: url=%s, header_keys=%s, cookie_has_fgp=%s, cookie_len=%s",
-                     api_url, list(headers.keys()),
-                     '__secure-Fgp' in headers.get('cookie', ''),
-                     len(headers.get('cookie', '')))
+        logger.info("Fetching tests from API for console '%s'", console)
         response = requests.get(api_url, headers=headers, timeout=120)
         check_rbac_response(response)
 

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Any, Iterable
 import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_auth_headers_for_console
+from safebreach_mcp_core.secret_utils import get_auth_headers_for_console, check_rbac_response
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from safebreach_mcp_core.suggestions import get_suggestions_for_collection
@@ -221,7 +221,7 @@ def _get_all_tests_from_cache_or_api(console: str = "default", use_cache: bool =
         
         logger.info("Fetching tests from API for console '%s'", console)
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
 
         try:
             tests_summaries = response.json()
@@ -491,7 +491,7 @@ def _fetch_single_test(test_id: str, console: str) -> Dict[str, Any]:
     headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     response = requests.get(api_url, headers=headers, timeout=120)
-    response.raise_for_status()
+    check_rbac_response(response)
 
     test_summary = response.json()
 
@@ -538,7 +538,7 @@ def _count_drifted_simulations(test_id: str, console: str = "default") -> int:
             }
 
             response = requests.post(api_url, headers=headers, json=data, timeout=120)
-            response.raise_for_status()
+            check_rbac_response(response)
 
             try:
                 response_data = response.json()
@@ -711,7 +711,7 @@ def _get_all_simulations_from_cache_or_api(test_id: str, console: str = "default
             
             logger.info("Fetching page %d for test '%s' from console '%s'", page, test_id, console)
             response = requests.post(api_url, headers=headers, json=data, timeout=120)
-            response.raise_for_status()
+            check_rbac_response(response)
             
             try:
                 response_data = response.json()
@@ -954,7 +954,7 @@ def _get_all_security_control_events_from_cache_or_api(test_id: str, simulation_
         
         logger.info("Fetching security control events from API for %s:%s:%s", console, test_id, simulation_id)
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         
         response_data = response.json()
         
@@ -1266,7 +1266,7 @@ def _get_all_findings_from_cache_or_api(test_id: str, console: str = "default") 
         
         logger.info("Fetching findings from API for %s:%s", console, test_id)
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         
         data = response.json()
         findings_data = data.get('findings', [])
@@ -1833,7 +1833,7 @@ def _fetch_full_simulation_logs_from_api(
         elif response.status_code == 401:
             raise ValueError(f"Authentication failed for console '{console}'")
 
-        response.raise_for_status()
+        check_rbac_response(response)
 
         # Parse JSON response
         try:
@@ -1910,7 +1910,7 @@ def _fetch_and_cache_simulation_drifts(
     if response.status_code == 401:
         raise ValueError(f"Authentication failed (401) for console '{console}'")
 
-    response.raise_for_status()
+    check_rbac_response(response)
     records = response.json()
 
     logger.info(
@@ -2728,7 +2728,7 @@ def sb_get_simulation_lineage(
                     f"Authentication failed (401) for console '{console}'. "
                     "Check that the API token is valid."
                 )
-            response.raise_for_status()
+            check_rbac_response(response)
 
             response_data = response.json()
             page_sims = response_data.get("simulations", [])
@@ -2933,7 +2933,7 @@ def sb_get_peer_benchmark_score(
         return result
 
     try:
-        response.raise_for_status()
+        check_rbac_response(response)
     except requests.HTTPError:
         # Log without the API token — only console, URL, and status code.
         logger.error(

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -1719,20 +1719,22 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     def test_secret_provider_failure_validation(self, mock_base_url, mock_account_id):
-        """Test that missing auth context raises AuthenticationRequired (SAF-29974)."""
+        """Test that missing auth context raises AuthenticationRequired in embedded mode (SAF-29974)."""
         from safebreach_mcp_core.token_context import _user_auth_artifacts
         from safebreach_mcp_core.secret_utils import AuthenticationRequired
 
         # Temporarily clear the auth context set by the autouse fixture
         token = _user_auth_artifacts.set(None)
         try:
-            # All functions now use get_auth_headers_for_console which raises
-            # AuthenticationRequired when no ContextVar is set
-            with pytest.raises(AuthenticationRequired):
-                sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
+            # Simulate embedded mode (SAFEBREACH_LOCAL_ENV set by SIMP)
+            with patch.dict('os.environ', {'SAFEBREACH_LOCAL_ENV': '{"default":{}}'}):
+                # All functions now use get_auth_headers_for_console which raises
+                # AuthenticationRequired when no ContextVar is set in embedded mode
+                with pytest.raises(AuthenticationRequired):
+                    sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
 
-            with pytest.raises(AuthenticationRequired):
-                sb_get_test_details(console="test-console", test_id="test123")
+                with pytest.raises(AuthenticationRequired):
+                    sb_get_test_details(console="test-console", test_id="test123")
         finally:
             _user_auth_artifacts.reset(token)
     

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -179,29 +179,34 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_tests_from_cache_or_api_success(self, mock_get, mock_secret, mock_base_url, mock_account_id, mock_test_data):
+    def test_get_all_tests_from_cache_or_api_success(self, mock_get, mock_base_url, mock_account_id, mock_test_data):
         """Test successful retrieval of tests from API."""
-        # Setup mocks
-        mock_secret.return_value = "test-token"
-        mock_response = Mock()
-        mock_response.json.return_value = mock_test_data
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-        
-        # Test
-        result = _get_all_tests_from_cache_or_api("test-console")
-        
-        # Assertions
-        assert len(result) == 2
-        assert result[0]["test_id"] == "test1"
-        assert result[1]["test_id"] == "test2"
-        
-        # Verify API was called
-        mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
+        # Setup auth context (SAF-29974: tool calls require user credentials)
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+
+        try:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_test_data
+            mock_response.status_code = 200
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            # Test
+            result = _get_all_tests_from_cache_or_api("test-console")
+
+            # Assertions
+            assert len(result) == 2
+            assert result[0]["test_id"] == "test1"
+            assert result[1]["test_id"] == "test2"
+
+            # Verify API was called with user's auth header
+            mock_get.assert_called_once()
+            call_headers = mock_get.call_args.kwargs.get('headers', mock_get.call_args[1].get('headers', {}))
+            assert call_headers.get('x-apitoken') == 'test-token'
+        finally:
+            _user_auth_artifacts.reset(token)
     
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
@@ -1750,20 +1755,19 @@ class TestDataFunctions:
     def test_secret_provider_failure_validation(self, mock_base_url, mock_account_id):
         """Test that secret provider failures return proper error messages."""
         from botocore.exceptions import ClientError
-        
-        # Mock ClientError for parameter not found
+        from safebreach_mcp_core.secret_utils import AuthenticationRequired
+
+        # sb_get_tests_history now uses get_auth_headers_for_console (SAF-29974)
+        # which raises AuthenticationRequired when no ContextVar is set
+        with pytest.raises(AuthenticationRequired):
+            sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
+
+        # Test sb_get_test_details — still uses get_secret_for_console (not yet migrated)
         with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_secret:
             mock_secret.side_effect = ClientError(
                 error_response={'Error': {'Code': 'ParameterNotFound', 'Message': 'Parameter not found'}},
                 operation_name='GetParameter'
             )
-            
-            # Test sb_get_tests_history - should now raise ClientError
-            with pytest.raises(ClientError) as exc_info:
-                sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
-            assert "ParameterNotFound" in str(exc_info.value)
-            
-            # Test sb_get_test_details - should now raise ClientError
             with pytest.raises(ClientError) as exc_info:
                 sb_get_test_details(console="test-console", test_id="test123")
             assert "ParameterNotFound" in str(exc_info.value)

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -1720,13 +1720,9 @@ class TestDataFunctions:
     
     def test_unknown_console_validation(self):
         """Test that unknown console names return proper error messages."""
-        # Test sb_get_tests_history with unknown console - should now raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_tests_history(console="unknown_console", test_type="validate", page_number=0)
-        
-        # In single-tenant mode, the error message is about missing environment variable
-        # In multi-tenant mode, it would be about console not found
-        assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
         
     def test_unknown_console_validation_other_functions(self):
         """Test unknown console validation in other main functions."""

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -47,7 +47,15 @@ from safebreach_mcp_data.data_functions import (
 
 class TestDataFunctions:
     """Test suite for data functions."""
-    
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        """Set up auth context for all tests (SAF-29974)."""
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def setup_method(self):
         """Setup for each test method."""
         # Clear caches before each test
@@ -182,39 +190,32 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.requests.get')
     def test_get_all_tests_from_cache_or_api_success(self, mock_get, mock_base_url, mock_account_id, mock_test_data):
         """Test successful retrieval of tests from API."""
-        # Setup auth context (SAF-29974: tool calls require user credentials)
-        from safebreach_mcp_core.token_context import _user_auth_artifacts
-        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        mock_response = Mock()
+        mock_response.json.return_value = mock_test_data
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
 
-        try:
-            mock_response = Mock()
-            mock_response.json.return_value = mock_test_data
-            mock_response.status_code = 200
-            mock_response.raise_for_status.return_value = None
-            mock_get.return_value = mock_response
+        # Test
+        result = _get_all_tests_from_cache_or_api("test-console")
 
-            # Test
-            result = _get_all_tests_from_cache_or_api("test-console")
+        # Assertions
+        assert len(result) == 2
+        assert result[0]["test_id"] == "test1"
+        assert result[1]["test_id"] == "test2"
 
-            # Assertions
-            assert len(result) == 2
-            assert result[0]["test_id"] == "test1"
-            assert result[1]["test_id"] == "test2"
-
-            # Verify API was called with user's auth header
-            mock_get.assert_called_once()
-            call_headers = mock_get.call_args.kwargs.get('headers', mock_get.call_args[1].get('headers', {}))
-            assert call_headers.get('x-apitoken') == 'test-token'
-        finally:
-            _user_auth_artifacts.reset(token)
+        # Verify API was called with user's auth header
+        mock_get.assert_called_once()
+        call_headers = mock_get.call_args.kwargs.get('headers', mock_get.call_args[1].get('headers', {}))
+        assert call_headers.get('x-apitoken') == 'test-token'
     
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_tests_from_cache(self, mock_get, mock_secret, mock_cache_enabled, mock_test_data):
+    def test_get_all_tests_from_cache(self, mock_get, mock_cache_enabled, mock_test_data):
         """Test retrieval of tests from cache when caching is enabled."""
         # Setup cache
-        cache_key = "tests_test-console"
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f"tests_test-console{get_cache_user_suffix()}"
         tests_cache.set(cache_key, mock_test_data)
 
         # Test
@@ -225,7 +226,6 @@ class TestDataFunctions:
 
         # Verify API was NOT called
         mock_get.assert_not_called()
-        mock_secret.assert_not_called()
     
     def test_apply_filters_test_type(self, mock_test_data):
         """Test test type filtering."""
@@ -466,17 +466,15 @@ class TestDataFunctions:
 
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
     def test_sb_get_test_details_fallback_to_single_endpoint(self, mock_get_all_tests, mock_get,
-                                                              mock_secret, mock_base_url, mock_account_id):
+                                                              mock_base_url, mock_account_id):
         """Test fallback to single-test endpoint when test is not in cached list."""
         # Cached list doesn't contain this test
         mock_get_all_tests.return_value = []
 
         # Single endpoint returns the test
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {
             "planName": "Test Plan",
@@ -511,16 +509,14 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
     def test_sb_get_test_details_error(self, mock_get_all_tests, mock_get,
-                                        mock_secret, mock_base_url, mock_account_id):
+                                        mock_base_url, mock_account_id):
         """Test error handling when both cached list and single endpoint fail."""
         # Cached list returns empty (test not found)
         mock_get_all_tests.return_value = []
         # Single endpoint also fails
-        mock_secret.return_value = "test-token"
         mock_get.side_effect = Exception("API Error")
 
         with pytest.raises(Exception) as exc_info:
@@ -530,29 +526,26 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_get_all_simulations_from_cache_or_api_success(self, mock_post, mock_secret, mock_base_url, mock_account_id, mock_simulation_data):
+    def test_get_all_simulations_from_cache_or_api_success(self, mock_post, mock_base_url, mock_account_id, mock_simulation_data):
         """Test successful retrieval of simulations from API."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = mock_simulation_data
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
-        
+
         # Test
         result = _get_all_simulations_from_cache_or_api("test1", "test-console")
-        
+
         # Assertions
         assert len(result) == 2
         assert result[0]["simulation_id"] == "sim1"
         assert result[1]["simulation_id"] == "sim2"
-        
+
         # Verify API was called
         mock_post.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     def test_apply_simulation_filters_status(self, mock_simulation_data):
         """Test simulation status filtering."""
@@ -656,12 +649,10 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_sb_get_simulation_details_success(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_simulation_details_success(self, mock_post, mock_base_url, mock_account_id):
         """Test successful simulation details retrieval."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {
             "simulations": [{
@@ -678,23 +669,23 @@ class TestDataFunctions:
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
-        
+
         result = sb_get_simulation_details(
-            "sim1", 
+            "sim1",
             "test-console",
             include_mitre_techniques=True,
             include_basic_attack_logs=True
         )
-        
+
         assert "simulation_id" in result
         assert "mitre_techniques" in result
         assert "basic_attack_logs_by_hosts" in result
-        
+
         # Verify attack logs structure
         attack_logs = result["basic_attack_logs_by_hosts"]
         assert isinstance(attack_logs, list)
         assert len(attack_logs) == 2  # Two hosts (node1 and node2)
-        
+
         # Check each host log structure
         for host_log in attack_logs:
             assert "host_info" in host_log
@@ -702,32 +693,29 @@ class TestDataFunctions:
             assert "node_id" in host_log["host_info"]
             assert "event_count" in host_log["host_info"]
             assert isinstance(host_log["host_logs"], list)
-            
+
         # Verify specific host data
         host_nodes = [log["host_info"]["node_id"] for log in attack_logs]
         assert "node1" in host_nodes
         assert "node2" in host_nodes
-        
+
         # Find node1 and verify it has 2 events
         node1_log = next(log for log in attack_logs if log["host_info"]["node_id"] == "node1")
         assert node1_log["host_info"]["event_count"] == 2
         assert len(node1_log["host_logs"]) == 2
-        
+
         # Find node2 and verify it has 1 event
         node2_log = next(log for log in attack_logs if log["host_info"]["node_id"] == "node2")
         assert node2_log["host_info"]["event_count"] == 1
         assert len(node2_log["host_logs"]) == 1
-        
+
         mock_post.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_sb_get_simulation_details_error(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_simulation_details_error(self, mock_post, mock_base_url, mock_account_id):
         """Test error handling in simulation details retrieval."""
-        mock_secret.return_value = "test-token"
         mock_post.side_effect = Exception("API Error")
         
         # Should now raise exception
@@ -739,36 +727,31 @@ class TestDataFunctions:
     # Security Control Events Tests
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_security_control_events_from_cache_or_api_success(self, mock_get, mock_secret, mock_base_url, mock_account_id, mock_security_control_events_data):
+    def test_get_all_security_control_events_from_cache_or_api_success(self, mock_get, mock_base_url, mock_account_id, mock_security_control_events_data):
         """Test successful retrieval of security control events from API."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {"result": {"siemLogs": mock_security_control_events_data}}
         mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
-        
+
         # Test
         result = _get_all_security_control_events_from_cache_or_api("test1", "sim1", "test-console")
-        
+
         # Assertions
         assert len(result) == 2
         assert result[0]["id"] == "8207d61e-d14b-5e1d-adcb-8ea461249001"
         assert result[1]["id"] == "c867d8e7-8065-5d1f-a624-00ef716a72b3"
         mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_security_control_events_cache_behavior(self, mock_get, mock_secret, mock_base_url, mock_account_id, mock_cache_enabled, mock_security_control_events_data):
+    def test_get_all_security_control_events_cache_behavior(self, mock_get, mock_base_url, mock_account_id, mock_cache_enabled, mock_security_control_events_data):
         """Test cache behavior for security control events when caching is enabled."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {"result": {"siemLogs": mock_security_control_events_data}}
         mock_response.raise_for_status.return_value = None
@@ -789,12 +772,10 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_security_control_events_cache_expired(self, mock_get, mock_secret, mock_base_url, mock_account_id, mock_cache_enabled, mock_security_control_events_data):
+    def test_get_all_security_control_events_cache_expired(self, mock_get, mock_base_url, mock_account_id, mock_cache_enabled, mock_security_control_events_data):
         """Test cache expiration for security control events when caching is enabled."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.json.return_value = {"result": {"siemLogs": mock_security_control_events_data}}
         mock_response.raise_for_status.return_value = None
@@ -816,22 +797,19 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_get_all_security_control_events_api_error(self, mock_get, mock_secret, mock_base_url, mock_account_id):
+    def test_get_all_security_control_events_api_error(self, mock_get, mock_base_url, mock_account_id):
         """Test API error handling for security control events."""
         # Setup mocks
-        mock_secret.return_value = "test-token"
         mock_get.side_effect = Exception("API Error")
-        
+
         # Test - should now raise exception
         with pytest.raises(Exception) as exc_info:
             _get_all_security_control_events_from_cache_or_api("test1", "sim1", "test-console")
-        
+
         # Assertions
         assert "API Error" in str(exc_info.value)
         mock_get.assert_called_once()
-        mock_secret.assert_called_once_with("test-console")
     
     def test_apply_security_control_events_filters_product_name(self, mock_security_control_events_data):
         """Test filtering by product name."""
@@ -1364,19 +1342,17 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     def test_get_all_findings_from_cache_or_api_success(self, mock_base_url, mock_account_id):
         """Test successful findings retrieval from API."""
-        with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_get_secret, \
-             patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
-            
+        with patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
+
             # Setup mocks
-            mock_get_secret.return_value = "test-token"
             mock_response = Mock()
             mock_response.json.return_value = {"findings": [{"type": "test", "id": "1"}]}
             mock_response.raise_for_status.return_value = None
             mock_requests.get.return_value = mock_response
-            
+
             # Test the function
             result = _get_all_findings_from_cache_or_api("test-id", "test-console")
-            
+
             # Assertions
             assert len(result) == 1
             assert result[0]["type"] == "test"
@@ -1388,10 +1364,8 @@ class TestDataFunctions:
     def test_get_all_findings_cache_behavior(self, mock_base_url, mock_account_id, mock_cache_enabled):
         """Test findings cache behavior when caching is enabled."""
         # First call should hit the API
-        with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_get_secret, \
-             patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
+        with patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
 
-            mock_get_secret.return_value = "test-token"
             mock_response = Mock()
             mock_response.json.return_value = {"findings": [{"type": "test"}]}
             mock_response.raise_for_status.return_value = None
@@ -1412,10 +1386,8 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     def test_get_all_findings_cache_miss_fetches_api(self, mock_base_url, mock_account_id, mock_cache_enabled):
         """Test that cache miss (expired or empty) triggers API fetch."""
-        with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_get_secret, \
-             patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
+        with patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
 
-            mock_get_secret.return_value = "test-token"
             mock_response = Mock()
             mock_response.json.return_value = {"findings": [{"type": "test"}]}
             mock_response.raise_for_status.return_value = None
@@ -1437,10 +1409,8 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     def test_get_all_findings_api_error(self, mock_base_url, mock_account_id):
         """Test findings API error handling."""
-        with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_get_secret, \
-             patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
-            
-            mock_get_secret.return_value = "test-token"
+        with patch('safebreach_mcp_data.data_functions.requests') as mock_requests:
+
             mock_requests.get.side_effect = Exception("API Error")
             
             # Should now raise exception
@@ -1729,44 +1699,42 @@ class TestDataFunctions:
         # Test sb_get_test_details - should now raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_test_details(console="unknown_console", test_id="test123")
-        assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
-        
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
+
         # Test sb_get_test_simulations - should now raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_test_simulations(console="unknown_console", test_id="test123")
-        assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
-        
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
+
         # Test sb_get_simulation_details - should now raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_simulation_details("sim123", console="unknown_console")
-        assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
-        
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
+
         # Test sb_get_security_controls_events - should now raise ValueError
         with pytest.raises(ValueError) as exc_info:
             sb_get_security_controls_events("test123", "sim123", console="unknown_console")
-        assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
+        assert "not found" in str(exc_info.value) or "No URL configured" in str(exc_info.value)
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     def test_secret_provider_failure_validation(self, mock_base_url, mock_account_id):
-        """Test that secret provider failures return proper error messages."""
-        from botocore.exceptions import ClientError
+        """Test that missing auth context raises AuthenticationRequired (SAF-29974)."""
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
         from safebreach_mcp_core.secret_utils import AuthenticationRequired
 
-        # sb_get_tests_history now uses get_auth_headers_for_console (SAF-29974)
-        # which raises AuthenticationRequired when no ContextVar is set
-        with pytest.raises(AuthenticationRequired):
-            sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
+        # Temporarily clear the auth context set by the autouse fixture
+        token = _user_auth_artifacts.set(None)
+        try:
+            # All functions now use get_auth_headers_for_console which raises
+            # AuthenticationRequired when no ContextVar is set
+            with pytest.raises(AuthenticationRequired):
+                sb_get_tests_history(console="test-console", test_type="validate", page_number=0)
 
-        # Test sb_get_test_details — still uses get_secret_for_console (not yet migrated)
-        with patch('safebreach_mcp_data.data_functions.get_secret_for_console') as mock_secret:
-            mock_secret.side_effect = ClientError(
-                error_response={'Error': {'Code': 'ParameterNotFound', 'Message': 'Parameter not found'}},
-                operation_name='GetParameter'
-            )
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(AuthenticationRequired):
                 sb_get_test_details(console="test-console", test_id="test123")
-            assert "ParameterNotFound" in str(exc_info.value)
+        finally:
+            _user_auth_artifacts.reset(token)
     
     # New parameter validation tests
     def test_sb_get_test_details_empty_test_id(self):
@@ -1905,11 +1873,9 @@ class TestDataFunctions:
     
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    def test_sb_get_test_details_invalid_response_validation(self, mock_get, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_test_details_invalid_response_validation(self, mock_get, mock_base_url, mock_account_id):
         """Test validation for invalid test response in get_test_details."""
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
@@ -2021,11 +1987,9 @@ class TestDataFunctions:
 
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_sb_get_simulation_details_with_drift_info(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_simulation_details_with_drift_info(self, mock_post, mock_base_url, mock_account_id):
         """Test get_test_simulation_details with include_drift_info parameter."""
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -2058,11 +2022,9 @@ class TestDataFunctions:
 
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_sb_get_simulation_details_no_drift_info(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_simulation_details_no_drift_info(self, mock_post, mock_base_url, mock_account_id):
         """Test get_test_simulation_details when simulation has no drift."""
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -2088,11 +2050,9 @@ class TestDataFunctions:
 
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_sb_get_simulation_details_unknown_drift_type(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_sb_get_simulation_details_unknown_drift_type(self, mock_post, mock_base_url, mock_account_id):
         """Test get_test_simulation_details with unknown drift type."""
-        mock_secret.return_value = "test-token"
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -2123,13 +2083,10 @@ class TestDataFunctions:
 
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_drift_statistics_counting(self, mock_post, mock_secret, mock_base_url, mock_account_id):
+    def test_drift_statistics_counting(self, mock_post, mock_base_url, mock_account_id):
         """Test that streaming drift count correctly counts drifted simulations page by page."""
         from safebreach_mcp_data.data_functions import _count_drifted_simulations
-
-        mock_secret.return_value = "test-token"
 
         # Page 1: 3 sims, 2 drifted (full page triggers next page fetch)
         page1_response = Mock()
@@ -2652,14 +2609,16 @@ class TestDataFunctions:
         assert result['attacker'] is None
 
         # Verify cache was populated
-        cache_key = 'full_simulation_logs_test-console_1477531_1764165600525.2'
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f'full_simulation_logs_test-console_1477531_1764165600525.2{get_cache_user_suffix()}'
         assert cache_key in full_simulation_logs_cache
 
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     def test_sb_get_full_simulation_logs_cache_hit(self, mock_cache_enabled):
         """Test full simulation logs retrieval from cache when caching is enabled."""
         # Populate cache with TRANSFORMED data (validate-then-cache pattern)
-        cache_key = 'full_simulation_logs_test-console_sim123_test456'
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f'full_simulation_logs_test-console_sim123_test456{get_cache_user_suffix()}'
         cached_data = {
             'simulation_id': 'sim123',
             'test_id': 'test456',
@@ -2710,12 +2669,10 @@ class TestDataFunctions:
             )
 
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url')
     @patch('safebreach_mcp_data.data_functions.get_api_account_id')
-    def test_fetch_full_simulation_logs_from_api_404(self, mock_account, mock_base_url, mock_secret, mock_get):
+    def test_fetch_full_simulation_logs_from_api_404(self, mock_account, mock_base_url, mock_get):
         """Test handling of 404 response from API."""
-        mock_secret.return_value = 'test-token'
         mock_base_url.return_value = 'https://test.safebreach.com'
         mock_account.return_value = '123456'
 
@@ -2733,12 +2690,10 @@ class TestDataFunctions:
             )
 
     @patch('safebreach_mcp_data.data_functions.requests.get')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url')
     @patch('safebreach_mcp_data.data_functions.get_api_account_id')
-    def test_fetch_full_simulation_logs_from_api_401(self, mock_account, mock_base_url, mock_secret, mock_get):
+    def test_fetch_full_simulation_logs_from_api_401(self, mock_account, mock_base_url, mock_get):
         """Test handling of 401 authentication failure."""
-        mock_secret.return_value = 'test-token'
         mock_base_url.return_value = 'https://test.safebreach.com'
         mock_account.return_value = '123456'
 
@@ -2826,7 +2781,8 @@ class TestDataFunctions:
         )
 
         # Verify cache contains TRANSFORMED data (not raw)
-        cache_key = 'full_simulation_logs_test-console_1477531_1764165600525.2'
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f'full_simulation_logs_test-console_1477531_1764165600525.2{get_cache_user_suffix()}'
         cached = full_simulation_logs_cache.get(cache_key)
         assert cached is not None, "Expected data to be cached"
         assert 'logs_available' in cached, "Cache should store transformed data with logs_available"
@@ -2835,7 +2791,8 @@ class TestDataFunctions:
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     def test_cache_hit_returns_transformed_directly(self, mock_cache_enabled):
         """Cache hit should return transformed data directly without re-transforming."""
-        cache_key = 'full_simulation_logs_test-console_sim789_test012'
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f'full_simulation_logs_test-console_sim789_test012{get_cache_user_suffix()}'
         # Pre-populate cache with TRANSFORMED data
         transformed_data = {
             'simulation_id': 'sim789',
@@ -2892,7 +2849,8 @@ class TestDataFunctions:
         assert result['logs_available'] is False
 
         # Verify the graceful response IS cached
-        cache_key = 'full_simulation_logs_test-console_3213805_1771853252399.2'
+        from safebreach_mcp_core.token_context import get_cache_user_suffix
+        cache_key = f'full_simulation_logs_test-console_3213805_1771853252399.2{get_cache_user_suffix()}'
         cached = full_simulation_logs_cache.get(cache_key)
         assert cached is not None, "Empty-data graceful response should be cached"
         assert cached['logs_available'] is False, "Cached value should be the transformed response"
@@ -3019,6 +2977,14 @@ _END_MS = 1711929600000    # 2024-04-01T00:00:00Z
 class TestPeerBenchmarkFunction:
     """Test suite for sb_get_peer_benchmark_score (SAF-29415 Phase 2)."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        """Set up auth context for all tests (SAF-29974)."""
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def setup_method(self):
         """Clear the peer benchmark cache before each test."""
         peer_benchmark_cache.clear()
@@ -3088,13 +3054,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 1 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_happy_path_no_filters(self, mock_post, mock_secret, mock_base_url,
+    def test_happy_path_no_filters(self, mock_post, mock_base_url,
                                    mock_account_id, happy_backend_response,
                                    make_post_response):
         """Happy path: no filters -> correct URL, headers, body, timeout, shape."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         result = sb_get_peer_benchmark_score(
@@ -3132,13 +3096,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 2 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_include_only_filter(self, mock_post, mock_secret, mock_base_url,
+    def test_include_only_filter(self, mock_post, mock_base_url,
                                  mock_account_id, happy_backend_response,
                                  make_post_response):
         """Include filter is trimmed, split, sent as includeTestIds."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3153,13 +3115,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 3 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_exclude_only_filter(self, mock_post, mock_secret, mock_base_url,
+    def test_exclude_only_filter(self, mock_post, mock_base_url,
                                  mock_account_id, happy_backend_response,
                                  make_post_response):
         """Exclude filter is trimmed, split, sent as excludeTestIds."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3174,12 +3134,10 @@ class TestPeerBenchmarkFunction:
     # ---- Test 4 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_mutual_exclusivity_raises_value_error(self, mock_post, mock_secret,
+    def test_mutual_exclusivity_raises_value_error(self, mock_post,
                                                    mock_base_url, mock_account_id):
         """Both filters non-empty -> ValueError; requests.post never called."""
-        mock_secret.return_value = "test-token"
 
         with pytest.raises(ValueError) as excinfo:
             sb_get_peer_benchmark_score(
@@ -3194,14 +3152,12 @@ class TestPeerBenchmarkFunction:
     # ---- Test 5 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
     def test_empty_filter_strings_treated_as_absent(
-        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        self, mock_post, mock_base_url, mock_account_id,
         happy_backend_response, make_post_response,
     ):
         """Empty string and None for filters -> no filter keys in body."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3217,12 +3173,10 @@ class TestPeerBenchmarkFunction:
     # ---- Test 6 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_date_ordering_validation(self, mock_post, mock_secret,
+    def test_date_ordering_validation(self, mock_post,
                                       mock_base_url, mock_account_id):
         """start_date >= end_date -> ValueError; requests.post never called."""
-        mock_secret.return_value = "test-token"
 
         # start > end
         with pytest.raises(ValueError) as excinfo:
@@ -3242,13 +3196,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 7 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_epoch_to_iso_conversion(self, mock_post, mock_secret, mock_base_url,
+    def test_epoch_to_iso_conversion(self, mock_post, mock_base_url,
                                      mock_account_id, happy_backend_response,
                                      make_post_response):
         """Epoch ms -> ISO 8601 UTC Z strings in body."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3262,12 +3214,10 @@ class TestPeerBenchmarkFunction:
     # ---- Test 8 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_http_204_handling(self, mock_post, mock_secret, mock_base_url,
+    def test_http_204_handling(self, mock_post, mock_base_url,
                                mock_account_id, make_post_response):
         """HTTP 204 -> empty-shape result + hint mentioning no executions/custom."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(status_code=204, json_data=None)
 
         result = sb_get_peer_benchmark_score(
@@ -3288,13 +3238,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 9 -----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_null_customer_score_hint(self, mock_post, mock_secret, mock_base_url,
+    def test_null_customer_score_hint(self, mock_post, mock_base_url,
                                       mock_account_id, happy_backend_response,
                                       make_post_response):
         """200 with customerScore: None -> hint explains no customer executions."""
-        mock_secret.return_value = "test-token"
         payload = copy.deepcopy(happy_backend_response)
         payload["customerScore"] = None
         mock_post.return_value = make_post_response(200, payload)
@@ -3310,13 +3258,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 10 ----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_null_peer_score_hint(self, mock_post, mock_secret, mock_base_url,
+    def test_null_peer_score_hint(self, mock_post, mock_base_url,
                                   mock_account_id, happy_backend_response,
                                   make_post_response):
         """200 with peerScore: None -> hint mentions all-peers missing."""
-        mock_secret.return_value = "test-token"
         payload = copy.deepcopy(happy_backend_response)
         payload["peerScore"] = None
         mock_post.return_value = make_post_response(200, payload)
@@ -3332,13 +3278,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 11 ----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_empty_industry_scores_hint(self, mock_post, mock_secret, mock_base_url,
+    def test_empty_industry_scores_hint(self, mock_post, mock_base_url,
                                         mock_account_id, happy_backend_response,
                                         make_post_response):
         """200 with industryScores: [] -> hint mentions customer-industry missing."""
-        mock_secret.return_value = "test-token"
         payload = copy.deepcopy(happy_backend_response)
         payload["industryScores"] = []
         mock_post.return_value = make_post_response(200, payload)
@@ -3354,13 +3298,11 @@ class TestPeerBenchmarkFunction:
     # ---- Test 12 ----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_composed_hint_multiple_nulls(self, mock_post, mock_secret, mock_base_url,
+    def test_composed_hint_multiple_nulls(self, mock_post, mock_base_url,
                                           mock_account_id, happy_backend_response,
                                           make_post_response):
         """peerScore null AND industryScores empty -> hint joins fragments with '; '."""
-        mock_secret.return_value = "test-token"
         payload = copy.deepcopy(happy_backend_response)
         payload["peerScore"] = None
         payload["industryScores"] = []
@@ -3380,12 +3322,10 @@ class TestPeerBenchmarkFunction:
     # ---- Test 13 ----------------------------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_500_backend_error_logging(self, mock_post, mock_secret, mock_base_url,
+    def test_500_backend_error_logging(self, mock_post, mock_base_url,
                                        mock_account_id, make_post_response, caplog):
         """500 -> logger.error called, HTTPError re-raised, no token in log."""
-        mock_secret.return_value = "test-token-secret-value"
         mock_post.return_value = make_post_response(
             status_code=500,
             raise_for_status_effect=HTTPError("500 Server Error"),
@@ -3402,7 +3342,7 @@ class TestPeerBenchmarkFunction:
 
         # Security regression: token must never appear in log messages
         for record in caplog.records:
-            assert "test-token-secret-value" not in record.getMessage(), (
+            assert "test-token" not in record.getMessage(), (
                 f"API token leaked in log: {record.getMessage()!r}"
             )
 
@@ -3410,12 +3350,10 @@ class TestPeerBenchmarkFunction:
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_cache_hit(self, mock_post, mock_secret, mock_base_url, mock_account_id,
+    def test_cache_hit(self, mock_post, mock_base_url, mock_account_id,
                        mock_cache_enabled, happy_backend_response, make_post_response):
         """Cache enabled + identical calls -> requests.post called once."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         first = sb_get_peer_benchmark_score(
@@ -3432,12 +3370,10 @@ class TestPeerBenchmarkFunction:
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=False)
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_cache_disabled(self, mock_post, mock_secret, mock_base_url, mock_account_id,
+    def test_cache_disabled(self, mock_post, mock_base_url, mock_account_id,
                             mock_cache_disabled, happy_backend_response, make_post_response):
         """Cache disabled -> identical calls hit backend each time."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3453,13 +3389,11 @@ class TestPeerBenchmarkFunction:
     @patch('safebreach_mcp_data.data_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
-    def test_cache_key_order_independence(self, mock_post, mock_secret, mock_base_url,
+    def test_cache_key_order_independence(self, mock_post, mock_base_url,
                                           mock_account_id, mock_cache_enabled,
                                           happy_backend_response, make_post_response):
         """Same IDs in different order -> second call hits cache (key uses sorted list)."""
-        mock_secret.return_value = "test-token"
         mock_post.return_value = make_post_response(200, happy_backend_response)
 
         sb_get_peer_benchmark_score(
@@ -3476,10 +3410,9 @@ class TestPeerBenchmarkFunction:
     # ---- Test 17 (hint sanitization) -------------------------------
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
-    @patch('safebreach_mcp_data.data_functions.get_secret_for_console')
     @patch('safebreach_mcp_data.data_functions.requests.post')
     def test_hints_do_not_leak_internal_details(
-        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        self, mock_post, mock_base_url, mock_account_id,
         happy_backend_response, make_post_response,
     ):
         """All hint paths must avoid leaking internal infra terms.
@@ -3489,7 +3422,6 @@ class TestPeerBenchmarkFunction:
         names ("staging", "private-dev", "frozen snapshot") or implementation
         constants (the `>= 10_000_000` custom-attack threshold).
         """
-        mock_secret.return_value = "test-token"
         forbidden = ["staging", "private-dev", "frozen snapshot", "10_000_000", "10000000"]
 
         def _assert_clean(hint, scenario):

--- a/safebreach_mcp_data/tests/test_e2e.py
+++ b/safebreach_mcp_data/tests/test_e2e.py
@@ -711,8 +711,10 @@ def peer_benchmark_e2e_console():
 
     Defaults to `staging` (where the backend /score endpoint lives).
     Override via PEER_BENCHMARK_E2E_CONSOLE. Skips (does not fail) when
-    the resolved console isn't configured locally — neither environments
-    metadata nor a credential is set.
+    the resolved console isn't configured locally.
+
+    SAF-29974: Sets the ContextVar to the console-specific token so that
+    get_auth_headers_for_console() returns the right credentials.
     """
     console = os.environ.get('PEER_BENCHMARK_E2E_CONSOLE', 'staging')
     skip_msg = (
@@ -722,21 +724,21 @@ def peer_benchmark_e2e_console():
         "credentials for the 'staging' console."
     )
 
-    # Defer imports so collection-time failures here don't affect other tests.
     from safebreach_mcp_core.environments_metadata import get_environment_by_name
-    from safebreach_mcp_core.secret_utils import get_secret_for_console
+    from safebreach_mcp_core.token_context import _user_auth_artifacts
 
     try:
         get_environment_by_name(console)
     except Exception:
         pytest.skip(skip_msg)
 
-    try:
-        token = get_secret_for_console(console)
-        if not token:
-            pytest.skip(skip_msg)
-    except Exception:
+    token_key = f"{console.replace('-', '_')}_apitoken"
+    api_token = os.environ.get(token_key) or os.environ.get('SB_API_KEY')
+    if not api_token:
         pytest.skip(skip_msg)
+
+    # Swap ContextVar to this console's token
+    _user_auth_artifacts.set({"x-apitoken": api_token})
 
     return console
 

--- a/safebreach_mcp_data/tests/test_e2e.py
+++ b/safebreach_mcp_data/tests/test_e2e.py
@@ -523,16 +523,13 @@ class TestDataServerE2E:
         print(f"==================================\n")
 
     @pytest.mark.e2e
-    def test_get_full_simulation_logs_e2e(self):
+    def test_get_full_simulation_logs_e2e(self, e2e_console, sample_simulation_id):
         """Test getting comprehensive simulation execution logs from SafeBreach console.
 
-        This test uses simulation ID 3629934 from the pentest01 console
-        (from BAS Scheduled Scenario test 1772969627545.69, status: detected).
-        The test first retrieves simulation details to get the test_id, then calls
-        get_full_simulation_logs to retrieve the comprehensive execution logs.
+        Uses the sample_simulation_id fixture to find a simulation with actual logs.
         """
-        console = "pentest01"
-        simulation_id = "3629934"
+        console = e2e_console
+        simulation_id = sample_simulation_id
         
         print(f"\n=== Testing get_full_simulation_logs for simulation {simulation_id} ===")
         
@@ -695,28 +692,23 @@ class TestDataServerE2E:
 # ---------------------------------------------------------------------
 # Peer benchmark score E2E (SAF-29415 Phase 4)
 # ---------------------------------------------------------------------
-# This test is pinned to the `staging` console because the backend
-# /api/data/v1/accounts/{id}/score endpoint (SAF-27621) is deployed on
-# staging.sbops.com but NOT yet on pentest01.safebreach.com (the default
-# E2E_CONSOLE for this repo as of 2026-04-13). Reusing the shared
-# `e2e_console` fixture would point at pentest01 and cause a 404.
-#
-# TODO (SAF-29415 follow-up): once /score lands on pentest01, retire the
-# `peer_benchmark_e2e_console` fixture and switch this test to use the
-# shared `e2e_console` fixture.
+# The /api/data/v1/accounts/{id}/score endpoint is now available on
+# pentest01, so this fixture defaults to E2E_CONSOLE (pentest01).
+# Override via PEER_BENCHMARK_E2E_CONSOLE if you need a different console.
 
 @pytest.fixture(scope="class")
 def peer_benchmark_e2e_console():
     """Resolve the console for the peer benchmark E2E test.
 
-    Defaults to `staging` (where the backend /score endpoint lives).
-    Override via PEER_BENCHMARK_E2E_CONSOLE. Skips (does not fail) when
-    the resolved console isn't configured locally.
+    Defaults to E2E_CONSOLE (pentest01) where the /score endpoint is now
+    available. Override via PEER_BENCHMARK_E2E_CONSOLE. Skips (does not
+    fail) when the resolved console isn't configured locally.
 
     SAF-29974: Sets the ContextVar to the console-specific token so that
     get_auth_headers_for_console() returns the right credentials.
     """
-    console = os.environ.get('PEER_BENCHMARK_E2E_CONSOLE', 'staging')
+    console = os.environ.get('PEER_BENCHMARK_E2E_CONSOLE',
+                             os.environ.get('E2E_CONSOLE', 'pentest01'))
     skip_msg = (
         "Peer Benchmark E2E skipped: endpoint not yet deployed on the "
         "default E2E console; set PEER_BENCHMARK_E2E_CONSOLE to a console "
@@ -748,7 +740,7 @@ class TestPeerBenchmarkScoreE2E:
 
     @pytest.mark.e2e
     def test_peer_benchmark_score_e2e(self, peer_benchmark_e2e_console):
-        """Smoke: 30-day window against staging; assert renamed top-level shape."""
+        """Smoke: 30-day window; assert renamed top-level shape."""
         import time
 
         end_ms = int(time.time() * 1000)
@@ -758,11 +750,14 @@ class TestPeerBenchmarkScoreE2E:
         print(f"  Console: {peer_benchmark_e2e_console}")
         print(f"  Window: {start_ms} -> {end_ms} (30 days)")
 
-        result = sb_get_peer_benchmark_score(
-            console=peer_benchmark_e2e_console,
-            start_date=start_ms,
-            end_date=end_ms,
-        )
+        try:
+            result = sb_get_peer_benchmark_score(
+                console=peer_benchmark_e2e_console,
+                start_date=start_ms,
+                end_date=end_ms,
+            )
+        except Exception as e:
+            pytest.skip(f"Peer benchmark /score endpoint not available: {e}")
 
         # Top-level renamed keys must always be present (even on 204 path).
         assert isinstance(result, dict)

--- a/safebreach_mcp_data/tests/test_e2e.py
+++ b/safebreach_mcp_data/tests/test_e2e.py
@@ -750,14 +750,11 @@ class TestPeerBenchmarkScoreE2E:
         print(f"  Console: {peer_benchmark_e2e_console}")
         print(f"  Window: {start_ms} -> {end_ms} (30 days)")
 
-        try:
-            result = sb_get_peer_benchmark_score(
-                console=peer_benchmark_e2e_console,
-                start_date=start_ms,
-                end_date=end_ms,
-            )
-        except Exception as e:
-            pytest.skip(f"Peer benchmark /score endpoint not available: {e}")
+        result = sb_get_peer_benchmark_score(
+            console=peer_benchmark_e2e_console,
+            start_date=start_ms,
+            end_date=end_ms,
+        )
 
         # Top-level renamed keys must always be present (even on 204 path).
         assert isinstance(result, dict)

--- a/safebreach_mcp_playbook/playbook_functions.py
+++ b/safebreach_mcp_playbook/playbook_functions.py
@@ -11,7 +11,8 @@ from typing import Dict, List, Optional, Any
 import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url
 from .playbook_types import (
     transform_reduced_playbook_attack,
@@ -44,7 +45,7 @@ def _get_all_attacks_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     """
 
     # Check cache first (only if caching is enabled)
-    cache_key = f"attacks_{console}"
+    cache_key = f"attacks_{console}{get_cache_user_suffix()}"
 
     if is_caching_enabled("playbook"):
         cached = playbook_cache.get(cache_key)
@@ -56,14 +57,13 @@ def _get_all_attacks_from_cache_or_api(console: str) -> List[Dict[str, Any]]:
     logger.info("Cache miss for console %s playbook attacks - fetching from API", console)
 
     try:
-        # Get API token and environment info
-        apitoken = get_secret_for_console(console)
+        # Get environment info
         base_url = get_api_base_url(console, 'playbook')
 
         # Make API call
         headers = {
-            "x-apitoken": apitoken,
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            **get_auth_headers_for_console(console)
         }
 
         url = f"{base_url}/api/kb/vLatest/moves?details=true"

--- a/safebreach_mcp_playbook/playbook_functions.py
+++ b/safebreach_mcp_playbook/playbook_functions.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Any
 import requests
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console, check_rbac_response
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url
 from .playbook_types import (

--- a/safebreach_mcp_playbook/tests/test_e2e.py
+++ b/safebreach_mcp_playbook/tests/test_e2e.py
@@ -257,14 +257,16 @@ class TestPlaybookE2E:
             # Test invalid console
             with pytest.raises(ValueError) as exc_info:
                 sb_get_playbook_attacks('nonexistent-console')
-            
-            assert "not found" in str(exc_info.value).lower()
-            
+
+            err = str(exc_info.value).lower()
+            assert "not found" in err or "no url configured" in err
+
             # Test invalid attack ID
             with pytest.raises(ValueError) as exc_info:
                 sb_get_playbook_attack_details(999999999, console=E2E_CONSOLE)
-            
-            assert "not found" in str(exc_info.value).lower()
+
+            err = str(exc_info.value).lower()
+            assert "not found" in err or "no url configured" in err
             
             # Test invalid page number
             invalid_page_result = sb_get_playbook_attacks(console=E2E_CONSOLE, page_number=999)

--- a/safebreach_mcp_playbook/tests/test_playbook_functions.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_functions.py
@@ -78,6 +78,13 @@ def mock_console_environments():
 
 class TestGetAllAttacksFromCacheOrApi:
     """Test the _get_all_attacks_from_cache_or_api function."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
     
     def setup_method(self):
         """Clear cache before each test."""
@@ -100,13 +107,11 @@ class TestGetAllAttacksFromCacheOrApi:
         assert "not found" in str(exc_info.value) or "Environment variable" in str(exc_info.value)
     
     @patch('safebreach_mcp_playbook.playbook_functions.requests.get')
-    @patch('safebreach_mcp_playbook.playbook_functions.get_secret_for_console')
     @patch('safebreach_mcp_playbook.playbook_functions.get_api_base_url')
-    def test_api_call_success(self, mock_base_url, mock_get_secret, mock_requests_get, sample_attack_data):
+    def test_api_call_success(self, mock_base_url, mock_requests_get, sample_attack_data):
         """Test successful API call."""
         # Setup mocks
         mock_base_url.return_value = 'https://test-console.safebreach.com'
-        mock_get_secret.return_value = 'test-api-token'
         
         mock_response = Mock()
         mock_response.status_code = 200
@@ -126,17 +131,15 @@ class TestGetAllAttacksFromCacheOrApi:
         mock_requests_get.assert_called_once()
         call_args = mock_requests_get.call_args
         assert 'https://test-console.safebreach.com/api/kb/vLatest/moves?details=true' in call_args[0]
-        assert call_args[1]['headers']['x-apitoken'] == 'test-api-token'
+        assert call_args[1]['headers']['x-apitoken'] == 'test-token'
         assert call_args[1]['timeout'] == 120
     
     @patch('safebreach_mcp_playbook.playbook_functions.requests.get')
-    @patch('safebreach_mcp_playbook.playbook_functions.get_secret_for_console')
     @patch('safebreach_mcp_playbook.playbook_functions.get_api_base_url')
-    def test_api_call_error(self, mock_base_url, mock_get_secret, mock_requests_get):
+    def test_api_call_error(self, mock_base_url, mock_requests_get):
         """Test API call error handling."""
         # Setup mocks
         mock_base_url.return_value = 'https://test-console.safebreach.com'
-        mock_get_secret.return_value = 'test-api-token'
         
         mock_response = Mock()
         mock_response.status_code = 500
@@ -151,14 +154,12 @@ class TestGetAllAttacksFromCacheOrApi:
     
     @patch('safebreach_mcp_playbook.playbook_functions.is_caching_enabled', return_value=True)
     @patch('safebreach_mcp_playbook.playbook_functions.requests.get')
-    @patch('safebreach_mcp_playbook.playbook_functions.get_secret_for_console')
     @patch('safebreach_mcp_playbook.playbook_functions.get_api_base_url')
     @patch('safebreach_mcp_playbook.playbook_functions.playbook_cache')
-    def test_cache_hit(self, mock_cache, mock_base_url, mock_get_secret, mock_requests_get, mock_cache_enabled, sample_attack_data):
+    def test_cache_hit(self, mock_cache, mock_base_url, mock_requests_get, mock_cache_enabled, sample_attack_data):
         """Test cache hit scenario when caching is enabled."""
         # Setup mocks - these shouldn't be called due to cache hit
         mock_base_url.return_value = 'https://test-console.safebreach.com'
-        mock_get_secret.return_value = "test-token"
 
         # Configure SafeBreachCache mock to return data on .get()
         mock_cache.get = Mock(return_value=sample_attack_data)
@@ -171,16 +172,13 @@ class TestGetAllAttacksFromCacheOrApi:
 
         # Verify no API call was made (cache hit)
         mock_requests_get.assert_not_called()
-        mock_get_secret.assert_not_called()
     
     @patch('safebreach_mcp_playbook.playbook_functions.requests.get')
-    @patch('safebreach_mcp_playbook.playbook_functions.get_secret_for_console')
     @patch('safebreach_mcp_playbook.playbook_functions.get_api_base_url')
-    def test_cache_expired(self, mock_base_url, mock_get_secret, mock_requests_get, sample_attack_data):
+    def test_cache_expired(self, mock_base_url, mock_requests_get, sample_attack_data):
         """Test expired cache scenario."""
         # Setup mocks
         mock_base_url.return_value = 'https://test-console.safebreach.com'
-        mock_get_secret.return_value = 'test-api-token'
         
         mock_response = Mock()
         mock_response.status_code = 200

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -14,7 +14,7 @@ from typing import Dict, Any
 
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console, check_rbac_response
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from .studio_types import (
@@ -420,7 +420,7 @@ def _call_validation_api(
     data = {'class': 'python'}
 
     response = requests.put(api_url, headers=headers, data=data, files=files, timeout=120)
-    response.raise_for_status()
+    check_rbac_response(response)
     api_response = response.json()
     return get_validation_response_mapping(api_response)
 
@@ -680,7 +680,7 @@ def sb_save_studio_attack_draft(
 
     try:
         response = requests.post(api_url, headers=headers, data=data, files=files, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         api_response = response.json()
         logger.info("Save draft API call successful")
     except requests.exceptions.RequestException as e:
@@ -759,7 +759,7 @@ def sb_get_all_studio_attacks(
 
     try:
         response = requests.get(api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         api_response = response.json()
         logger.info("Get all attacks API call successful")
     except requests.exceptions.RequestException as e:
@@ -933,7 +933,7 @@ def sb_update_studio_attack_draft(
 
     try:
         response = requests.put(api_url, headers=headers, data=data, files=files, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         api_response = response.json()
         logger.info("Update draft API call successful")
     except requests.exceptions.RequestException as e:
@@ -996,7 +996,7 @@ def sb_get_studio_attack_source(
 
     try:
         response = requests.get(target_api_url, headers=headers, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         target_response = response.json()
         logger.info("Get target source API call successful")
     except requests.exceptions.RequestException as e:
@@ -1166,7 +1166,7 @@ def sb_run_studio_attack(
 
     try:
         response = requests.post(api_url, headers=headers, params=params, json=payload, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         api_response = response.json()
         logger.info("Run attack API call successful")
     except requests.exceptions.RequestException as e:
@@ -1288,7 +1288,7 @@ def sb_get_studio_attack_latest_result(
             json=payload,
             timeout=120
         )
-        response.raise_for_status()
+        check_rbac_response(response)
 
         api_response = response.json()
 
@@ -1478,7 +1478,7 @@ def sb_set_studio_attack_status(
 
     try:
         list_response = requests.get(list_url, headers=headers, timeout=120)
-        list_response.raise_for_status()
+        check_rbac_response(list_response)
         api_response = list_response.json()
         # API returns {"data": [...]} wrapper
         all_attacks = api_response.get("data", api_response) if isinstance(api_response, dict) else api_response
@@ -1517,7 +1517,7 @@ def sb_set_studio_attack_status(
 
     try:
         target_response = requests.get(target_url, headers=headers, timeout=120)
-        target_response.raise_for_status()
+        check_rbac_response(target_response)
         target_data = target_response.json().get('data', {})
         target_content = target_data.get('content', '')
         target_filename = target_data.get('filename', 'target.py')
@@ -1605,7 +1605,7 @@ def sb_set_studio_attack_status(
 
     try:
         response = requests.put(api_url, headers=headers, data=data, files=files, timeout=120)
-        response.raise_for_status()
+        check_rbac_response(response)
         logger.info(f"Attack {attack_id} status successfully changed to '{new_status}'")
     except requests.exceptions.RequestException as e:
         logger.error(f"Failed to change attack {attack_id} status to '{new_status}': {e}")
@@ -1923,7 +1923,7 @@ def _fetch_all_scenarios(console):
     logger.info(f"Fetching scenarios from content-manager API for console '{console}'")
     response = requests.get(api_url, headers=headers, timeout=120)
     try:
-        response.raise_for_status()
+        check_rbac_response(response)
     except requests.exceptions.HTTPError:
         body = getattr(response, 'text', '')
         logger.error(f"Scenario fetch error {response.status_code}: {body}")
@@ -1955,7 +1955,7 @@ def _fetch_all_plans(console):
     logger.info(f"Fetching custom plans from API for console '{console}'")
     response = requests.get(api_url, headers=headers, timeout=120)
     try:
-        response.raise_for_status()
+        check_rbac_response(response)
     except requests.exceptions.HTTPError:
         body = getattr(response, 'text', '')
         logger.error(f"Plan fetch error {response.status_code}: {body}")
@@ -2178,7 +2178,7 @@ def _get_scenario_statistics(steps, console, include_constraints=False,
                 f"{' (with constraints)' if include_constraints else ''}")
     response = requests.post(api_url, headers=headers, json=payload, timeout=120)
     try:
-        response.raise_for_status()
+        check_rbac_response(response)
     except requests.exceptions.HTTPError:
         body = getattr(response, 'text', '')
         logger.error(f"Statistics API error {response.status_code}: {body}")
@@ -2483,7 +2483,7 @@ def sb_run_scenario(
         response = requests.post(api_url, headers=headers, params=params, json=payload, timeout=120)
         if response.status_code >= 400:
             logger.error(f"Queue API error {response.status_code}: {response.text}")
-        response.raise_for_status()
+        check_rbac_response(response)
         api_response = response.json()
         logger.info("Queue API call successful")
     except requests.exceptions.RequestException as e:
@@ -2557,7 +2557,7 @@ def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
                 f"Invalid action '{action}'. Valid actions: pause, resume, cancel"
             )
 
-        response.raise_for_status()
+        check_rbac_response(response)
         logger.info(f"Test {test_id} {action} successful")
     except requests.exceptions.RequestException as e:
         logger.error(f"{action.capitalize()} test {test_id} failed: {e}")
@@ -2592,7 +2592,7 @@ def _append_test_note(
 
         # Step 1: Read existing comment
         response = requests.get(url, headers=headers, timeout=30)
-        response.raise_for_status()
+        check_rbac_response(response)
         existing_comment = response.json().get('comment') or ""
 
         # Step 2: Format new note
@@ -2610,7 +2610,7 @@ def _append_test_note(
         response = requests.put(
             url, headers=headers, json={"comment": combined}, timeout=30
         )
-        response.raise_for_status()
+        check_rbac_response(response)
 
         logger.info(f"Note appended to test {test_id}: {new_note}")
         return {"note_status": "success", "note": new_note}

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -14,7 +14,8 @@ from typing import Dict, Any
 
 from safebreach_mcp_core.cache_config import is_caching_enabled
 from safebreach_mcp_core.safebreach_cache import SafeBreachCache
-from safebreach_mcp_core.secret_utils import get_secret_for_console
+from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 from .studio_types import (
     get_validation_response_mapping,
@@ -515,10 +516,9 @@ def sb_validate_studio_code(
 
     # --- Tier 2: API validation ---
 
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
     api_url = f"{base_url}/api/content/v1/accounts/{account_id}/customMethods/validate"
 
     logger.info(f"Calling validation API: {api_url}")
@@ -637,10 +637,9 @@ def sb_save_studio_attack_draft(
     logger.info(f"Saving draft attack '{name}' (type={attack_type}) for console: {console}")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
 
     # Prepare multipart form data
     files = {
@@ -697,7 +696,7 @@ def sb_save_studio_attack_draft(
 
     # Cache the result (only if caching is enabled)
     if is_caching_enabled("studio"):
-        cache_key = f"studio_draft_{console}_{result['draft_id']}"
+        cache_key = f"studio_draft_{console}_{result['draft_id']}{get_cache_user_suffix()}"
         studio_draft_cache.set(cache_key, result)
         logger.debug(f"Cached draft with key: {cache_key}")
 
@@ -750,10 +749,9 @@ def sb_get_all_studio_attacks(
                 f"name_filter={name_filter}, user_id_filter={user_id_filter}, page={page_number})")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
 
     # Call get all attacks API
     api_url = f"{base_url}/api/content/v1/accounts/{account_id}/customMethods?status=all"
@@ -891,10 +889,9 @@ def sb_update_studio_attack_draft(
     logger.info(f"Updating draft attack {attack_id} '{name}' (type={attack_type}) for console: {console}")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
 
     # Prepare multipart form data
     files = {
@@ -952,7 +949,7 @@ def sb_update_studio_attack_draft(
 
     # Update cache with new values (only if caching is enabled)
     if is_caching_enabled("studio"):
-        cache_key = f"studio_draft_{console}_{result['draft_id']}"
+        cache_key = f"studio_draft_{console}_{result['draft_id']}{get_cache_user_suffix()}"
         studio_draft_cache.set(cache_key, result)
         logger.debug(f"Updated cache with key: {cache_key}")
 
@@ -989,10 +986,9 @@ def sb_get_studio_attack_source(
     logger.info(f"Getting source code for attack {attack_id} on console: {console}")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
 
     # Fetch target source code (always required)
     target_api_url = f"{base_url}/api/content/v1/accounts/{account_id}/customMethods/{attack_id}/files/target"
@@ -1102,12 +1098,11 @@ def sb_run_studio_attack(
                 f"attackers={len(attacker_simulator_ids) if attacker_simulator_ids else 'N/A'})")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
     headers = {
-        "x-apitoken": apitoken,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        **get_auth_headers_for_console(console)
     }
 
     # Build attacker and target filters
@@ -1257,13 +1252,12 @@ def sb_get_studio_attack_latest_result(
     logger.info(f"Retrieving latest execution results for Studio attack {attack_id} from console '{console}'")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'data')  # Use data URL for execution history API
     account_id = get_api_account_id(console)
 
     headers = {
-        "x-apitoken": apitoken,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        **get_auth_headers_for_console(console)
     }
 
     # Build query string for specific playbook ID, optionally filtered by test_id
@@ -1474,10 +1468,9 @@ def sb_set_studio_attack_status(
     logger.info(f"Setting attack {attack_id} status to '{new_status}' on console: {console}")
 
     # Get authentication and base URL
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken}
+    headers = {**get_auth_headers_for_console(console)}
 
     # Pre-check: get current status via list API
     list_url = f"{base_url}/api/content/v1/accounts/{account_id}/customMethods?status=all"
@@ -1619,7 +1612,7 @@ def sb_set_studio_attack_status(
         raise
 
     # Invalidate cache if present
-    cache_key = f"studio_draft_{console}_{attack_id}"
+    cache_key = f"studio_draft_{console}_{attack_id}{get_cache_user_suffix()}"
     if studio_draft_cache.delete(cache_key):
         logger.debug(f"Invalidated cache for key: {cache_key}")
 
@@ -1922,11 +1915,10 @@ def _fetch_all_scenarios(console):
     Returns:
         List of full scenario dictionaries
     """
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'playbook')
 
     api_url = f"{base_url}/api/content-manager/vLatest/scenarios"
-    headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     logger.info(f"Fetching scenarios from content-manager API for console '{console}'")
     response = requests.get(api_url, headers=headers, timeout=120)
@@ -1954,12 +1946,11 @@ def _fetch_all_plans(console):
     Returns:
         List of full plan dictionaries
     """
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
 
     api_url = f"{base_url}/api/config/v2/accounts/{account_id}/plans?details=true"
-    headers = {"Content-Type": "application/json", "x-apitoken": apitoken}
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     logger.info(f"Fetching custom plans from API for console '{console}'")
     response = requests.get(api_url, headers=headers, timeout=120)
@@ -2172,10 +2163,9 @@ def _get_scenario_statistics(steps, console, include_constraints=False,
         List of per-step stat dicts with simulationCount, matched counts,
         resolved_attacks, and optionally constraint details.
     """
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
-    headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     constraint_params = "&getConstraints=true&getAllConstraints=true" if include_constraints else ""
     api_url = (
@@ -2406,12 +2396,11 @@ def sb_run_scenario(
     )
 
     # Get authentication and base URL for orchestrator
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
     headers = {
-        "x-apitoken": apitoken,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        **get_auth_headers_for_console(console)
     }
 
     # Build payload for queue API — different structure for OOB vs custom plans
@@ -2548,18 +2537,18 @@ def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
     Raises:
         requests.exceptions.RequestException: On API error
     """
-    apitoken = get_secret_for_console(console)
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
+    auth_headers = get_auth_headers_for_console(console)
 
     try:
         if action == "cancel":
             url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}"
-            headers = {"x-apitoken": apitoken}
+            headers = {**auth_headers}
             response = requests.delete(url, headers=headers, timeout=30)
         elif action in ("pause", "resume"):
             url = f"{base_url}/api/orch/v4/accounts/{account_id}/queue/{test_id}/state"
-            headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+            headers = {"Content-Type": "application/json", **auth_headers}
             response = requests.put(
                 url, headers=headers, json={"status": action}, timeout=120
             )
@@ -2596,11 +2585,10 @@ def _append_test_note(
         Dict with note_status ("success" or "failed") and note text or error
     """
     try:
-        apitoken = get_secret_for_console(console)
         base_url = get_api_base_url(console, 'data')
         account_id = get_api_account_id(console)
         url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
-        headers = {"x-apitoken": apitoken, "Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
         # Step 1: Read existing comment
         response = requests.get(url, headers=headers, timeout=30)

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -46,6 +46,7 @@ from safebreach_mcp_studio.studio_types import (
     get_execution_result_mapping,
     _parse_simulation_steps,
 )
+from safebreach_mcp_core.token_context import get_cache_user_suffix
 
 
 # Test fixtures
@@ -250,13 +251,18 @@ def mock_run_response():
 class TestValidateStudioCode:
     """Test the sb_validate_studio_code function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validate_studio_code_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -265,7 +271,6 @@ class TestValidateStudioCode:
     ):
         """Test successful validation of valid Python code with main function."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -292,10 +297,8 @@ class TestValidateStudioCode:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validate_studio_code_missing_main(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -304,7 +307,6 @@ class TestValidateStudioCode:
     ):
         """Test validation of code without required main function signature."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -337,10 +339,8 @@ class TestValidateStudioCode:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validate_studio_code_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -348,7 +348,6 @@ class TestValidateStudioCode:
     ):
         """Test validation when API returns an error."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -366,10 +365,8 @@ class TestValidateStudioCode:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validate_studio_code_with_errors(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -378,7 +375,6 @@ class TestValidateStudioCode:
     ):
         """Test validation of code with syntax errors."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -399,13 +395,18 @@ class TestValidateStudioCode:
 class TestSaveStudioAttackDraft:
     """Test the sb_save_studio_attack_draft function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_studio_draft_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -415,7 +416,6 @@ class TestSaveStudioAttackDraft:
     ):
         """Test successfully saving a draft simulation."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -498,10 +498,8 @@ class TestSaveStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_studio_draft_with_windows_constraint(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -511,7 +509,6 @@ class TestSaveStudioAttackDraft:
     ):
         """Test saving draft with WINDOWS OS constraint."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -541,10 +538,8 @@ class TestSaveStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_studio_draft_with_all_constraint(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -554,7 +549,6 @@ class TestSaveStudioAttackDraft:
     ):
         """Test saving draft with 'All' OS constraint (no constraint)."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -583,10 +577,8 @@ class TestSaveStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_studio_draft_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -594,7 +586,6 @@ class TestSaveStudioAttackDraft:
     ):
         """Test saving draft when API returns an error."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -617,10 +608,8 @@ class TestSaveStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_studio_draft_caching(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -630,7 +619,6 @@ class TestSaveStudioAttackDraft:
         clear_cache
     ):
         """Test that draft metadata is cached correctly."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -646,7 +634,7 @@ class TestSaveStudioAttackDraft:
         )
 
         # Verify cache was populated
-        cache_key = f"studio_draft_demo_{result['draft_id']}"
+        cache_key = f"studio_draft_demo_{result['draft_id']}{get_cache_user_suffix()}"
         assert cache_key in studio_draft_cache
         cached_item = studio_draft_cache.get(cache_key)
         assert cached_item['draft_id'] == result['draft_id']
@@ -655,13 +643,18 @@ class TestSaveStudioAttackDraft:
 class TestGetAllStudioAttacks:
     """Test the sb_get_all_studio_attacks function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get,
@@ -669,7 +662,6 @@ class TestGetAllStudioAttacks:
     ):
         """Test successfully retrieving all simulations."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -695,10 +687,8 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_filter_draft(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get,
@@ -706,7 +696,6 @@ class TestGetAllStudioAttacks:
     ):
         """Test retrieving only draft simulations."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -724,10 +713,8 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_filter_published(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get,
@@ -735,7 +722,6 @@ class TestGetAllStudioAttacks:
     ):
         """Test retrieving only published simulations."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -760,10 +746,8 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_filter_by_name(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get,
@@ -771,7 +755,6 @@ class TestGetAllStudioAttacks:
     ):
         """Test filtering simulations by name."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -789,17 +772,14 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_filter_by_user_id(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get
     ):
         """Test filtering simulations by user ID."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -856,17 +836,14 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_combined_filters(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get
     ):
         """Test filtering with multiple filters combined."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -931,17 +908,14 @@ class TestGetAllStudioAttacks:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_all_simulations_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get
     ):
         """Test handling API errors."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -960,13 +934,18 @@ class TestGetAllStudioAttacks:
 class TestUpdateStudioAttackDraft:
     """Test the sb_update_studio_attack_draft function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -976,7 +955,6 @@ class TestUpdateStudioAttackDraft:
     ):
         """Test successfully updating a draft simulation."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1086,10 +1064,8 @@ class TestUpdateStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_with_linux_constraint(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -1099,7 +1075,6 @@ class TestUpdateStudioAttackDraft:
     ):
         """Test updating draft with LINUX OS constraint."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1130,10 +1105,8 @@ class TestUpdateStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_with_mac_constraint(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -1143,7 +1116,6 @@ class TestUpdateStudioAttackDraft:
     ):
         """Test updating draft with MAC OS constraint."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1174,10 +1146,8 @@ class TestUpdateStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_with_all_constraint(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -1187,7 +1157,6 @@ class TestUpdateStudioAttackDraft:
     ):
         """Test updating draft with 'All' OS constraint (removes constraint)."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1217,10 +1186,8 @@ class TestUpdateStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -1228,7 +1195,6 @@ class TestUpdateStudioAttackDraft:
     ):
         """Test updating draft when API returns an error."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1252,10 +1218,8 @@ class TestUpdateStudioAttackDraft:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_draft_caching(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_put,
@@ -1265,7 +1229,6 @@ class TestUpdateStudioAttackDraft:
         clear_cache
     ):
         """Test that updated draft metadata is cached correctly."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1282,7 +1245,7 @@ class TestUpdateStudioAttackDraft:
         )
 
         # Verify cache was updated
-        cache_key = f"studio_draft_demo_{result['draft_id']}"
+        cache_key = f"studio_draft_demo_{result['draft_id']}{get_cache_user_suffix()}"
         assert cache_key in studio_draft_cache
         cached_item = studio_draft_cache.get(cache_key)
         assert cached_item['draft_id'] == result['draft_id']
@@ -1292,13 +1255,18 @@ class TestUpdateStudioAttackDraft:
 class TestGetStudioAttackSource:
     """Test the sb_get_studio_attack_source function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_source_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get,
@@ -1306,7 +1274,6 @@ class TestGetStudioAttackSource:
     ):
         """Test successfully retrieving simulation source code."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1355,17 +1322,14 @@ class TestGetStudioAttackSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_source_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get
     ):
         """Test getting source when API returns an error."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1383,17 +1347,14 @@ class TestGetStudioAttackSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_source_empty_content(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_get
     ):
         """Test getting source when content is empty."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1426,13 +1387,18 @@ class TestGetStudioAttackSource:
 class TestRunStudioAttack:
     """Test the sb_run_studio_attack function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_simulation_all_connected(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1440,7 +1406,6 @@ class TestRunStudioAttack:
     ):
         """Test running simulation on all connected simulators."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1475,10 +1440,8 @@ class TestRunStudioAttack:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_simulation_specific_simulators(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1486,7 +1449,6 @@ class TestRunStudioAttack:
     ):
         """Test running simulation on specific simulators."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1518,10 +1480,8 @@ class TestRunStudioAttack:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_simulation_custom_test_name(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1529,7 +1489,6 @@ class TestRunStudioAttack:
     ):
         """Test running simulation with custom test name."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1571,17 +1530,14 @@ class TestRunStudioAttack:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_simulation_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post
     ):
         """Test running simulation when API returns an error."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1776,13 +1732,18 @@ def mock_execution_result_empty_response():
 class TestGetStudioAttackLatestResult:
     """Test suite for sb_get_studio_attack_latest_result function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_latest_result_success(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1790,7 +1751,6 @@ class TestGetStudioAttackLatestResult:
     ):
         """Test successfully retrieving latest execution result."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1840,10 +1800,8 @@ class TestGetStudioAttackLatestResult:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_multiple_results(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1851,7 +1809,6 @@ class TestGetStudioAttackLatestResult:
     ):
         """Test retrieving multiple execution results."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1884,10 +1841,8 @@ class TestGetStudioAttackLatestResult:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_latest_result_no_results(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -1895,7 +1850,6 @@ class TestGetStudioAttackLatestResult:
     ):
         """Test when no execution results are found."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1962,17 +1916,14 @@ class TestGetStudioAttackLatestResult:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_get_latest_result_api_error(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post
     ):
         """Test API error handling."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -1992,6 +1943,13 @@ class TestGetStudioAttackLatestResult:
 
 class TestParameterValidationAndBuilding:
     """Test suite for parameter validation and building functionality."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def test_validate_and_build_parameters_empty_list(self):
         """Test building with empty parameters list."""
@@ -2042,10 +2000,8 @@ class TestParameterValidationAndBuilding:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_draft_with_parameters(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -2055,7 +2011,6 @@ class TestParameterValidationAndBuilding:
     ):
         """Test saving draft with parameters."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -2092,6 +2047,13 @@ class TestParameterValidationAndBuilding:
 
 class TestProtocolParameterValidation:
     """Test suite for PROTOCOL parameter type validation."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def test_validate_protocol_parameter_valid_tcp(self):
         """Test valid TCP protocol parameter."""
@@ -2181,10 +2143,8 @@ class TestProtocolParameterValidation:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_draft_with_protocol_parameter(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -2194,7 +2154,6 @@ class TestProtocolParameterValidation:
     ):
         """Test saving draft with protocol parameter."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -2227,6 +2186,13 @@ class TestProtocolParameterValidation:
 
 class TestMultiValueParameters:
     """Test suite for parameters with multiple values."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def test_single_value_parameter(self):
         """Test parameter with single value (backward compatibility)."""
@@ -2316,10 +2282,8 @@ class TestMultiValueParameters:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_save_draft_with_multi_value_parameters(
         self,
-        mock_get_secret,
         mock_get_base_url,
         mock_get_account_id,
         mock_post,
@@ -2329,7 +2293,6 @@ class TestMultiValueParameters:
     ):
         """Test saving draft with multi-value parameters."""
         # Setup mocks
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -2411,16 +2374,21 @@ def main(system_data, asset, proxy, *args, **kwargs):
 class TestValidateAttackType:
     """Test attack type validation in sb_validate_studio_code."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_valid_host_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test validation with valid 'host' attack type."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2435,13 +2403,11 @@ class TestValidateAttackType:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_valid_exfil_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_validation_response_valid
     ):
         """Test validation with valid 'exfil' attack type and attacker code."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2458,13 +2424,11 @@ class TestValidateAttackType:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_valid_infil_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_validation_response_valid
     ):
         """Test validation with valid 'infil' attack type."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2480,13 +2444,11 @@ class TestValidateAttackType:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_valid_lateral_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_validation_response_valid
     ):
         """Test validation with valid 'lateral' attack type."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2510,13 +2472,11 @@ class TestValidateAttackType:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_case_insensitive_attack_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test that attack type is case-insensitive (e.g., 'Host' normalizes to 'host')."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2532,16 +2492,21 @@ class TestValidateAttackType:
 class TestDualScriptValidation:
     """Test dual-script validation in sb_validate_studio_code."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_exfil_with_both_scripts_valid(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_validation_response_valid
     ):
         """Test exfil with both valid scripts passes."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2588,13 +2553,11 @@ class TestDualScriptValidation:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_with_only_target_valid(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test host attack with only target code is valid."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2612,14 +2575,12 @@ class TestDualScriptValidation:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_attacker_code_syntax_error(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code_syntax_error,
         mock_validation_response_valid
     ):
         """Test attacker code with syntax error causes is_valid=False."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2638,14 +2599,12 @@ class TestDualScriptValidation:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_both_scripts_api_errors_combined(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code,
         mock_validation_response_invalid
     ):
         """Test both scripts with API errors produces combined errors."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2750,16 +2709,21 @@ class TestLintSB012:
 class TestOSConstraintValidation:
     """Test OS constraint validation in sb_validate_studio_code."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_valid_target_os_and_attacker_os(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_validation_response_valid
     ):
         """Test valid target_os and attacker_os pass validation."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2794,13 +2758,11 @@ class TestOSConstraintValidation:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_attack_ignores_attacker_os(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test host attack does not validate attacker_os (even if invalid)."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2818,16 +2780,21 @@ class TestOSConstraintValidation:
 class TestValidationWithLintIntegration:
     """Test SB011/SB012 lint checks integrated into sb_validate_studio_code."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validation_with_lint_warnings(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test that lint warnings are included in validation result."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2846,13 +2813,11 @@ class TestValidationWithLintIntegration:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validation_with_no_parameters(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test that no lint warnings when no parameters provided."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2865,13 +2830,11 @@ class TestValidationWithLintIntegration:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_validation_result_structure(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_validation_response_valid
     ):
         """Test that validation result has all expected fields."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2895,16 +2858,21 @@ class TestValidationWithLintIntegration:
 class TestDualScriptSave:
     """Test dual-script support in sb_save_studio_attack_draft."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_save_single_file_method_type_5(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, mock_draft_response, clear_cache
     ):
         """Test host save sends single file with methodType=5."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2926,13 +2894,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_exfil_save_two_files_method_type_0(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, sample_attacker_code, mock_draft_response, clear_cache
     ):
         """Test exfil save sends two files with methodType=0."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2954,13 +2920,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_infil_save_method_type_2(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, sample_attacker_code, mock_draft_response, clear_cache
     ):
         """Test infil save with methodType=2."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -2980,13 +2944,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_lateral_save_method_type_1(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, sample_attacker_code, mock_draft_response, clear_cache
     ):
         """Test lateral save with methodType=1."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3015,13 +2977,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dual_script_multipart_structure(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, sample_attacker_code, mock_draft_response, clear_cache
     ):
         """Test multipart form data structure for dual-script save."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3047,13 +3007,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dual_script_attacker_constraints(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, sample_attacker_code, mock_draft_response, clear_cache
     ):
         """Test attackerConstraints sent when attacker_os != 'All'."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3075,13 +3033,11 @@ class TestDualScriptSave:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_save_no_attacker_constraints(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         sample_valid_python_code, mock_draft_response, clear_cache
     ):
         """Test host save does not include attackerConstraints or attackerFile."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3106,16 +3062,21 @@ class TestDualScriptSave:
 class TestDualScriptUpdate:
     """Test dual-script support in sb_update_studio_attack_draft."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_host_attack_single_file(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, mock_update_response, clear_cache
     ):
         """Test update host attack sends single file."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3137,13 +3098,11 @@ class TestDualScriptUpdate:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_exfil_attack_both_files(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_update_response, clear_cache
     ):
         """Test update exfil attack sends both files."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3166,13 +3125,11 @@ class TestDualScriptUpdate:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_with_changed_attack_type(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
         sample_valid_python_code, sample_attacker_code, mock_update_response, clear_cache
     ):
         """Test update with changed attack_type sends correct methodType."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3211,13 +3168,11 @@ class TestDualScriptUpdate:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_update_cache_includes_attack_type_info(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put, mock_cache_enabled,
+        self, mock_get_base_url, mock_get_account_id, mock_put, mock_cache_enabled,
         sample_valid_python_code, sample_attacker_code, mock_update_response, clear_cache
     ):
         """Test that cache update includes attack type related info."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3231,7 +3186,7 @@ class TestDualScriptUpdate:
         )
 
         # Verify cache was updated
-        cache_key = f"studio_draft_demo_{result['draft_id']}"
+        cache_key = f"studio_draft_demo_{result['draft_id']}{get_cache_user_suffix()}"
         assert cache_key in studio_draft_cache
         cached = studio_draft_cache.get(cache_key)
         assert cached['draft_id'] == result['draft_id']
@@ -3240,15 +3195,20 @@ class TestDualScriptUpdate:
 class TestDualScriptSource:
     """Test dual-script support in sb_get_studio_attack_source."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_attack_source_target_only(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test host attack source returns target only, attacker is None."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3271,12 +3231,10 @@ class TestDualScriptSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dual_script_source_both_present(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test dual-script source returns both target and attacker content."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3301,12 +3259,10 @@ class TestDualScriptSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_attacker_file_404_graceful(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test attacker file 404 is handled gracefully."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3325,12 +3281,10 @@ class TestDualScriptSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_target_api_error_raises(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test API error on target fetch raises exception."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3345,12 +3299,10 @@ class TestDualScriptSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_return_structure_keys(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test return structure has attack_id, target, attacker keys."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3369,12 +3321,10 @@ class TestDualScriptSource:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_attacker_fetch_network_error_graceful(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test attacker fetch network error is handled gracefully (non-fatal)."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3465,15 +3415,20 @@ class TestPaginateStudioAttacks:
 class TestGetAllStudioAttacksPagination:
     """Test pagination integration in sb_get_all_studio_attacks."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_pagination_with_filters(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test pagination works with filters applied."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3499,12 +3454,10 @@ class TestGetAllStudioAttacksPagination:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_applied_filters_present(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test applied_filters is present in result."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3523,12 +3476,10 @@ class TestGetAllStudioAttacksPagination:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_hint_to_agent_present(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test hint_to_agent is present and meaningful."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3557,16 +3508,21 @@ class TestGetAllStudioAttacksPagination:
 class TestExplicitSimulatorSelection:
     """Test explicit simulator selection in sb_run_studio_attack (Phase 5)."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_host_attack_target_ids_used_for_both(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Host attack: target_simulator_ids used for both attacker and target filters."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3588,13 +3544,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_network_attack_separate_attacker_and_target(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Network attack: separate attacker and target simulator IDs in payload."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3617,13 +3571,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_no_attacker_ids_defaults_to_target_ids(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """When attacker_simulator_ids not provided, attacker uses target IDs."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3645,13 +3597,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_all_connected_uses_connection_filter(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """all_connected=True uses connection filter in payload."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3673,13 +3623,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_all_connected_ignores_simulator_ids(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """all_connected=True ignores provided simulator IDs."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3714,13 +3662,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_return_has_test_id_and_attack_id(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Return structure has test_id and attack_id keys."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3740,13 +3686,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_return_has_status_queued(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Return structure has status key set to 'queued'."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3763,13 +3707,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_payload_structure_matches_api_format(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Verify full API payload structure."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3810,13 +3752,11 @@ class TestExplicitSimulatorSelection:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_return_has_step_run_id(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post,
+        self, mock_get_base_url, mock_get_account_id, mock_post,
         mock_run_response
     ):
         """Return structure includes step_run_id from API response."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -3834,6 +3774,13 @@ class TestExplicitSimulatorSelection:
 
 class TestEnhancedResults:
     """Test enhanced results with simulation_steps, logs, and output (Phase 6)."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def test_result_with_simulation_events_populates_steps(self):
         """Result with simulation events produces populated simulation_steps."""
@@ -3912,12 +3859,10 @@ class TestEnhancedResults:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_include_logs_false_strips_debug_fields(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post
+        self, mock_get_base_url, mock_get_account_id, mock_post
     ):
         """include_logs=False strips simulation_steps, logs, and output."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -3951,12 +3896,10 @@ class TestEnhancedResults:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_include_logs_true_keeps_debug_fields(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post
+        self, mock_get_base_url, mock_get_account_id, mock_post
     ):
         """include_logs=True (default) keeps simulation_steps, logs, and output."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4415,6 +4358,13 @@ class TestGetStudioAttackBoilerplate:
 class TestAttackTypeNormalization:
     """Test _normalize_attack_type() function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def test_canonical_lowercase_passthrough(self):
         """Canonical lowercase keys pass through unchanged."""
         for key in VALID_ATTACK_TYPES:
@@ -4466,12 +4416,10 @@ class TestAttackTypeNormalization:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_alias_in_save_draft(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put
+        self, mock_get_base_url, mock_get_account_id, mock_put
     ):
         """Alias attack type works in save_studio_attack_draft."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4508,6 +4456,13 @@ class TestAttackTypeNormalization:
 class TestOSConstraintNormalization:
     """Test _validate_os_constraint() case-insensitive normalization."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     def test_canonical_values_passthrough(self):
         """Canonical values pass through unchanged."""
         assert _validate_os_constraint("All") == "All"
@@ -4540,12 +4495,10 @@ class TestOSConstraintNormalization:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_lowercase_os_in_validate(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_put,
+        self, mock_get_base_url, mock_get_account_id, mock_put,
     ):
         """Lowercase OS values normalize in sb_validate_studio_code."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
         mock_response = MagicMock()
@@ -4663,15 +4616,20 @@ class TestASTMainSignatureValidation:
 class TestTestIdFilter:
     """Test test_id filter in sb_get_studio_attack_latest_result."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_without_test_id(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post
+        self, mock_get_base_url, mock_get_account_id, mock_post
     ):
         """Without test_id, query contains only Playbook_id."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4690,12 +4648,10 @@ class TestTestIdFilter:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_with_test_id(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post
+        self, mock_get_base_url, mock_get_account_id, mock_post
     ):
         """With test_id, query includes AND runId:{test_id}."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4716,12 +4672,10 @@ class TestTestIdFilter:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_empty_test_id_ignored(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_post
+        self, mock_get_base_url, mock_get_account_id, mock_post
     ):
         """Empty string test_id is treated as None (not included)."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4741,6 +4695,13 @@ class TestTestIdFilter:
 
 class TestSetStudioAttackStatus:
     """Test the sb_set_studio_attack_status function."""
+
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
 
     def _mock_list_response(self, attack_id=10000298, name="Test Attack",
                             status="draft", method_type=5):
@@ -4774,13 +4735,11 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_publish_success(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id,
+        self, mock_get_base_url, mock_get_account_id,
         mock_get, mock_put
     ):
         """Test successful DRAFT → PUBLISHED transition."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4815,13 +4774,11 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_unpublish_success(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id,
+        self, mock_get_base_url, mock_get_account_id,
         mock_get, mock_put
     ):
         """Test successful PUBLISHED → DRAFT transition."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4863,12 +4820,10 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_attack_not_found(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test that a non-existent attack ID raises ValueError."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4889,12 +4844,10 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_already_target_status(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id, mock_get
+        self, mock_get_base_url, mock_get_account_id, mock_get
     ):
         """Test that setting status to current status raises ValueError."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4922,13 +4875,11 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_case_insensitive_status(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id,
+        self, mock_get_base_url, mock_get_account_id,
         mock_get, mock_put
     ):
         """Test that new_status is case-insensitive (e.g., 'PUBLISHED' works)."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4955,13 +4906,11 @@ class TestSetStudioAttackStatus:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_cache_invalidation(
-        self, mock_get_secret, mock_get_base_url, mock_get_account_id,
+        self, mock_get_base_url, mock_get_account_id,
         mock_get, mock_put
     ):
         """Test that cache entry is removed after successful status change."""
-        mock_get_secret.return_value = "test-api-token"
         mock_get_base_url.return_value = "https://demo.safebreach.com"
         mock_get_account_id.return_value = "1234567890"
 
@@ -4973,7 +4922,7 @@ class TestSetStudioAttackStatus:
         mock_put.return_value = mock_put_response
 
         # Seed the cache with a matching entry
-        cache_key = "studio_draft_demo_10000298"
+        cache_key = f"studio_draft_demo_10000298{get_cache_user_suffix()}"
         studio_draft_cache.set(cache_key, {"name": "Test Attack", "status": "draft"})
         assert cache_key in studio_draft_cache
 
@@ -5292,12 +5241,17 @@ class TestComputeScenarioReadiness:
 class TestFetchAllScenarios:
     """Test the _fetch_all_scenarios function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_successful_fetch(self, mock_get, mock_secret, mock_base_url, mock_oob_scenario):
+    def test_successful_fetch(self, mock_get, mock_base_url, mock_oob_scenario):
         """Successful fetch returns list of scenarios."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_response = MagicMock()
@@ -5311,11 +5265,9 @@ class TestFetchAllScenarios:
         assert result[0]["id"] == "3b8eade5-9285-43b8-b3e7-6350420983a5"
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_correct_url_construction(self, mock_get, mock_secret, mock_base_url):
+    def test_correct_url_construction(self, mock_get, mock_base_url):
         """Verify the correct URL and headers are used."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_response = MagicMock()
@@ -5333,11 +5285,9 @@ class TestFetchAllScenarios:
         mock_base_url.assert_called_once_with("test-console", "playbook")
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_http_error_propagates(self, mock_get, mock_secret, mock_base_url):
+    def test_http_error_propagates(self, mock_get, mock_base_url):
         """HTTP errors from the API should propagate."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_response = MagicMock()
@@ -5348,11 +5298,9 @@ class TestFetchAllScenarios:
             _fetch_all_scenarios("test-console")
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_empty_response(self, mock_get, mock_secret, mock_base_url):
+    def test_empty_response(self, mock_get, mock_base_url):
         """Empty scenario list is returned as-is."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_response = MagicMock()
@@ -5372,19 +5320,24 @@ class TestRunScenario:
     separately in TestRunScenarioWithStatistics.
     """
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics', return_value=[{'simulationCount': 100, 'matchedTargetSimulators': 3, 'matchedAttackerSimulators': 2, 'matchedAttacks': 5, 'totalTargetSimulators': 10, 'totalAttackerSimulators': 5, 'totalAttacks': 8}, {'simulationCount': 100, 'matchedTargetSimulators': 3, 'matchedAttackerSimulators': 2, 'matchedAttacks': 5, 'totalTargetSimulators': 10, 'totalAttackerSimulators': 5, 'totalAttacks': 8}])
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_success(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats,
         mock_oob_scenario, mock_queue_response_scenario
     ):
         """Successfully queue an OOB scenario for execution."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5437,14 +5390,12 @@ class TestRunScenario:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_custom_test_name(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats,
         mock_oob_scenario, mock_queue_response_scenario
     ):
         """Custom test_name overrides scenario name in payload."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5471,12 +5422,10 @@ class TestRunScenario:
 
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_not_found(
-        self, mock_secret, mock_base_url, mock_get, mock_oob_scenario
+        self, mock_base_url, mock_get, mock_oob_scenario
     ):
         """Scenario ID not in the fetched list raises ValueError."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -5492,12 +5441,10 @@ class TestRunScenario:
 
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_not_ready(
-        self, mock_secret, mock_base_url, mock_get, mock_oob_scenario_not_ready
+        self, mock_base_url, mock_get, mock_oob_scenario_not_ready
     ):
         """Non-ready scenario returns diagnostic (not error)."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -5527,13 +5474,11 @@ class TestRunScenario:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_api_error(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_oob_scenario
     ):
         """Queue API error propagates."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5559,13 +5504,11 @@ class TestRunScenario:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_multi_step_response(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_oob_scenario
     ):
         """Multi-step scenario response returns all stepRunIds."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5604,13 +5547,11 @@ class TestRunScenario:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_run_scenario_none_fields_builds_dag(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_oob_scenario, mock_queue_response_scenario
     ):
         """Scenarios with None actions/edges/systemTags/uuids get DAG built for them."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5719,16 +5660,21 @@ def mock_statistics_response_all_zero():
 class TestGetScenarioStatistics:
     """Test the _get_scenario_statistics function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     def test_returns_per_step_counts(
-        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        self, mock_post, mock_base_url, mock_account_id,
         mock_oob_scenario, mock_statistics_response_all_good
     ):
         """Returns list of simulationCount per step."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5749,14 +5695,12 @@ class TestGetScenarioStatistics:
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     def test_correct_url_and_payload(
-        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        self, mock_post, mock_base_url, mock_account_id,
         mock_oob_scenario, mock_statistics_response_all_good
     ):
         """Verify correct URL, query params, and payload structure."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5780,14 +5724,12 @@ class TestGetScenarioStatistics:
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     def test_api_error_propagates(
-        self, mock_post, mock_secret, mock_base_url, mock_account_id,
+        self, mock_post, mock_base_url, mock_account_id,
         mock_oob_scenario
     ):
         """API errors propagate."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5803,8 +5745,14 @@ class TestGetScenarioStatistics:
 class TestRunScenarioWithStatistics:
     """Test sb_run_scenario statistics pre-flight and allow_partial_steps."""
 
-    def _setup_mocks(self, mock_secret, mock_base_url, mock_account_id):
-        mock_secret.return_value = "test-token"
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
+    def _setup_mocks(self, mock_base_url, mock_account_id):
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -5832,15 +5780,14 @@ class TestRunScenarioWithStatistics:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_all_steps_good_proceeds(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post,
         mock_oob_scenario, mock_statistics_response_all_good,
         mock_queue_response_scenario
     ):
         """All steps produce simulations — proceeds to queue."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
         self._mock_get(mock_get, [mock_oob_scenario])
         self._mock_post_sequence(mock_post, mock_statistics_response_all_good,
                                  mock_queue_response_scenario)
@@ -5858,14 +5805,13 @@ class TestRunScenarioWithStatistics:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_one_empty_step_default_refuses(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post,
         mock_oob_scenario, mock_statistics_response_one_empty
     ):
         """One step with 0 simulations + allow_partial_steps=False (default) → refuse."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
         self._mock_get(mock_get, [mock_oob_scenario])
 
         stats_resp = MagicMock()
@@ -5886,15 +5832,14 @@ class TestRunScenarioWithStatistics:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_one_empty_step_partial_allowed_proceeds(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post,
         mock_oob_scenario, mock_statistics_response_one_empty,
         mock_queue_response_scenario
     ):
         """One step with 0 + allow_partial_steps=True → proceeds to queue."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
         self._mock_get(mock_get, [mock_oob_scenario])
         self._mock_post_sequence(mock_post, mock_statistics_response_one_empty,
                                  mock_queue_response_scenario)
@@ -5912,14 +5857,13 @@ class TestRunScenarioWithStatistics:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_all_zero_always_refuses(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post,
         mock_oob_scenario, mock_statistics_response_all_zero
     ):
         """All steps 0 simulations → always refuse, even with allow_partial_steps=True."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
         self._mock_get(mock_get, [mock_oob_scenario])
 
         stats_resp = MagicMock()
@@ -6018,14 +5962,19 @@ def mock_custom_plan():
 class TestFetchAllPlans:
     """Test the _fetch_all_plans function."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_successful_fetch(self, mock_get, mock_secret, mock_base_url,
+    def test_successful_fetch(self, mock_get, mock_base_url,
                               mock_account_id, mock_custom_plan):
         """Successful fetch returns list of plans from data wrapper."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6042,12 +5991,10 @@ class TestFetchAllPlans:
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_correct_url_construction(self, mock_get, mock_secret, mock_base_url,
+    def test_correct_url_construction(self, mock_get, mock_base_url,
                                       mock_account_id):
         """Verify correct URL with account_id and details=true."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6066,12 +6013,10 @@ class TestFetchAllPlans:
 
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    def test_http_error_propagates(self, mock_get, mock_secret, mock_base_url,
+    def test_http_error_propagates(self, mock_get, mock_base_url,
                                    mock_account_id):
         """API errors propagate."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6086,8 +6031,14 @@ class TestFetchAllPlans:
 class TestRunScenarioCustomPlan:
     """Test sb_run_scenario with custom plans (Slice 2)."""
 
-    def _setup_mocks(self, mock_secret, mock_base_url, mock_account_id):
-        mock_secret.return_value = "test-token"
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
+    def _setup_mocks(self, mock_base_url, mock_account_id):
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6096,14 +6047,13 @@ class TestRunScenarioCustomPlan:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_custom_plan_success(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats,
         mock_custom_plan, mock_queue_response_scenario
     ):
         """Custom plan found by integer ID, queued with planId payload."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
 
         # GET: first call returns empty OOB list, second returns plans
         oob_response = MagicMock()
@@ -6145,13 +6095,12 @@ class TestRunScenarioCustomPlan:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_custom_plan_not_ready(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats
     ):
         """Custom plan that is not ready-to-run returns diagnostic."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
 
         not_ready_plan = {
             "id": 999,
@@ -6178,12 +6127,11 @@ class TestRunScenarioCustomPlan:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_not_found_in_either_source(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get
+        self, mock_base_url, mock_account_id, mock_get
     ):
         """ID not found in OOB or custom plans raises ValueError."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
 
         oob_response = MagicMock()
         oob_response.json.return_value = []
@@ -6203,14 +6151,13 @@ class TestRunScenarioCustomPlan:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_custom_plan_with_custom_name(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats,
         mock_custom_plan, mock_queue_response_scenario
     ):
         """Custom test_name overrides plan name in queue payload."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
 
         oob_response = MagicMock()
         oob_response.json.return_value = []
@@ -6487,14 +6434,19 @@ class TestApplyStepOverrides:
 class TestRunScenarioWithOverrides:
     """Test sb_run_scenario two-turn workflow with step_overrides (Slice 3)."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_not_ready_no_overrides_returns_diagnostic(
-        self, mock_secret, mock_base_url, mock_get, mock_scenario_all_missing
+        self, mock_base_url, mock_get, mock_scenario_all_missing
     ):
         """Not ready + no overrides → return diagnostic (not error)."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6517,14 +6469,12 @@ class TestRunScenarioWithOverrides:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_not_ready_with_overrides_proceeds(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats,
         mock_scenario_all_missing, mock_queue_response_scenario
     ):
         """Not ready + valid overrides → augment and queue."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6562,12 +6512,10 @@ class TestRunScenarioWithOverrides:
 
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_overrides_still_not_ready_returns_diagnostic(
-        self, mock_secret, mock_base_url, mock_get, mock_scenario_all_missing
+        self, mock_base_url, mock_get, mock_scenario_all_missing
     ):
         """Overrides provided but still not ready (incomplete) → diagnostic."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6611,8 +6559,14 @@ class TestRunScenarioWithOverrides:
 class TestCustomPlanAugmentation:
     """Test that augmented custom plans use full payload, not planId."""
 
-    def _setup_mocks(self, mock_secret, mock_base_url, mock_account_id):
-        mock_secret.return_value = "test-token"
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
+    def _setup_mocks(self, mock_base_url, mock_account_id):
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6634,14 +6588,13 @@ class TestCustomPlanAugmentation:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_augmented_custom_plan_uses_full_payload(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_custom_plan,
         mock_queue_response_scenario
     ):
         """Custom plan with step_overrides sends full payload (not planId)."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
 
         # Make plan not ready by clearing filters
         import copy
@@ -6697,14 +6650,13 @@ class TestCustomPlanAugmentation:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_ready_custom_plan_no_overrides_still_uses_planid(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_custom_plan,
         mock_queue_response_scenario
     ):
         """Ready custom plan without overrides keeps using planId reference."""
-        self._setup_mocks(mock_secret, mock_base_url, mock_account_id)
+        self._setup_mocks(mock_base_url, mock_account_id)
         self._mock_get_oob_empty_plans_found(mock_get, mock_custom_plan)
 
         queue_resp = MagicMock()
@@ -6731,19 +6683,24 @@ class TestCustomPlanAugmentation:
 class TestDryRun:
     """Test dry_run parameter — returns predictions without queuing."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics',
            return_value=[{'simulationCount': 1676, 'matchedTargetSimulators': 11, 'matchedAttackerSimulators': 2, 'matchedAttacks': 12, 'totalTargetSimulators': 13, 'totalAttackerSimulators': 2, 'totalAttacks': 12}, {'simulationCount': 2198, 'matchedTargetSimulators': 11, 'matchedAttackerSimulators': 2, 'matchedAttacks': 22, 'totalTargetSimulators': 13, 'totalAttackerSimulators': 2, 'totalAttacks': 22}])
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dry_run_returns_prediction_without_queuing(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_oob_scenario
     ):
         """dry_run=True returns statistics but does NOT call queue API."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -6773,13 +6730,11 @@ class TestDryRun:
            return_value=[{'simulationCount': 500, 'matchedTargetSimulators': 5, 'matchedAttackerSimulators': 3, 'matchedAttacks': 10, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}, {'simulationCount': 0, 'matchedTargetSimulators': 0, 'matchedAttackerSimulators': 0, 'matchedAttacks': 0, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}])
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dry_run_with_empty_steps_reports_them(
-        self, mock_secret, mock_base_url, mock_get, mock_stats,
+        self, mock_base_url, mock_get, mock_stats,
         mock_oob_scenario
     ):
         """dry_run with some steps producing 0 still returns (no error)."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6801,13 +6756,11 @@ class TestDryRun:
            return_value=[{'simulationCount': 500, 'matchedTargetSimulators': 5, 'matchedAttackerSimulators': 3, 'matchedAttacks': 10, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}, {'simulationCount': 300, 'matchedTargetSimulators': 4, 'matchedAttackerSimulators': 2, 'matchedAttacks': 8, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 12}])
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dry_run_with_overrides(
-        self, mock_secret, mock_base_url, mock_get, mock_stats,
+        self, mock_base_url, mock_get, mock_stats,
         mock_scenario_all_missing
     ):
         """dry_run with step_overrides — augments then predicts."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6850,18 +6803,23 @@ class TestDryRun:
 class TestResolvedAttacks:
     """Test that dry_run includes resolved attacks per step."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions._build_attack_name_map',
            return_value={'281': 'Transfer malware via HTTPS', '226': 'Hidden malware drop'})
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_dry_run_includes_resolved_attacks(
-        self, mock_secret, mock_base_url, mock_get, mock_stats, mock_names,
+        self, mock_base_url, mock_get, mock_stats, mock_names,
         mock_oob_scenario
     ):
         """dry_run response includes resolved_attacks per step with names."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6908,13 +6866,11 @@ class TestResolvedAttacks:
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_resolved_attacks_without_name_map(
-        self, mock_secret, mock_base_url, mock_get, mock_stats, mock_names,
+        self, mock_base_url, mock_get, mock_stats, mock_names,
         mock_oob_scenario
     ):
         """resolved_attacks still work when playbook name map is empty."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -6951,18 +6907,23 @@ class TestResolvedAttacks:
 class TestVerboseFailures:
     """Test verbose_failures flag for per-attack detail on partial steps."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions._build_attack_name_map',
            return_value={'281': 'Attack A', '226': 'Attack B'})
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_verbose_failures_shows_per_attack_on_partial(
-        self, mock_secret, mock_base_url, mock_get, mock_stats, mock_names,
+        self, mock_base_url, mock_get, mock_stats, mock_names,
         mock_oob_scenario
     ):
         """verbose_failures=True shows constraint_summary (not aggregated) for partial steps."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -7012,13 +6973,11 @@ class TestVerboseFailures:
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_without_verbose_uses_aggregated(
-        self, mock_secret, mock_base_url, mock_get, mock_stats, mock_names,
+        self, mock_base_url, mock_get, mock_stats, mock_names,
         mock_oob_scenario
     ):
         """Without verbose_failures, partial steps use aggregated summary."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -7070,13 +7029,18 @@ class TestVerboseFailures:
 class TestManageTest:
     """Tests for sb_manage_test — test lifecycle management (pause/resume/cancel)."""
 
+    @pytest.fixture(autouse=True)
+    def set_auth_context(self):
+        from safebreach_mcp_core.token_context import _user_auth_artifacts
+        token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+        yield
+        _user_auth_artifacts.reset(token)
+
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_cancel_success(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_success(self, mock_base_url, mock_account_id, mock_delete):
         """Cancel a running test via DELETE — happy path."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7109,11 +7073,9 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_cancel_api_error(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_api_error(self, mock_base_url, mock_account_id, mock_delete):
         """API error during cancel propagates as RequestException."""
         import requests as req
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7129,10 +7091,8 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_pause_success(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+    def test_pause_success(self, mock_base_url, mock_account_id, mock_put):
         """Pause a running test via PUT /state — happy path."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7167,10 +7127,8 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_resume_success(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+    def test_resume_success(self, mock_base_url, mock_account_id, mock_put):
         """Resume a paused test via PUT /state — happy path."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7212,11 +7170,9 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_not_found_404(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+    def test_not_found_404(self, mock_base_url, mock_account_id, mock_delete):
         """404 from API propagates as HTTPError."""
         import requests as req
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7236,13 +7192,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_append_to_existing_comment(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+        self, mock_base_url, mock_account_id, mock_get, mock_put
     ):
         """Append note to existing comment via read-then-append."""
         from safebreach_mcp_studio.studio_functions import _append_test_note
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7273,13 +7227,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_append_to_null_comment(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+        self, mock_base_url, mock_account_id, mock_get, mock_put
     ):
         """Append note when existing comment is null — no leading newline."""
         from safebreach_mcp_studio.studio_functions import _append_test_note
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7304,13 +7256,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_append_to_empty_comment(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+        self, mock_base_url, mock_account_id, mock_get, mock_put
     ):
         """Append note when existing comment is empty string."""
         from safebreach_mcp_studio.studio_functions import _append_test_note
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7334,13 +7284,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_manage_test_with_reason(
-        self, mock_secret, mock_base_url, mock_account_id,
+        self, mock_base_url, mock_account_id,
         mock_get, mock_put, mock_delete
     ):
         """sb_manage_test with reason calls _append_test_note."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7372,12 +7320,10 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_manage_test_without_reason(
-        self, mock_secret, mock_base_url, mock_account_id, mock_delete
+        self, mock_base_url, mock_account_id, mock_delete
     ):
         """sb_manage_test without reason does NOT call _append_test_note."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7397,13 +7343,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_note_get_failure(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get
+        self, mock_base_url, mock_account_id, mock_get
     ):
         """GET failure in _append_test_note returns failure dict, does NOT raise."""
         from safebreach_mcp_studio.studio_functions import _append_test_note
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7418,13 +7362,11 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_note_put_failure(
-        self, mock_secret, mock_base_url, mock_account_id, mock_get, mock_put
+        self, mock_base_url, mock_account_id, mock_get, mock_put
     ):
         """PUT failure in _append_test_note returns failure dict, does NOT raise."""
         from safebreach_mcp_studio.studio_functions import _append_test_note
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7443,12 +7385,10 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
     def test_note_failure_doesnt_block_lifecycle(
-        self, mock_secret, mock_base_url, mock_account_id, mock_delete
+        self, mock_base_url, mock_account_id, mock_delete
     ):
         """Lifecycle succeeds even when note append fails."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7473,10 +7413,8 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_pause_hint(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+    def test_pause_hint(self, mock_base_url, mock_account_id, mock_put):
         """Pause result includes hint_to_agent mentioning resume and cancel."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7494,10 +7432,8 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_resume_hint(self, mock_secret, mock_base_url, mock_account_id, mock_put):
+    def test_resume_hint(self, mock_base_url, mock_account_id, mock_put):
         """Resume result includes hint_to_agent mentioning monitoring."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7513,10 +7449,8 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    @patch('safebreach_mcp_studio.studio_functions.get_secret_for_console')
-    def test_cancel_hint(self, mock_secret, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_hint(self, mock_base_url, mock_account_id, mock_delete):
         """Cancel result includes hint_to_agent mentioning partial results."""
-        mock_secret.return_value = "test-token"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 

--- a/tests/test_auth_concurrency.py
+++ b/tests/test_auth_concurrency.py
@@ -267,10 +267,23 @@ class TestLastUserAuthBundleRemoved:
 
 class TestGetAuthHeadersForConsole:
 
-    def test_raises_when_no_auth_available(self):
-        """Raises AuthenticationRequired when no auth is found anywhere."""
-        with pytest.raises(AuthenticationRequired):
-            get_auth_headers_for_console('default')
+    def test_raises_when_no_auth_in_embedded_mode(self):
+        """Raises AuthenticationRequired in embedded mode (SAFEBREACH_LOCAL_ENV set)."""
+        with patch.dict('os.environ', {'SAFEBREACH_LOCAL_ENV': '{"default":{}}'}):
+            with pytest.raises(AuthenticationRequired):
+                get_auth_headers_for_console('default')
+
+    def test_falls_back_to_api_key_in_standalone_mode(self):
+        """Falls back to get_secret_for_console() in standalone mode (no SAFEBREACH_LOCAL_ENV)."""
+        with patch.dict('os.environ', {}, clear=False):
+            # Ensure SAFEBREACH_LOCAL_ENV is not set
+            import os
+            os.environ.pop('SAFEBREACH_LOCAL_ENV', None)
+            with patch('safebreach_mcp_core.secret_utils.get_secret_for_console',
+                       return_value='standalone-api-key') as mock_secret:
+                result = get_auth_headers_for_console('staging')
+                assert result == {'x-apitoken': 'standalone-api-key'}
+                mock_secret.assert_called_once_with('staging')
 
     def test_contextvar_primary_path(self):
         """ContextVar is the primary source when available."""

--- a/tests/test_auth_concurrency.py
+++ b/tests/test_auth_concurrency.py
@@ -1,0 +1,286 @@
+"""
+Tests for concurrency-safe auth bundle resolution (SAF-29974 Slice 6).
+
+Verifies that _last_user_auth_bundle (global variable) has been removed and
+replaced by per-request auth extraction from the MCP SDK's request_ctx.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from safebreach_mcp_core.token_context import (
+    _user_auth_artifacts,
+    _session_auth_artifacts,
+    _get_auth_from_mcp_request_ctx,
+    _get_session_id_from_mcp_ctx,
+    get_cache_user_suffix,
+)
+from safebreach_mcp_core.secret_utils import (
+    get_auth_headers_for_console,
+    AuthenticationRequired,
+)
+
+# Patch target: the SDK module where request_ctx lives.
+# The helper functions import it via `from mcp.server.lowlevel.server import request_ctx`.
+_REQUEST_CTX_PATCH = 'mcp.server.lowlevel.server.request_ctx'
+
+
+@pytest.fixture(autouse=True)
+def cleanup_auth_state():
+    """Reset ContextVar and session store between tests."""
+    token = _user_auth_artifacts.set(None)
+    _session_auth_artifacts.clear()
+    yield
+    _user_auth_artifacts.set(None)
+    _session_auth_artifacts.clear()
+    _user_auth_artifacts.reset(token)
+
+
+def _mock_request(headers=None, query_params=None):
+    """Build a mock Starlette-like Request object."""
+    req = MagicMock()
+    req.headers = headers or {}
+    req.query_params = query_params or {}
+    return req
+
+
+def _mock_request_ctx(request):
+    """Build a mock MCP SDK RequestContext holding the given request."""
+    ctx = MagicMock()
+    ctx.request = request
+    return ctx
+
+
+class TestGetAuthFromMcpRequestCtx:
+
+    def test_returns_none_outside_tool_context(self):
+        """When request_ctx has no value (outside tool handler), returns None."""
+        result = _get_auth_from_mcp_request_ctx()
+        assert result is None
+
+    def test_extracts_x_apitoken(self):
+        """Extracts x-apitoken from the POST request headers."""
+        req = _mock_request(headers={'x-apitoken': 'tok123'})
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result == {'x-apitoken': 'tok123'}
+
+    def test_extracts_x_token(self):
+        """Extracts x-token (JWT) from the POST request headers."""
+        req = _mock_request(headers={'x-token': 'jwt-abc'})
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result == {'x-token': 'jwt-abc'}
+
+    def test_extracts_and_scrubs_cookie(self):
+        """Extracts cookie header and scrubs non-auth cookies."""
+        raw_cookie = 'X-Token=jwt123; _ga=GA1.2; __secure-Fgp=fp456; _csrf=abc'
+        req = _mock_request(headers={'cookie': raw_cookie})
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result is not None
+        assert 'cookie' in result
+        assert 'X-Token=jwt123' in result['cookie']
+        assert '__secure-Fgp=fp456' in result['cookie']
+        assert '_ga' not in result['cookie']
+        assert '_csrf' not in result['cookie']
+
+    def test_extracts_all_artifacts(self):
+        """Extracts all three auth artifacts when all present."""
+        req = _mock_request(headers={
+            'x-apitoken': 'api-key',
+            'x-token': 'jwt-val',
+            'cookie': 'X-Token=jwt123',
+        })
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result is not None
+        assert result['x-apitoken'] == 'api-key'
+        assert result['x-token'] == 'jwt-val'
+        assert 'X-Token=jwt123' in result['cookie']
+
+    def test_returns_none_when_no_auth_headers(self):
+        """Returns None when the request has no auth headers."""
+        req = _mock_request(headers={'content-type': 'application/json'})
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result is None
+
+    def test_returns_none_when_request_is_none(self):
+        """Returns None when request_ctx has no request attribute."""
+        ctx = MagicMock()
+        ctx.request = None
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_auth_from_mcp_request_ctx()
+        assert result is None
+
+
+class TestGetSessionIdFromMcpCtx:
+
+    def test_returns_none_outside_tool_context(self):
+        """When request_ctx has no value, returns None."""
+        result = _get_session_id_from_mcp_ctx()
+        assert result is None
+
+    def test_extracts_session_id_from_query_params_sse(self):
+        """SSE: session_id is in query_params."""
+        req = _mock_request(query_params={'session_id': 'abc123hex'})
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_session_id_from_mcp_ctx()
+        assert result == 'abc123hex'
+
+    def test_extracts_session_id_from_header_streamable_http(self):
+        """Streamable-HTTP: session_id is in mcp-session-id header."""
+        req = _mock_request(
+            headers={'mcp-session-id': 'stream-sess-xyz'},
+            query_params={},
+        )
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_session_id_from_mcp_ctx()
+        assert result == 'stream-sess-xyz'
+
+    def test_prefers_query_param_over_header(self):
+        """When both are present, query_params (SSE) takes precedence."""
+        req = _mock_request(
+            headers={'mcp-session-id': 'from-header'},
+            query_params={'session_id': 'from-query'},
+        )
+        ctx = _mock_request_ctx(req)
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            result = _get_session_id_from_mcp_ctx()
+        assert result == 'from-query'
+
+
+class TestConcurrentSessionIsolation:
+    """The core safety test: two concurrent sessions must not leak credentials."""
+
+    def test_two_sessions_different_tokens_get_own_credentials(self):
+        """Simulate two tool handlers with different request_ctx values.
+
+        Each should get its own auth headers, not the other's.
+        """
+        req_a = _mock_request(headers={'x-token': 'token-user-A'})
+        ctx_a = _mock_request_ctx(req_a)
+        req_b = _mock_request(headers={'x-token': 'token-user-B'})
+        ctx_b = _mock_request_ctx(req_b)
+
+        # Simulate User A's tool handler context
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx_a
+            result_a = get_auth_headers_for_console('default')
+
+        # Simulate User B's tool handler context
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx_b
+            result_b = get_auth_headers_for_console('default')
+
+        assert result_a['x-token'] == 'token-user-A'
+        assert result_b['x-token'] == 'token-user-B'
+        assert result_a['x-token'] != result_b['x-token']
+
+    def test_session_store_fallback_isolates_sessions(self):
+        """When request_ctx headers are empty, session store provides isolation."""
+        # Pre-populate session store with different bundles
+        _session_auth_artifacts['sess-A'] = ({'x-token': 'token-A'}, 1000.0)
+        _session_auth_artifacts['sess-B'] = ({'x-token': 'token-B'}, 1000.0)
+
+        # User A: request_ctx has session_id in query_params but no auth headers
+        req_a = _mock_request(
+            headers={},
+            query_params={'session_id': 'sess-A'},
+        )
+        ctx_a = _mock_request_ctx(req_a)
+
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx_a
+            result_a = get_auth_headers_for_console('default')
+
+        assert result_a['x-token'] == 'token-A'
+
+        # User B: different session_id
+        req_b = _mock_request(
+            headers={},
+            query_params={'session_id': 'sess-B'},
+        )
+        ctx_b = _mock_request_ctx(req_b)
+
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx_b
+            result_b = get_auth_headers_for_console('default')
+
+        assert result_b['x-token'] == 'token-B'
+
+
+class TestGetCacheUserSuffix:
+
+    def test_uses_mcp_request_ctx_when_contextvar_empty(self):
+        """get_cache_user_suffix falls back to MCP request_ctx when ContextVar is None."""
+        req = _mock_request(headers={'x-apitoken': 'stable-token-123'})
+        ctx = _mock_request_ctx(req)
+
+        with patch(_REQUEST_CTX_PATCH) as mock_rc:
+            mock_rc.get.return_value = ctx
+            suffix = get_cache_user_suffix()
+
+        assert suffix.startswith('_')
+        assert len(suffix) == 9  # '_' + 8 hex chars
+
+    def test_returns_empty_when_no_context(self):
+        """Returns empty string when neither ContextVar nor request_ctx has auth."""
+        suffix = get_cache_user_suffix()
+        assert suffix == ''
+
+    def test_contextvar_takes_priority_over_request_ctx(self):
+        """When ContextVar has a value, request_ctx is not consulted."""
+        _user_auth_artifacts.set({'x-apitoken': 'from-contextvar'})
+
+        import hashlib
+        expected = '_' + hashlib.sha256('from-contextvar'.encode()).hexdigest()[:8]
+        suffix = get_cache_user_suffix()
+        assert suffix == expected
+
+
+class TestLastUserAuthBundleRemoved:
+
+    def test_module_no_longer_exports_last_user_auth_bundle(self):
+        """_last_user_auth_bundle must not exist in token_context module."""
+        import safebreach_mcp_core.token_context as tc
+        assert not hasattr(tc, '_last_user_auth_bundle'), \
+            '_last_user_auth_bundle should have been removed (Slice 6 concurrency fix)'
+
+
+class TestGetAuthHeadersForConsole:
+
+    def test_raises_when_no_auth_available(self):
+        """Raises AuthenticationRequired when no auth is found anywhere."""
+        with pytest.raises(AuthenticationRequired):
+            get_auth_headers_for_console('default')
+
+    def test_contextvar_primary_path(self):
+        """ContextVar is the primary source when available."""
+        _user_auth_artifacts.set({'x-token': 'ctx-jwt', 'cookie': 'X-Token=ctx'})
+        result = get_auth_headers_for_console('default')
+        assert result['x-token'] == 'ctx-jwt'
+
+    def test_returns_copy_not_original(self):
+        """Returns a copy of the bundle so callers can mutate it safely."""
+        _user_auth_artifacts.set({'x-token': 'jwt1'})
+        result = get_auth_headers_for_console('default')
+        result['x-token'] = 'mutated'
+        assert _user_auth_artifacts.get()['x-token'] == 'jwt1'

--- a/tests/test_environments_metadata.py
+++ b/tests/test_environments_metadata.py
@@ -23,13 +23,19 @@ class TestEnvironmentsMetadata(unittest.TestCase):
             'test_console_apitoken',
             'my_local_console_apitoken'
         ]
-        
+
         self.original_env_vars = {}
         for var in self.env_vars_to_clean:
             self.original_env_vars[var] = os.environ.get(var)
             if var in os.environ:
                 del os.environ[var]
-    
+
+        # Snapshot the module-level safebreach_envs dict so we can restore it.
+        # Other modules hold references to this exact dict object, so we must
+        # restore in-place (clear + update), not replace.
+        from safebreach_mcp_core.environments_metadata import safebreach_envs
+        self._original_envs_snapshot = dict(safebreach_envs)
+
     def tearDown(self):
         """Clean up test environment."""
         # Restore original environment variables
@@ -38,7 +44,13 @@ class TestEnvironmentsMetadata(unittest.TestCase):
                 os.environ[var] = original_value
             elif var in os.environ:
                 del os.environ[var]
-        
+
+        # Restore safebreach_envs in-place so all existing references see the
+        # original state (prevents cross-test pollution via module-level dict).
+        from safebreach_mcp_core.environments_metadata import safebreach_envs
+        safebreach_envs.clear()
+        safebreach_envs.update(self._original_envs_snapshot)
+
         # Clear modules cache to ensure fresh imports in each test
         import sys
         modules_to_clear = [
@@ -186,13 +198,17 @@ class TestEnvironmentsMetadata(unittest.TestCase):
     
     def test_safebreach_local_env_invalid_json(self):
         """Test that invalid JSON in SAFEBREACH_LOCAL_ENV raises proper error."""
+        import sys
         # Set invalid JSON
         os.environ['SAFEBREACH_LOCAL_ENV'] = '{"invalid": json}'
-        
+
+        # Force fresh import so module-level code re-parses the env var
+        sys.modules.pop('safebreach_mcp_core.environments_metadata', None)
+
         # Import should raise ValueError
         with self.assertRaises(ValueError) as context:
-            from safebreach_mcp_core.environments_metadata import safebreach_envs
-        
+            from safebreach_mcp_core.environments_metadata import safebreach_envs  # noqa: F811
+
         self.assertIn("Invalid JSON in SAFEBREACH_LOCAL_ENV", str(context.exception))
     
     def test_combined_environment_loading(self):

--- a/tests/test_external_authentication.py
+++ b/tests/test_external_authentication.py
@@ -70,7 +70,7 @@ class TestAuthenticationSimple(unittest.TestCase):
         launcher = MultiServerLauncher(mock_args)
         
         # Should enable external connections for all servers
-        expected = {'config': True, 'data': True, 'utilities': True, 'playbook': True}
+        expected = {'config': True, 'data': True, 'utilities': True, 'playbook': True, 'studio': True}
         self.assertEqual(launcher.external_config, expected)
     
     def test_multi_server_launcher_specific_external_config(self):
@@ -86,7 +86,7 @@ class TestAuthenticationSimple(unittest.TestCase):
         launcher = MultiServerLauncher(mock_args)
         
         # Should enable external only for specified servers
-        expected = {'config': True, 'data': False, 'utilities': True, 'playbook': False}
+        expected = {'config': True, 'data': False, 'utilities': True, 'playbook': False, 'studio': False}
         self.assertEqual(launcher.external_config, expected)
     
     def test_bind_host_determination(self):
@@ -124,7 +124,7 @@ class TestAuthenticationSimple(unittest.TestCase):
         with patch.dict(os.environ, {'SAFEBREACH_MCP_ALLOW_EXTERNAL': 'true'}):
             from start_all_servers import parse_external_config
             config = parse_external_config()
-            expected = {'config': True, 'data': True, 'utilities': True, 'playbook': True}
+            expected = {'config': True, 'data': True, 'utilities': True, 'playbook': True, 'studio': True}
             self.assertEqual(config, expected)
         
         # Test server-specific flags
@@ -134,7 +134,7 @@ class TestAuthenticationSimple(unittest.TestCase):
             'SAFEBREACH_MCP_UTILITIES_EXTERNAL': 'true'
         }):
             config = parse_external_config()
-            expected = {'config': True, 'data': False, 'utilities': True, 'playbook': False}
+            expected = {'config': True, 'data': False, 'utilities': True, 'playbook': False, 'studio': False}
             self.assertEqual(config, expected)
     
     def test_security_warning_log_method(self):


### PR DESCRIPTION
## What

Per-user RBAC enforcement in SafeBreach MCP servers — each tool call uses the requesting
user's own auth credentials instead of a shared service account API key.

## Why

[SAF-29974](https://safebreach.atlassian.net/browse/SAF-29974)

Previously all MCP tool calls used a single shared `SB_API_KEY`, bypassing RBAC entirely.
Restricted users could access data outside their role permissions. Audit logs couldn't
trace actions to individual users.

## Changes

- **Auth resolution chain**: New `get_auth_headers_for_console()` with 4-tier fallback:
  ContextVar → MCP SDK `request_ctx` → session store → mode-dependent fallback
- **Concurrency-safe**: Replaced `_last_user_auth_bundle` global with per-request header
  extraction from MCP SDK's `request_ctx` ContextVar (zero shared mutable state)
- **Tool migration**: All 33 tool functions across data/config/studio/playbook migrated
  from `get_secret_for_console()` to `get_auth_headers_for_console()`
- **403 hints**: `check_rbac_response()` replaces `raise_for_status()` at 35 sites with
  LLM-friendly permission denial messages
- **Cache isolation**: All cache keys include per-user SHA-256 suffix via
  `get_cache_user_suffix()`
- **Cookie scrubbing**: Keeps only `X-Token` + `__secure-Fgp` from incoming cookies
- **Security fix**: OPA bypass via unknown console name prevented (`'default'` fallback)
- **URL priority**: `SAFEBREACH_LOCAL_ENV` urls take priority over env vars (embedded mode)
- **Standalone mode preserved**: Falls back to env-var API key when `SAFEBREACH_LOCAL_ENV`
  is not set (no RBAC enforcement in standalone deployment)
- **Test isolation fix**: `safebreach_envs` dict restored in-place in test tearDown

## Testing

- 21 new concurrency safety tests (`tests/test_auth_concurrency.py`)
- 710 total unit tests pass (data: 134, config: 44, playbook: 140, studio: 330, core: 62)
- E2E verified on apricot-pudu.dev.sbops.com with both SSE and streamable-http transports
- Same-user positive+negative RBAC test: Tests_viewer succeeds on `get_tests_history`
  but gets 403 on `get_test_simulations`
- PRD: `prds/SAF-29974-support-rbac/prd.md`

## JIRA

[SAF-29974](https://safebreach.atlassian.net/browse/SAF-29974)