### PR TITLE
SAF-30718: Introduce versioning mechanism for deterministic consumer dependency pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'pyproject.toml' ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Extract version from pyproject.toml
+      id: version
+      run: |
+        VERSION=$(grep -Po '^version\s*=\s*"\K[^"]+' pyproject.toml)
+        if [ -z "$VERSION" ]; then
+          echo "::error::Could not extract version from pyproject.toml"
+          exit 1
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Detected version: $VERSION"
+
+    - name: Check if tag already exists
+      id: check_tag
+      run: |
+        if git tag -l "${{ steps.version.outputs.version }}" | grep -q .; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "Tag ${{ steps.version.outputs.version }} already exists — skipping release"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "Tag ${{ steps.version.outputs.version }} does not exist — proceeding"
+        fi
+
+    - name: Validate CHANGELOG entry
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        if ! grep -q "^## $VERSION" CHANGELOG.md; then
+          echo "::error::CHANGELOG.md is missing an entry for version $VERSION"
+          echo "::error::Add a '## $VERSION' section to CHANGELOG.md before bumping the version"
+          exit 1
+        fi
+        echo "CHANGELOG entry found for $VERSION"
+
+    - name: Extract release notes from CHANGELOG
+      if: steps.check_tag.outputs.exists == 'false'
+      id: notes
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        # Extract content between "## $VERSION" and the next "## " heading (or EOF)
+        NOTES=$(awk "/^## $VERSION/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md)
+        if [ -z "$NOTES" ]; then
+          NOTES="Release $VERSION"
+        fi
+        # Write to file to preserve multiline content
+        echo "$NOTES" > /tmp/release-notes.md
+
+    - name: Create tag
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a "$VERSION" -m "Release $VERSION"
+        git push origin "$VERSION"
+
+    - name: Create GitHub Release
+      if: steps.check_tag.outputs.exists == 'false'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        gh release create "$VERSION" \
+          --title "$VERSION" \
+          --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the safebreach-mcp project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.1.0 — 2026-05-07
+
+### Added
+
+- Multi-server MCP architecture with domain-specific servers: Config (port 8000), Data (port 8001),
+  Utilities (port 8002), Playbook (port 8003), Studio (port 8004)
+- External connection support with Bearer token authentication and localhost bypass
+- SSE and Streamable HTTP transport modes
+- Playbook attack filtering by MITRE ATT&CK techniques/tactics and attacker/target platform
+- Drift analysis tools: test-run-centric (`get_test_drifts`) and time-window-based
+  (`get_simulation_result_drifts`, `get_simulation_status_drifts`)
+- Scenario execution (`run_scenario`) with three-turn augmentation workflow, dry-run mode,
+  step overrides, and constraint diagnostics
+- Test lifecycle management (`manage_test`) for pause, resume, and cancel operations
+- Per-user RBAC enforcement across all MCP servers
+- Peer benchmark scoring (`get_peer_benchmark_score`) with industry comparison
+- Full simulation log retrieval (`get_full_simulation_logs`) for forensic analysis
+- Bounded TTL caching (`SafeBreachCache`) with per-type LRU eviction and background monitoring
+- Pluggable secret provider interface (AWS SSM, AWS Secrets Manager, environment variables)
+- Dynamic environment loading via `SAFEBREACH_ENVS_FILE` and `SAFEBREACH_LOCAL_ENV`
+- Concurrent multi-server launcher (`start_all_servers.py`)
+- Security scanning CI workflow (Gitleaks, TruffleHog, GitGuardian, detect-secrets)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,10 @@ SAFEBREACH_MCP_AUTH_TOKEN="your-token" SAFEBREACH_MCP_DATA_EXTERNAL=true uv run 
 
 **Running the MCP Server (Remote Installation):**
 ```bash
-# Install and run from git repository
+# Install and run from git repository (latest)
 uv tool install git+ssh://git@github.com/SafeBreach/safebreach-mcp.git
+# Or install a specific version
+uv tool install git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0
 export PATH="$HOME/.local/bin:$PATH"  # If needed
 
 # Run multi-server architecture
@@ -585,8 +587,10 @@ Basic installation commands:
 git clone git@github.com:SafeBreach/safebreach-mcp.git
 uv sync
 
-# Remote installation
+# Remote installation (latest)
 uv tool install git+ssh://git@github.com:SafeBreach/safebreach-mcp.git/
+# Or install a specific version
+uv tool install git+ssh://git@github.com:SafeBreach/safebreach-mcp.git/@1.1.0
 ```
 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include CLAUDE.md
+include CHANGELOG.md
 include DESIGN.md
 include requirements.txt
 include *.py

--- a/README.md
+++ b/README.md
@@ -308,8 +308,11 @@ Install and run the MCP server directly from the repository:
 4. Test: `ssh -T git@github.com`
 
 ```bash
-# Method 1: Install latest version of the package as a tool with SSH (recommended for private repos)
+# Method 1: Install with SSH (recommended for private repos)
+# Latest:
 uv tool install --force git+ssh://git@github.com/SafeBreach/safebreach-mcp.git
+# Specific version:
+uv tool install --force git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0
 
 # Update PATH if needed (uv will show a warning if required)
 export PATH="/Users/$(whoami)/.local/bin:$PATH"  # or run: uv tool update-shell
@@ -325,19 +328,33 @@ safebreach-mcp-playbook-server   # Port 8003
 safebreach-mcp-studio-server    # Port 8004
 
 # Method 2: Install with HTTPS authentication
-# First, configure git credentials or use personal access token
-uv tool install git+https://username:personal-access-token@github.com/SafeBreach/safebreach-mcp.git
+# First, configure git credentials: git config credential.helper store
+# Then install (git will prompt for credentials):
+# Latest:
+uv tool install git+https://github.com/SafeBreach/safebreach-mcp.git
+# Specific version:
+uv tool install git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0
 safebreach-mcp-all-servers
 
 # Method 3: Install with pip in a uv environment
 uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+# Latest:
 uv pip install git+ssh://git@github.com/SafeBreach/safebreach-mcp.git
+# Specific version:
+uv pip install git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0
 safebreach-mcp-all-servers
 
 # Method 4: For newer uv versions (0.4.0+) with SSH
+# Latest:
 uv run --from git+ssh://git@github.com/SafeBreach/safebreach-mcp.git safebreach-mcp-all-servers
+# Specific version:
+uv run --from git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0 safebreach-mcp-all-servers
 ```
+
+> **Version pinning:** Append `@<version>` to any git URL to install a specific release
+> (e.g., `@1.1.0`). See [Releases](https://github.com/SafeBreach/safebreach-mcp/releases)
+> for available versions.
 
 ### Option 2: Local Development Setup 🛠️
 

--- a/prds/SAF-30718-Introduce-versioning/context.md
+++ b/prds/SAF-30718-Introduce-versioning/context.md
@@ -1,0 +1,127 @@
+# Ticket Context: SAF-30718
+
+## Status
+Phase 6: PRD Created (planning-dev-task)
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: [safebreach-mcp] Create a versioning mechanism allowing consumers of the codebase to explicitly sync to a particular version
+- **Description**: Currently the consumers (like mcp-proxy) of the safebreach-mcp repository on public GitHub simply clone and sync to the latest main branch. This is causing many sync problems. We want to introduce official versioning to the safebreach-mcp repo to allow consumers to pin to a specific version (e.g., `git+https://github.com/SafeBreach/safebreach-mcp.git@version_1.1`). The mechanism should be explicit, readable, reliable, and easy to set on the repo.
+- **Acceptance Criteria**: Not yet defined
+- **Status**: To Do
+
+## Task Scope
+1. Versioning mechanism: git tags, pyproject.toml version, changelog, CI considerations
+2. Consumer impact analysis: how mcp-proxy and deployment scripts currently depend on this repo
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+- /Users/yossiattas/projects/mcp-proxy
+
+## Investigation Findings
+
+### safebreach-mcp
+
+- **Version defined**: `version = "1.1.0"` in `pyproject.toml` (line 3) — single source of truth
+- **No git tags**: `git tag -l` returns empty — no tags have ever been created
+- **No CHANGELOG**: No CHANGELOG.md, RELEASES, or HISTORY file exists
+- **No `__version__`**: No runtime version attributes in any package `__init__.py`
+- **Build system**: setuptools (`pyproject.toml` lines 56-58), auto-discovery for `safebreach_mcp_*` packages
+- **6 entry points**: config-server, data-server, utilities-server, playbook-server, studio-server, all-servers
+- **CI/CD**: Only `.github/workflows/security-scan.yml` (Gitleaks/TruffleHog). No release, publish, or tag workflows
+- **Pre-commit**: Only secret detection (gitleaks). No version management hooks
+- **Lock files**: `uv.lock` and `requirements.txt` exist for reproducibility
+- **README**: Documents version 1.1.0 and installation via git URLs (no version pinning examples)
+- **Installation docs**: All methods use unpinned git URLs (`git+ssh://...safebreach-mcp.git`)
+
+### mcp-proxy
+
+- **Dependency**: `requirements.txt` line 5: `git+https://github.com/SafeBreach/safebreach-mcp.git` — completely unpinned
+- **History**: Was temporarily pinned to `streamable-http` branch, then moved back to unpinned main
+- **Not in setup.py**: safebreach-mcp is only in requirements.txt, not `install_requires`
+- **Dynamic imports**: mcp-proxy uses string-based `__import__()` for all 5 MCP server classes — no compile-time checks
+- **Runtime version tracking**: `src/simp/version_info.py` reads git commit hash from `direct_url.json` metadata at startup
+- **Three Dockerfiles**: dev, prod, integ — all install via `pip install -r requirements.txt`, all unpinned
+- **Jenkins CI**: `integrationPipeline()` with `prepareSshDeps()`. No version override build parameters
+- **Other unpinned deps**: moves-runner and python-common (SSH git URLs) are also unpinned
+- **PyPI deps pinned**: fastapi==0.115.12, uvicorn==0.34.0, httpx==0.28.1 — explicit version pinning
+- **No lock files**: No uv.lock, poetry.lock, or requirements.lock in mcp-proxy
+
+## Problem Analysis
+
+### Problem Scope
+The safebreach-mcp repo has a version string (`1.1.0`) in pyproject.toml but no mechanism to make it
+accessible to consumers. No git tags, no release workflow, no changelog exist. Consumers like mcp-proxy
+pull latest `main`, creating non-deterministic builds where any commit can break downstream without notice.
+
+### Affected Areas
+- **safebreach-mcp**: pyproject.toml, git tags, CI workflows, README/docs, CHANGELOG
+- **mcp-proxy**: requirements.txt (pinning), potentially Jenkinsfile (version override)
+- **Other consumers**: Deployment scripts, `uv tool install` commands in CLAUDE.md
+
+### Risks & Edge Cases
+- Multi-package consistency: all 6 servers share one version — bump must cover whole repo
+- Consumer adoption: existing consumers must update dependency specs on upgrade
+- Tag format choice: need convention (e.g., `v1.1.0`) and adherence
+- Stale egg-info: cached version in `safebreach_mcp_server.egg-info/` could cause confusion
+
+### Dependencies
+- No external blockers — internal tooling decision
+- mcp-proxy changes can be coordinated after tags are published
+
+## Clarified Requirements (Phase 2)
+- **Tag strategy**: Auto-tag on version change in pyproject.toml when merged to main
+- **GitHub Releases**: Create GitHub Release objects with CHANGELOG entry as release notes
+- **CHANGELOG scope**: Start fresh with v1.1.0 only (no retroactive history)
+- **Tag format**: `X.Y.Z` (semver, no `v` prefix — matches pyproject.toml directly, PEP 440 aligned)
+- **Source of truth**: pyproject.toml version field remains canonical
+
+## Implementation-Specific Findings (Phase 4)
+
+### Files Requiring Changes
+- **pyproject.toml** (line 3): `version = "1.1.0"` — source of truth, no change needed
+- **README.md**: 4 unpinned git URLs at lines 312, 329, 335, 339 — add version-pinned examples
+- **CLAUDE.md**: 2 unpinned git URLs at lines 86, 589 — add version-pinned examples
+- **New file**: `.github/workflows/release.yml` — auto-tag + GitHub Release workflow
+- **New file**: `CHANGELOG.md` — initial entry for v1.1.0
+- **MANIFEST.in**: May need to include CHANGELOG.md
+
+### No Changes Needed
+- `.gitignore`: Already has `*.egg-info/` (line 24)
+- `safebreach_mcp_server.egg-info/`: Not tracked in git (confirmed via `git ls-files`)
+- Build system: setuptools with pyproject.toml — standard, works well
+- Pre-commit hooks: No version-related hooks needed
+
+### CI Workflow Style Reference
+- Existing workflow: `.github/workflows/security-scan.yml` (45 lines)
+- Triggers on push/PR to main and develop
+- Single-job structure, ubuntu-latest, consistent YAML formatting
+- Uses `${{ secrets.X }}` pattern for sensitive values
+
+### Version References in Codebase
+- `pyproject.toml` line 3: canonical source
+- `PKG-INFO` (generated): auto-derived from pyproject.toml
+- README.md: mentions version 1.1.0 in multiple places
+- TEMPLATE_VERSION in studio_templates.py: separate constant "1.0.0" (not package version)
+
+## Brainstorming Results (Phase 5)
+
+### Chosen Approach: Path-Filtered Workflow (Approach B)
+- Triggers on push to main, filtered by `paths: ['pyproject.toml']`
+- Extracts version from pyproject.toml, checks if tag `v{version}` exists
+- Verifies CHANGELOG.md has entry for new version (gate)
+- Creates git tag + GitHub Release with CHANGELOG excerpt as release notes
+- Simple, self-contained, no external dependencies
+
+### Rejected Alternatives
+- **Approach A (Version-Diff)**: Runs on every push — wasteful CI minutes
+- **Approach C (Semantic Release)**: Overkill, requires conventional commit adoption
+
+### Additional Decisions
+- CHANGELOG gate: workflow validates CHANGELOG has `## v{version}` section before tagging
+- Initial v1.1.0 tag: created manually after PR merges (not by workflow)
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/SAF-30718-Introduce-versioning/prd.md
+++ b/prds/SAF-30718-Introduce-versioning/prd.md
@@ -1,0 +1,357 @@
+# Git Tag Versioning for safebreach-mcp — SAF-30718
+
+## 1. Overview
+
+- **Task Type**: Feature (infrastructure/developer tooling)
+- **Purpose**: Enable consumers of safebreach-mcp to pin to explicit, stable versions instead of pulling the
+  latest `main` branch. Eliminates non-deterministic builds, enables rollback, and provides a structured
+  release communication channel.
+- **Target Consumer**: Downstream consumers of safebreach-mcp (deployment engineers, integration teams)
+- **Key Benefits**:
+  - Deterministic builds: same dependency spec always produces the same installation
+  - Rollback capability: consumers can revert to any prior tagged version
+  - Release communication: CHANGELOG and GitHub Releases document what changed per version
+- **Business Alignment**: Improves reliability and maintainability of the SafeBreach MCP integration layer,
+  reducing sync-related outages and debugging time
+- **Originating Request**: SAF-30718 — downstream consumers currently install unpinned `git+https://...`
+  with no way to pin to a specific version
+
+---
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-05-07 15:00 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution: Path-Filtered GitHub Actions Workflow
+
+A lightweight GitHub Actions workflow that triggers only when `pyproject.toml` is modified on `main`.
+It extracts the version string, verifies a matching CHANGELOG entry exists, then creates a git tag
+(`X.Y.Z`) and a GitHub Release with the CHANGELOG excerpt as release notes.
+
+**Key characteristics:**
+- `pyproject.toml` version field remains the single source of truth
+- Tags follow `X.Y.Z` semver format (e.g., `1.1.0`) — no `v` prefix, matching pyproject.toml directly
+- CHANGELOG gate: workflow refuses to tag if CHANGELOG.md lacks an entry for the new version
+- No external dependencies beyond standard GitHub Actions
+
+### Alternatives Considered
+
+| Approach | Description | Why Rejected |
+|----------|-------------|--------------|
+| **Version-Diff (every push)** | Runs on every push to main, compares version vs latest tag | Wastes CI minutes on non-version commits |
+| **python-semantic-release** | Automated version bumps from conventional commits | Overkill; requires team-wide conventional commit adoption; removes manual version control |
+
+### Decision Rationale
+Path-filtered approach is simple, efficient (runs only when pyproject.toml changes), self-contained
+(~50 lines YAML), and preserves manual control over when versions are bumped. It matches the team's
+preference for explicit, readable, reliable versioning.
+
+---
+
+## 3. Core Feature Components
+
+### Component A: GitHub Actions Release Workflow
+
+- **Purpose**: New CI workflow (`.github/workflows/release.yml`) that automates git tag creation and
+  GitHub Release publishing when the version in `pyproject.toml` changes on `main`
+- **Key Features**:
+  - Triggers on push to `main` with path filter on `pyproject.toml`
+  - Extracts version from `pyproject.toml` using grep/sed
+  - Checks if tag `{version}` already exists (idempotent — skips if tag present)
+  - Validates CHANGELOG.md contains a `## {version}` heading (CHANGELOG gate)
+  - Creates annotated git tag `{version}`
+  - Creates GitHub Release with CHANGELOG excerpt between current and previous version headings
+  - Uses `GITHUB_TOKEN` for authentication (no additional secrets required)
+
+### Component B: CHANGELOG.md
+
+- **Purpose**: New file tracking notable changes per version in Keep a Changelog format
+- **Key Features**:
+  - Initial entry for `1.1.0` documenting the current feature set
+  - Structured sections: Added, Changed, Fixed (as applicable per version)
+  - `## {version}` heading format matched by the release workflow CHANGELOG gate
+  - Included in MANIFEST.in for distribution
+
+### Component C: Documentation Updates
+
+- **Purpose**: Update README.md and CLAUDE.md installation instructions to include version-pinned examples
+- **Key Features**:
+  - Add version-pinned install examples alongside existing unpinned URLs
+  - Preserve existing unpinned URLs for users who want latest
+  - Cover all 4 installation methods in README.md and 2 in CLAUDE.md
+
+---
+
+## 4. API Endpoints and Integration
+
+*Omitted — no API changes involved.*
+
+---
+
+## 5. Example Customer Flow
+
+*Omitted — backend/infrastructure change with no user-facing workflow.*
+
+---
+
+## 6. Non-Functional Requirements
+
+### Technical Constraints
+
+- **Backward Compatibility**: Existing unpinned git URLs continue to work (point to latest main). Version
+  pinning is additive — consumers opt in by appending `@vX.Y.Z` to their dependency URL.
+- **GitHub Actions Permissions**: The workflow needs `contents: write` permission to create tags and releases
+  using `GITHUB_TOKEN`.
+- **CHANGELOG Format**: Must use `## vX.Y.Z` heading format consistently so the workflow can parse and
+  extract release notes programmatically.
+
+---
+
+## 7. Definition of Done
+
+- [ ] `.github/workflows/release.yml` exists and is syntactically valid
+- [ ] Workflow triggers only on pushes to `main` that modify `pyproject.toml`
+- [ ] Workflow extracts version from `pyproject.toml` correctly
+- [ ] Workflow skips gracefully if tag `{version}` already exists
+- [ ] Workflow fails with clear error if CHANGELOG.md lacks `## {version}` entry
+- [ ] Workflow creates annotated git tag `{version}` on success
+- [ ] Workflow creates GitHub Release with CHANGELOG excerpt as body
+- [ ] `CHANGELOG.md` exists with `## 1.1.0` entry
+- [ ] `MANIFEST.in` includes `CHANGELOG.md`
+- [ ] `README.md` shows version-pinned installation examples for all 4 methods
+- [ ] `CLAUDE.md` shows version-pinned installation examples for both references
+- [ ] Consumers can install via `pip install git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+- [ ] Initial `1.1.0` tag is created manually on `main` after PR merges
+
+---
+
+## 8. Testing Strategy
+
+### Manual Verification
+
+Since this feature is CI infrastructure + documentation, testing is primarily manual:
+
+- **Workflow syntax**: Validate YAML with `actionlint` or GitHub's built-in workflow validator
+- **Version extraction**: Test the grep/sed command locally against pyproject.toml
+- **CHANGELOG parsing**: Test the sed/awk command that extracts release notes between version headings
+- **Tag creation**: After merging, manually create `1.1.0` tag and verify GitHub Release
+- **Consumer install**: Run `pip install git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+  from a clean environment to verify version pinning works
+
+### Workflow Dry-Run
+
+- Push a test branch with a modified pyproject.toml version to verify the workflow triggers
+  (will not create tags since it only runs on `main`)
+- Review workflow run logs for correct version extraction and CHANGELOG validation
+
+### Coverage Gaps
+
+- Full end-to-end workflow test requires merging to `main` — cannot be fully tested pre-merge
+- GitHub Release body formatting can only be verified after first real release
+
+---
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: CHANGELOG.md | ⏳ Pending | - | - | |
+| Phase 2: Release Workflow | ⏳ Pending | - | - | |
+| Phase 3: Documentation Updates | ⏳ Pending | - | - | |
+| Phase 4: MANIFEST.in Update | ⏳ Pending | - | - | |
+| Phase 5: Manual Tag Creation | ⏳ Pending | - | - | Post-merge |
+
+### Phase 1: CHANGELOG.md
+
+**Semantic Change**: Create initial changelog with 1.1.0 entry
+
+**Deliverables**: `CHANGELOG.md` at repository root with first version entry
+
+**Implementation Details**:
+- Create `CHANGELOG.md` following Keep a Changelog conventions
+- Include a top-level title and a brief description of the changelog purpose
+- Add `## 1.1.0` heading with the current date (YYYY-MM-DD)
+- Under 1.1.0, summarize the current state of the project as the baseline release:
+  - Multi-server MCP architecture (Config, Data, Utilities, Playbook, Studio servers)
+  - External connection support with Bearer token authentication
+  - Playbook attack filtering (MITRE ATT&CK, platform)
+  - Drift analysis tools (test-run-centric and time-window-based)
+  - Scenario execution and management tools
+  - Per-user RBAC enforcement
+  - Peer benchmark scoring
+  - Caching with bounded TTL and monitoring
+- Use "Added" section since this is the initial release entry
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `CHANGELOG.md` | Create | Initial changelog with 1.1.0 entry |
+
+**Git Commit**: `docs: add CHANGELOG.md with initial 1.1.0 entry`
+
+---
+
+### Phase 2: Release Workflow
+
+**Semantic Change**: Add GitHub Actions workflow for automated tagging and releases
+
+**Deliverables**: `.github/workflows/release.yml` — path-filtered workflow
+
+**Implementation Details**:
+- Create workflow file triggered on push to `main` with path filter `pyproject.toml`
+- Job runs on `ubuntu-latest` with `contents: write` permission
+- Step 1: Checkout repository with `actions/checkout@v4`
+- Step 2: Extract version — read version field from `pyproject.toml` using grep to match the line
+  `version = "X.Y.Z"` and extract only the version string. Store as a step output.
+- Step 3: Check existing tag — use `git tag -l "v{version}"` to see if the tag already exists.
+  If it does, set an output flag and skip remaining steps.
+- Step 4: CHANGELOG gate — search `CHANGELOG.md` for a line matching `## {version}`. If not found,
+  fail the workflow with a clear error message stating that a CHANGELOG entry is required.
+- Step 5: Extract release notes — use sed/awk to extract the content between the `## {version}` heading
+  and the next `## v` heading (or end of file). This becomes the GitHub Release body.
+- Step 6: Create tag — use `git tag -a "v{version}" -m "Release v{version}"` followed by `git push origin "v{version}"`.
+- Step 7: Create GitHub Release — use `gh release create "v{version}" --title "v{version}" --notes "{extracted notes}"`.
+  The `gh` CLI is pre-installed on GitHub Actions runners and authenticates via `GITHUB_TOKEN`.
+- Each step after the tag-exists check should use a conditional (`if` clause) to skip when tag already exists.
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.github/workflows/release.yml` | Create | Auto-tag and release workflow |
+
+**Git Commit**: `ci: add release workflow for automated git tagging and GitHub Releases`
+
+---
+
+### Phase 3: Documentation Updates
+
+**Semantic Change**: Add version-pinned installation examples to README.md and CLAUDE.md
+
+**Deliverables**: Updated installation sections in both files with `@vX.Y.Z` examples
+
+**Implementation Details**:
+- **README.md** — For each of the 4 installation methods (lines 312, 329, 335, 339), add a version-pinned
+  variant directly below the existing unpinned command. Format: show the unpinned URL first (labeled as
+  "latest"), then the pinned URL with `@1.1.0` (labeled as "specific version"). Do not remove the
+  unpinned URLs.
+  - Option 1 SSH: add `git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+  - Option 2 HTTPS: add `git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+  - Option 3 pip: add `git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+  - Option 4 uv run: add `git+ssh://git@github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+- **CLAUDE.md** — Same pattern for the 2 git URLs (lines 86, 589). Add pinned variants below each.
+- Add a brief note explaining the `@vX.Y.Z` syntax and where to find available versions
+  (link to GitHub releases page or `git tag -l` command)
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `README.md` | Modify | Add version-pinned install examples (4 locations) |
+| `CLAUDE.md` | Modify | Add version-pinned install examples (2 locations) |
+
+**Git Commit**: `docs: add version-pinned installation examples to README and CLAUDE.md`
+
+---
+
+### Phase 4: MANIFEST.in Update
+
+**Semantic Change**: Include CHANGELOG.md in package distribution
+
+**Deliverables**: Updated MANIFEST.in with CHANGELOG.md entry
+
+**Implementation Details**:
+- Add `include CHANGELOG.md` line to `MANIFEST.in` alongside existing includes (README.md, CLAUDE.md, etc.)
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `MANIFEST.in` | Modify | Add `include CHANGELOG.md` |
+
+**Git Commit**: `chore: include CHANGELOG.md in MANIFEST.in`
+
+---
+
+### Phase 5: Manual Tag Creation (Post-Merge)
+
+**Semantic Change**: Create initial 1.1.0 tag on main after PR is merged
+
+**Deliverables**: Git tag `1.1.0` on the merge commit + GitHub Release
+
+**Implementation Details**:
+- After the PR merges to main, checkout main and pull latest
+- Create annotated tag: `git tag -a 1.1.0 -m "Release 1.1.0"`
+- Push tag: `git push origin 1.1.0`
+- Create GitHub Release manually or via `gh release create 1.1.0 --title "1.1.0" --notes-file -`
+  piping the CHANGELOG 1.1.0 section as release notes
+- Verify consumers can install: `pip install git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0`
+
+**Changes**: None (git operations only, no file changes)
+
+**Git Commit**: N/A (tag, not a commit)
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Version extraction regex breaks on pyproject.toml format change | Medium | Use simple, well-documented grep pattern; test in workflow |
+| CHANGELOG parsing fails on edge-case formatting | Low | Document exact heading format required (`## vX.Y.Z`) |
+| `GITHUB_TOKEN` permissions insufficient for tag/release creation | Medium | Explicitly set `permissions: contents: write` in workflow |
+| Workflow runs but tag push fails due to branch protection | Medium | Verify branch protection allows tag creation via GitHub Actions |
+
+### Assumptions
+
+- `GITHUB_TOKEN` has sufficient permissions to create tags and releases on this repository
+- The repository's branch protection rules do not block tag creation from GitHub Actions
+- The `gh` CLI is available on `ubuntu-latest` runners (currently pre-installed)
+- Consumers already know how to use `@tag` syntax with `pip install git+...` (standard pip feature)
+
+---
+
+## 11. Future Enhancements
+
+- **PyPI publishing**: Publish safebreach-mcp to a private PyPI registry so consumers can use
+  `pip install safebreach-mcp==1.1.0` without git URLs
+- **Automated version bump PR**: GitHub Action that creates a PR to bump the version when triggered manually
+- **Version compatibility matrix**: Document which safebreach-mcp versions are compatible with which
+  consumer versions
+- **Pre-release tags**: Support `1.2.0rc1` tags for release candidates (PEP 440 format)
+
+---
+
+## 12. Executive Summary
+
+- **Issue/Feature Description**: safebreach-mcp lacks git tags and a release workflow, forcing consumers to
+  depend on the unpinned latest `main` branch
+- **What Will Be Built**: A GitHub Actions release workflow that auto-creates git tags and GitHub Releases
+  when the version in pyproject.toml changes, plus a CHANGELOG and updated installation docs
+- **Key Technical Decisions**: Path-filtered workflow (only runs when pyproject.toml changes); CHANGELOG gate
+  enforces documentation; `X.Y.Z` tag format with pyproject.toml as single source of truth
+- **Scope**: safebreach-mcp repository only; consumer-side pinning is out of scope
+- **Business Value Delivered**: Deterministic builds, rollback capability, and structured release
+  communication for all consumers of safebreach-mcp
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-05-07 15:00 | PRD created — initial draft |
+| 2026-05-07 15:15 | Removed internal component references (mcp-proxy) to keep PRD public-safe |
+| 2026-05-07 15:20 | Changed tag format from `vX.Y.Z` to `X.Y.Z` (no prefix) for PEP 440 alignment |

--- a/prds/SAF-30718-Introduce-versioning/summary.md
+++ b/prds/SAF-30718-Introduce-versioning/summary.md
@@ -1,0 +1,154 @@
+# Ticket Summary: SAF-30718
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: safebreach-mcp, mcp-proxy
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] Create a versioning mechanism allowing consumers of the codebase to
+explicitly sync to a particular version
+**Issues Identified**: Ticket describes the problem well but lacks acceptance criteria, technical
+details about current state, and specific implementation requirements.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- Version `1.1.0` exists in `pyproject.toml` but no git tags — consumers cannot pin
+- No CHANGELOG, no release CI/CD workflow, no tag automation
+- Multi-package architecture (6 servers) sharing single version
+- Uses setuptools build backend with auto-discovery
+- README documents installation via unpinned git URLs only
+- Relevant files: `pyproject.toml`, `.github/workflows/security-scan.yml`, `README.md`
+
+### mcp-proxy
+- `requirements.txt` line 5: completely unpinned `git+https://...safebreach-mcp.git`
+- All other PyPI deps pinned to exact versions — safebreach-mcp is the outlier
+- Dynamic imports via `__import__()` — low breaking risk from version changes
+- Already tracks safebreach-mcp git commit hash at runtime (`src/simp/version_info.py`)
+- Three Dockerfiles (dev/prod/integ) all install unpinned
+- Relevant files: `requirements.txt`, `src/simp/version_info.py`, `src/simp/mcp_manager.py`
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The safebreach-mcp repository has a static version string (`1.1.0`) in `pyproject.toml` but no
+mechanism to expose it as a pinnable reference for downstream consumers. Without git tags, consumers
+like mcp-proxy are forced to pull the latest `main` branch, resulting in non-deterministic builds.
+Any commit to main can silently break downstream builds or introduce behavioral changes without notice.
+This is especially problematic because all other dependencies in mcp-proxy's requirements.txt are
+pinned to exact versions.
+
+### Impact Assessment
+- **Build reproducibility**: Same requirements.txt produces different installs depending on when
+  `pip install` runs — breaks deterministic CI/CD
+- **Debugging difficulty**: When issues arise, there's no easy way to identify which safebreach-mcp
+  version is deployed (only runtime commit hash logging)
+- **Rollback friction**: Cannot easily revert to a known-good version of safebreach-mcp
+- **Test flakiness**: mcp-proxy integration tests can fail due to unrelated safebreach-mcp main changes
+
+### Risks & Edge Cases
+- **Multi-package consistency**: All 6 servers share one version — version bump must cover the whole repo
+- **Consumer migration**: Existing consumers must update dependency specs when upgrading
+- **Tag format convention**: Must choose and document (e.g., `v1.1.0` vs `1.1.0`)
+- **Stale build artifacts**: `safebreach_mcp_server.egg-info/` caches old version metadata
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Introduce git tag versioning for deterministic consumer dependency pinning
+
+### Description
+
+**Background**
+
+Consumers of safebreach-mcp (e.g., mcp-proxy) install the package via git URLs without version
+pinning. While `pyproject.toml` declares version `1.1.0`, no git tags exist, so consumers cannot
+reference a specific release. This causes non-deterministic builds and sync issues.
+
+**Technical Context**
+
+* `pyproject.toml` version field is already set to `1.1.0` (single source of truth)
+* No git tags have ever been created on the repository
+* No CHANGELOG or release workflow exists
+* mcp-proxy's `requirements.txt` uses unpinned `git+https://...safebreach-mcp.git`
+* All other mcp-proxy PyPI dependencies are pinned to exact versions
+* mcp-proxy already has runtime commit hash tracking via `version_info.py`
+
+**Problem Description**
+
+* Builds are non-deterministic: same `requirements.txt` produces different installs over time
+* No rollback mechanism to a known-good safebreach-mcp version
+* Integration tests can flake due to unrelated main branch changes
+* No structured way to communicate breaking changes to consumers
+
+**Affected Areas**
+
+* safebreach-mcp: `pyproject.toml`, git tags, CI workflows, `README.md`, new `CHANGELOG.md`
+* mcp-proxy: `requirements.txt` (version pinning after tags are available)
+
+### Acceptance Criteria
+
+- [ ] Git tags following `vX.Y.Z` format (semver) are created for the current version (`v1.1.0`)
+- [ ] `pyproject.toml` version remains the single source of truth
+- [ ] CHANGELOG.md is created with at least the current version entry
+- [ ] README.md installation instructions updated with version-pinned examples
+      (e.g., `git+https://github.com/SafeBreach/safebreach-mcp.git@v1.1.0`)
+- [ ] GitHub Actions workflow added to automate tag creation when version in pyproject.toml changes
+      on main
+- [ ] Consumers can install a specific version via `pip install git+...@v1.1.0`
+- [ ] `.egg-info/` directory is added to `.gitignore` if not already
+
+### Suggested Labels/Components
+- Component: infrastructure
+- Labels: versioning, developer-experience
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+Consumers of safebreach-mcp (e.g., mcp-proxy) install the package via git URLs without version
+pinning. While pyproject.toml declares version 1.1.0, no git tags exist, so consumers cannot
+reference a specific release. This causes non-deterministic builds and sync issues.
+
+### Technical Context
+* pyproject.toml version field is already set to 1.1.0 (single source of truth)
+* No git tags have ever been created on the repository
+* No CHANGELOG or release workflow exists
+* mcp-proxy requirements.txt uses unpinned git+https://...safebreach-mcp.git
+* All other mcp-proxy PyPI dependencies are pinned to exact versions
+
+### Problem Description
+* Builds are non-deterministic: same requirements.txt produces different installs over time
+* No rollback mechanism to a known-good safebreach-mcp version
+* Integration tests can flake due to unrelated main branch changes
+* No structured way to communicate breaking changes to consumers
+
+### Affected Areas
+* safebreach-mcp: pyproject.toml, git tags, CI workflows, README.md, new CHANGELOG.md
+* mcp-proxy: requirements.txt (version pinning after tags are available)
+```
+
+**Acceptance Criteria:**
+```markdown
+* Git tags following vX.Y.Z format (semver) created for current version (v1.1.0)
+* pyproject.toml version remains the single source of truth
+* CHANGELOG.md created with at least the current version entry
+* README.md installation instructions updated with version-pinned examples
+* GitHub Actions workflow added to automate tag creation on version change in main
+* Consumers can install specific version via pip install git+...@v1.1.0
+* .egg-info/ directory added to .gitignore if not already
+```


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with initial 1.1.0 entry documenting current feature set
- Add `.github/workflows/release.yml` — auto-creates git tags and GitHub Releases when version changes in `pyproject.toml` on `main`
- Add version-pinned installation examples (`@1.1.0`) to README.md and CLAUDE.md
- Include `CHANGELOG.md` in `MANIFEST.in` for package distribution

## Details
Consumers of safebreach-mcp currently install via unpinned git URLs, pulling latest `main` on every install. This PR introduces a versioning mechanism so consumers can pin to specific releases (e.g., `git+ssh://...@1.1.0`).

**Release workflow**: Triggers only when `pyproject.toml` changes on `main`. Extracts version, validates a matching CHANGELOG entry exists (CHANGELOG gate), then creates an annotated git tag and GitHub Release with release notes.

**Tag format**: `X.Y.Z` (no `v` prefix) — matches `pyproject.toml` version directly, PEP 440 aligned.

**Post-merge**: Manually create initial `1.1.0` tag on main (`git tag -a 1.1.0 -m "Release 1.1.0" && git push origin 1.1.0`).

## Test plan
- [ ] Verify `release.yml` YAML is valid (actionlint or GitHub workflow validator)
- [ ] Verify version extraction grep works: `grep -Po '^version\s*=\s*"\K[^"]+' pyproject.toml`
- [ ] After merge: create `1.1.0` tag manually and verify GitHub Release is created
- [ ] Verify consumer install: `pip install git+https://github.com/SafeBreach/safebreach-mcp.git@1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SAF-30718](https://safebreach.atlassian.net/browse/SAF-30718)