### PR TITLE
feat: per-caller rate limiting for MCP write operations (SAF-29871)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,43 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 
 **Data Pagination**: All listing operations use `PAGE_SIZE = 10` with proper pagination handling for large datasets.
 
+**Rate Limiting** (`safebreach_mcp_core/rate_limiter.py`): Per-caller sliding-window rate limiting
+for all write (non-readOnly) tools. Uses a two-phase gate pattern:
+
+- `check_limit(caller_id, tool_name)` — pre-check before the mutating API call. Raises `ToolError`
+  with informative message (which limit, count/max, retry-after seconds) if exceeded. Does NOT
+  increment counters.
+- `record_action(caller_id, tool_name)` — post-success increment after the API call succeeds.
+  Only called on successful, non-dry-run execution paths.
+
+Gate placement rules:
+1. `check_limit` goes after parameter validation but before the mutating API call
+2. `record_action` goes after the API call succeeds and response is processed
+3. Dry-run and diagnostic branches must NOT trigger either gate
+4. API failures must NOT call `record_action` (let the exception propagate)
+5. Read-only pre-checks (e.g., `set_studio_attack_status` fetching current status) are allowed
+   before `check_limit` — don't count reads against the limit
+
+Caller identity (`get_caller_identity()`): auth token SHA256[:16] for external connections
+(survives reconnection), session ID fallback for localhost, `'anonymous'` if neither available.
+
+**Any new tool with `readOnlyHint=False` MUST add rate limiting gates following this pattern.**
+
+| Tool | `check_limit` placement | `record_action` placement | Special handling |
+|------|------------------------|--------------------------|------------------|
+| `save_studio_attack_draft` | After param validation | After POST + cache write | — |
+| `update_studio_attack_draft` | After param validation | After PUT + cache update | — |
+| `run_studio_attack` | After input validation | After POST queue response | — |
+| `set_studio_attack_status` | After pre-check GET | After PUT + cache invalidate | Allow read first |
+| `run_scenario` | Before queue POST | After POST queue response | Skip on dry_run/not_ready |
+| `manage_test` | After input validation | After state change | Note append is best-effort |
+
+Rate limiting environment variables:
+- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` — enable/disable (default: `true`)
+- `SAFEBREACH_MCP_ACTION_LIMIT` — total actions per caller per window (default: `10`)
+- `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` — per-tool-name limit per caller per window (default: `5`)
+- `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` — sliding window duration in minutes (default: `30`)
+
 ## MCP Tools Available
 
 ### Multi-Server Distribution
@@ -334,8 +371,8 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 18. `convert_datetime_to_epoch` - Convert ISO datetime strings to Unix epoch timestamps for API filtering
 19. `convert_epoch_to_datetime` - Convert Unix epoch timestamps to readable datetime strings
 
-**Studio Server (Port 8004):**
-20. `run_scenario` ✨ **NEW** - Execute a SafeBreach scenario (OOB or custom plan).
+**Studio Server (Port 8004):** *(all write tools are rate-limited — see Rate Limiting above)*
+20. `run_scenario` ✨ **NEW** 🔒 **Rate-limited** - Execute a SafeBreach scenario (OOB or custom plan).
   Supports both ready-to-run and non-ready scenarios via three-turn augmentation workflow.
   Fetches scenarios from content-manager API and custom plans from config API. Validates readiness,
   runs statistics pre-flight with per-step simulation predictions and constraint diagnostics,
@@ -362,7 +399,7 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
   and isProxySupported for informed filter planning.
   **Error handling**: Statistics API, scenario fetch, and plan fetch errors now propagate the
   full API response body in error messages (not just generic HTTP status codes).
-21. `manage_test` ✨ **NEW** - Manage a running test's lifecycle (pause, resume, cancel).
+21. `manage_test` ✨ **NEW** 🔒 **Rate-limited** - Manage a running test's lifecycle (pause, resume, cancel).
   Single tool with `action` parameter for all three operations. Accepts `test_id` (planRunId
   from `run_scenario`), `action` (required: "pause", "resume", or "cancel"), `console`,
   and optional `reason`. When `reason` is provided, appends a timestamped UTC note to the
@@ -490,6 +527,12 @@ export SAFEBREACH_MCP_CONCURRENCY_LIMIT=3
 # Transport mode (default: sse)
 export SAFEBREACH_MCP_TRANSPORT=sse            # Server-Sent Events (default) — endpoints: /sse + /messages/
 export SAFEBREACH_MCP_TRANSPORT=streamable-http # Streamable HTTP — single endpoint: /mcp (or $SAFEBREACH_MCP_BASE_URL)
+
+# Rate limiting (applies to all write tools)
+export SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true              # Enable/disable (default: true)
+export SAFEBREACH_MCP_ACTION_LIMIT=10                      # Total actions per caller per window (default: 10)
+export SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT=5             # Per-tool limit per caller per window (default: 5)
+export SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=30         # Sliding window in minutes (default: 30)
 ```
 
 **Command-Line Arguments:**

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ and sets the ContextVar so get_auth_headers_for_console() works.
 import os
 import pytest
 from safebreach_mcp_core.token_context import _user_auth_artifacts
+from safebreach_mcp_core.rate_limiter import _rate_limit_store
 
 
 def _resolve_api_token(console: str):
@@ -60,3 +61,11 @@ def e2e_auth_for_console():
             _user_auth_artifacts.reset(old)
 
     return _swap
+
+
+@pytest.fixture(autouse=True)
+def clear_rate_limit_store():
+    """Clear rate limit state between tests to prevent cross-test accumulation."""
+    _rate_limit_store.clear()
+    yield
+    _rate_limit_store.clear()

--- a/prds/SAF-29871-actions-rate-limit/context.md
+++ b/prds/SAF-29871-actions-rate-limit/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-29871
 
 ## Status
-Phase 6: Summary Created
+Phase 6: PRD Created
 
 ## Mode
 Improving
@@ -100,5 +100,80 @@ could repeatedly call write operations (run tests, manage tests, publish attacks
 - Cross-server shared state requires thread-safe access (all servers in same process)
 - Sliding window cleanup must handle disconnected sessions
 
-## Proposed Improvements
-(Phase 6)
+### Deep Investigation: Infrastructure Patterns
+
+**Concurrency Limiter (`safebreach_base.py:570-772`)**:
+- ASGI middleware closure wrapping original app
+- Installed in `run_server()` at line 253 as outermost middleware
+- SSE: session UUID on `/sse` GET, migrated to real_session_id via regex
+- Streamable-HTTP: `Mcp-Session-Id` header
+- `_session_semaphores: Dict[str, tuple[Semaphore, float]]` — module-level, shared across servers
+- Cleanup: every 600s, TTL=3600s (`_SEMAPHORE_MAX_AGE`)
+- HTTP 429: JSON body with error/message/retry_after, plus `retry-after: 5` header
+
+**Caller Identity (`token_context.py:160-187`)**:
+- `get_cache_user_suffix()` returns `'_' + SHA256(token)[:8]` or empty string
+- Priority: x-apitoken > x-token > cookie value
+- Sources: `_user_auth_artifacts` ContextVar → `_get_auth_from_mcp_request_ctx()` fallback
+- Session ID from `_get_session_id_from_mcp_ctx()`: query_params (SSE) or mcp-session-id header
+
+**Tool Manager Wrapping (`safebreach_base.py:143-175`)**:
+- `_install_disable_filtering()` monkey-patches `tool_manager.call_tool` and `list_tools`
+- Pattern: wrap `original_call_tool` with custom logic, raise `ToolError` to reject
+- Signature: `call_tool(name, arguments, context=None, convert_result=False)`
+
+**Middleware Installation Order** (innermost to outermost):
+1. MCP app (sse_app/streamable_http_app)
+2. Base URL mount
+3. External auth wrapper
+4. Disable-filtering wrapper
+5. Concurrency limiter (outermost)
+
+**Background Tasks** (started in `run_server()`):
+- `_cleanup_stale_semaphores()` — every 10 min
+- `start_cache_monitoring()` — every 5 min (singleton, only one per process)
+
+### Deep Investigation: Write Tool Gate Placement
+
+**CORRECTION: `create_new_studio_attack` is READ-ONLY** (returns static boilerplate templates,
+no API calls). Only **6 tools** need rate limiting gates.
+
+| Tool | Pre-check point | check_limit placement | record_action placement | Dry-run? |
+|------|-----------------|----------------------|------------------------|----------|
+| `save_studio_attack_draft` | None | After param validation (~L632) | After POST response + cache (~L701) | No |
+| `update_studio_attack_draft` | None | After param validation (~L885) | After PUT response + cache (~L954) | No |
+| `run_studio_attack` | None | After validation (~L1089) | After POST queue response (~L1191) | No |
+| `set_studio_attack_status` | Pre-check GET (~L1480) | After status confirmed (~L1508) | After PUT + cache invalidate (~L1617) | No |
+| `run_scenario` | Readiness + dry_run early returns | After all early returns, before POST (~L2483) | After POST queue response (~L2517) | Yes |
+| `manage_test` | None | After validation (~L2648) | After state change + note (~L2656) | No |
+
+**Gate placement rules:**
+1. `check_limit` goes after all validation/reads, before the first mutating API call
+2. `record_action` goes after confirming the API call succeeded (response parsed)
+3. For `run_scenario`: skip both gates on diagnostic (not_ready) and dry_run branches
+4. For `set_studio_attack_status`: allow pre-check GET before check_limit
+5. For `manage_test`: record after state change (note append is best-effort)
+
+## Brainstorm Results (Phase 5)
+
+### Chosen Approach: Explicit Two-Phase with Shared Helper (Approach B)
+
+**Design decisions:**
+- New `safebreach_mcp_core/rate_limiter.py` with singleton `RateLimiter` class
+- `get_caller_identity()` helper encapsulates hybrid logic (auth token hash / session fallback)
+- Each write tool explicitly calls `check_limit()` and `record_action()` at appropriate points
+- `check_limit` raises `ToolError` (MCP-level, not HTTP 429)
+- Sliding window: list of timestamps per (caller, tool_name), pruned on check/record
+
+**Configuration (env vars, all have defaults):**
+- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` — default: true
+- `SAFEBREACH_MCP_ACTION_LIMIT` — default: 10
+- `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` — default: 5
+- `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` — default: 30
+
+**Rejected alternatives:**
+- Approach A (fully explicit): too much boilerplate, caller ID extraction repeated per tool
+- Approach C (decorator): fights per-tool gate placement, hides timing, complex for dry-run
+
+**Error type:** ToolError (MCP-level) — agent sees it as a tool failure with meaningful message
+**Enable/disable:** Env var, default enabled

--- a/prds/SAF-29871-actions-rate-limit/context.md
+++ b/prds/SAF-29871-actions-rate-limit/context.md
@@ -1,0 +1,104 @@
+# Ticket Context: SAF-29871
+
+## Status
+Phase 6: Summary Created
+
+## Mode
+Improving
+
+## Original Ticket
+- **Summary**: MCP: Limit the rate of repeated actions
+- **Description**: Implement rate limiting as a safety guardrail. Two mechanisms: (1) Total action cap - max 10 actions per MCP client in a 30-min sliding window. (2) Identical action rate limit - max 5 identical actions of the same type per client in the same window. Clear error messages when limits are reached.
+- **Acceptance Criteria**: Not yet defined in ticket
+- **Status**: To Do
+
+## Task Scope
+Investigate implementing rate limiting for MCP server actions to prevent misuse through repetitive requests.
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+
+## Investigation Findings
+
+### Existing Infrastructure (safebreach_mcp_core/)
+
+**Concurrency Limiter** (`safebreach_base.py:570-772`):
+- Per-session `asyncio.Semaphore` limits concurrent requests (default: 2)
+- Session ID: UUID generated on `/sse` endpoint, or `Mcp-Session-Id` header for streamable-http
+- Module-level `_session_semaphores: Dict[str, tuple[Semaphore, float]]`
+- Cleanup task runs every 10 min, evicts stale entries after 1 hour
+- Returns HTTP 429 with `retry-after` header when limit exceeded
+- **This is the exact pattern to reuse for rate limiting**
+
+**Session Tracking** (`safebreach_base.py:586-684`):
+- `_mcp_session_id` ContextVar propagates session across async stack
+- SSE: UUID on `/sse` GET, real_session_id from FastMCP response body
+- Streamable-HTTP: `Mcp-Session-Id` header
+- Fallback: query string `?session_id=...` for POST `/messages/`
+
+**Auth/RBAC** (`token_context.py`):
+- Per-request auth artifacts stored by session_id with TTL cleanup
+- `get_cache_user_suffix()` returns SHA256 of auth token for user-scoped caching
+- Rate limiting can use session_id as client identity (aligns with ticket scope)
+
+**Caching** (`safebreach_cache.py:22-177`):
+- `SafeBreachCache` wraps `cachetools.TTLCache`, thread-safe with Lock
+- No sliding-window capability - new implementation needed for rate limiting
+
+### Tool Classification by Annotations
+
+All servers use `ToolAnnotations(readOnlyHint, destructiveHint)`:
+
+| Server | Tool | readOnlyHint | destructiveHint | Classification |
+|--------|------|---|---|---|
+| Config | get_console_simulators, get_simulator_details, get_scenarios, get_scenario_details | True | - | Read-only |
+| Data | All 15 tools | True | - | Read-only |
+| Utilities | convert_datetime_to_epoch, convert_epoch_to_datetime | True | - | Read-only |
+| Playbook | get_playbook_attacks, get_playbook_attack_details | True | - | Read-only |
+| Studio | validate_studio_code, get_all_studio_attacks, get_studio_attack_source, etc. | True | - | Read-only |
+| Studio | save_studio_attack_draft, update_studio_attack_draft, create_new_studio_attack | False | False | Mutating |
+| Studio | run_studio_attack, run_scenario, manage_test, set_studio_attack_status | False | True | **Action** |
+
+**Key insight**: Only Studio server has mutating/destructive tools. All other servers are read-only.
+
+### Transport & Middleware Stack
+
+Request flow: HTTP request -> Auth middleware -> Concurrency limiter -> MCP SDK -> Tool handler
+
+Both SSE and streamable-http transports converge at `_create_concurrency_limited_app()`.
+Rate limiting should count tool invocations (not HTTP requests).
+
+### Tool Registration Pattern
+
+Tools registered via `@self.mcp.tool(name=..., annotations=ToolAnnotations(...))` decorator.
+Tool metadata accessible via `self.mcp._tool_manager.list_tools()` which returns tool definitions
+including annotations.
+
+## Problem Analysis
+
+### Problem Description
+The MCP servers have no rate limiting on tool invocations. A malicious or misconfigured client
+could repeatedly call write operations (run tests, manage tests, publish attacks) without restriction.
+
+### Scope Clarifications (from stakeholder)
+- **"Action" definition**: Any MCP tool where `readOnlyHint != True` (i.e., all non-read-only tools)
+- **Two independent counters per session**:
+  1. **Total actions**: Count of all non-readOnly tool calls within the sliding window (default limit: 10)
+  2. **Per-action-name**: Count of each specific tool name within the sliding window (default limit: 5)
+- **Sliding window**: Default 30 minutes, configurable
+- **Cross-server**: Shared state across all servers (same process, module-level dict)
+- **All servers**: Rate limiter installed on every server, even if currently read-only (future-proofing)
+
+### Affected Areas
+- `safebreach_mcp_core/safebreach_base.py` - Middleware injection point
+- `safebreach_mcp_core/` - New rate_limiter module
+- All 5 server modules - Rate limiter installed in each
+
+### Risks & Edge Cases
+- ASGI middleware may not have tool name visibility - may need MCP SDK-level interception
+- Session ID must be consistent across the tool call lifecycle
+- Cross-server shared state requires thread-safe access (all servers in same process)
+- Sliding window cleanup must handle disconnected sessions
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/SAF-29871-actions-rate-limit/manual-tests-report.md
+++ b/prds/SAF-29871-actions-rate-limit/manual-tests-report.md
@@ -1,0 +1,199 @@
+Good — that tightens the model considerably. Updated picture:
+
+## Revised rules
+
+**Scope of rate limiter:** exactly these 6 mutating tools
+- `save_studio_attack_draft`
+- `update_studio_attack_draft`
+- `run_studio_attack`
+- `set_studio_attack_status` ✅ tested
+- `run_scenario`
+- `manage_test` ✅ tested
+
+All other tools (`get_*`, read-only, config, etc.) are **uncounted**. This collapses Phase 3.5 to "answered" and shrinks Phase 3 to 4 untested tools.
+
+**Window:** now 5 min instead of 30 for this test session — retry-after should max at ~300s, and cooldowns between phases shrink from 30 min → 5 min. We can run the whole plan in ~30–45 min.
+
+## Trimmed test plan
+
+| Phase | Tests | Notes |
+|---|---|---|
+| **2 — Accounting** | T2.1 no-op consumes? T2.2 500-error consumes? T2.3 schema-invalid consumes? | All on `set_studio_attack_status` to reuse known fixtures (raz attack, WAF attack). |
+| **3 — Tool coverage** | T3.1 `run_studio_attack`, T3.2 `save_studio_attack_draft`, T3.3 `update_studio_attack_draft`, T3.4 `run_scenario` | Each: do 6 calls, verify 6th hits `<tool> 5/5`. Need cheap/safe inputs — biggest risk is `run_scenario` (real tests). |
+| **4 — Precedence** | T4.1 mixed-tool global trip; T4.2 global-only message; T4.3 per-tool-only message | Constructs specific 9/10 vs 5/5 states. |
+| **5 — Window mechanics** | T5.1 per-entry decay (call evenly across 5 min, verify 1 slot frees at T+5); T5.2 retry-after accuracy | Now feasible in ~7 min instead of 32. |
+| **6 — Concurrency** | T6.1 race for last per-tool slot; T6.2 mixed-tool race for last global slot | Parallel batches with prepared counter state. |
+| **7 — Identity scope** | T7.1 cross-session; T7.2 cross-console | Requires second MCP client / different `console`. |
+
+## Practical sequencing
+
+Counter is currently around **10/10 global**, retry-after was 100s a moment ago — call it **clear in ~60s**.
+
+Suggested order, starting next window:
+
+1. **Phase 2.1** (no-op) — cheapest, 6 calls of `set_studio_attack_status new_status=draft` on attack 10003859 (already draft). Predicts: all 6 succeed and consume no budget → confirms "already in target state" is free.
+2. **Phase 2.2** (500 error) — 6 calls on WAF attack 10002222. Predicts: all 6 fail with 500 and consume no budget.
+3. Verify the counter is still clean after both → fire one real toggle and observe the counter went 0 → 1, not 12 → 13.
+4. **Phase 3 sweep** of `run_studio_attack` / drafts / `run_scenario` — needs decisions on inputs.
+
+Two decisions before I start:
+- **OK to run Phase 2 now** (will consume zero budget if our prediction holds, ≤6 budget if it doesn't)?
+- For **Phase 3**: which target attack should I use for `run_studio_attack` / drafts, and is it OK to launch one real `run_scenario` test (for T3.4)?
+
+Go ahead and test the feature.
+
+I'll run Phases 2, 4, 5, 6 autonomously (Phase 3 needs you to authorize new inputs for attack launches; Phase 7 needs a second client). Loading TodoWrite first.
+
+Waiting 90s for the rate-limit window to fully drain. Will start Phase 2.1 (no-op accounting) when it completes.
+
+Window cleared. Starting Phase 2.1 — 6 no-op calls (attack 10003859 is currently draft; setting to draft = no-op).
+
+All 6 no-ops returned `"Set Status Error: Attack already draft"`. Now probing — 5 real toggles to count remaining budget.
+
+**Phase 2.1 result — clean: no-ops do not consume budget.**
+
+| What happened | Calls | Outcome |
+|---|---|---|
+| 6 no-ops (`already draft`) | 6 | All returned `"Set Status Error: Attack already draft"`, no rate-limit fired |
+| Real toggles (probe) | 5 succeeded → 6th failed | 6th: `"set_studio_attack_status (5/5 in last 5 min)"`, retry 267s |
+
+Key findings already locked in:
+- ✅ No-op calls (already in target state) **do not consume rate-limit budget**
+- ✅ **Window confirmed as 5 min** in the error message verbatim: `"(5/5 in last 5 min)"`
+- ✅ Per-tool 5/5 cap reproduced from a clean window
+
+Attack 10003859 ended at **PUBLISHED** (5 toggles starting from draft). Per-tool set_studio is now 5/5; global is 5/10; manage_test 0/5.
+
+Waiting ~280s for set_studio per-tool window to drain before Phase 2.2.
+
+Background wait started. Will fire Phase 2.2 (6× publish attempts on WAF attack 10002222 → expected 500s) when it completes.
+
+Window clear. Phase 2.2 — 6 publish attempts on WAF attack 10002222 (expected 500s).
+
+All 6 returned 500. Probing now — 5 toggles on attack 10003859 (currently PUBLISHED), then a 6th to test the wall.
+
+The MCP server hiccuped mid-probe but the **first two probe successes already proved the point**: if any of the 6 prior 500-error calls had consumed budget, probe call 1 would have failed with "5/5". It didn't.
+
+✅ **Phase 2.2 conclusion: 500/upstream-error calls do NOT consume rate-limit budget.**
+
+Now let me check whether the server is back and recover state.
+
+Server back. Attack is PUBLISHED. Toggling back to DRAFT.
+
+Cleanup done — attack back to DRAFT. Counter is ~3/5 set_studio per-tool. Starting 5-min cooldown before Phase 5 (sliding window decay test).
+
+Waiting 310s. Phase 5 plan once it completes:
+
+1. Fire 5 toggles rapidly at T+0 → per-tool at 5/5
+2. Wait 60s, fire 1 → expect fail with `retry ≈ 240s` (confirms 60s decay)
+3. Wait 250s → total ~310s from T+0 → call 1 should have just aged out
+4. Fire 1 → expect success (1 slot freed)
+5. Fire 1 immediately after → expect fail (4 original + 1 new = 5/5)
+
+Phase 5 step 1: capturing T0 and firing 5 rapid toggles.
+
+T0 = 17:10:32 UTC. All 5 toggles succeeded — per-tool at 5/5. Sleeping 60s then probing for retry-after.
+
+At T0+102s, retry-after = 202s. **Confirms 5-min (300s) window:** expected 300−102 = 198s, actual 202s — 4s offset matches the burst's serialization latency.
+
+Now waiting ~210s until oldest entry expires, then dual-probe.
+
+T2 = 17:16:06 (T0+334s). First toggle succeeded — confirms 1 slot freed. Now immediate follow-up to confirm cap re-engaged.
+
+Both succeeded — unexpected. Probing again to find the actual cap point.
+
+The 5 burst entries all expired together (clustered within 1-2s of each other → expire within 1-2s of each other). At T4 I've fired 4 fresh calls since the window cleared (T2, T2+1s, T3, T4) — so counter should be 4/5. Firing one more → expect last slot used; then immediate follow-up → expect cap.
+
+**Phase 5 confirmed cleanly.** Full timeline:
+
+| Time | Event | Outcome |
+|---|---|---|
+| T0 = 17:10:32 | Burst 5 toggles | All 5 ✅, counter 5/5 |
+| T0+102s (T1) | Probe | ❌ retry 202s (expected 198s, +4s = burst latency) |
+| T0+302..304s | (Burst entries expire ~together — clustered server-side) | — |
+| T0+334s (T2) | Toggle | ✅ counter 1/5 |
+| T0+335s | Toggle | ✅ counter 2/5 |
+| T0+363s (T3) | Toggle | ✅ counter 3/5 |
+| T0+376s (T4) | Toggle | ✅ counter 4/5 |
+| T0+412s (T5) | Toggle | ✅ counter 5/5 |
+| T0+412s | Toggle (immediate) | ❌ retry 227s (expected 222s = 300-78, +5s = burst latency again) |
+
+✅ **Sliding window per entry, exact 300s lifetime, retry-after = remaining time until oldest entry expires.**
+
+⚠️ **Practical caveat**: parallel burst calls land server-side within ~1-2s of each other, so they expire together (all-or-nothing on bursts) — you don't get a slow trickle of freed slots if your initial burst was parallel.
+
+Now compiling the consolidated rules + findings report.
+
+# SafeBreach MCP Rate Limiter — Verified Rules
+
+## Scope
+Applies to exactly these 6 mutating tools:
+- `save_studio_attack_draft`
+- `update_studio_attack_draft`
+- `run_studio_attack`
+- `set_studio_attack_status` ✅ tested
+- `run_scenario`
+- `manage_test` ✅ tested
+
+All other tools (reads, config queries, etc.) are uncounted.
+
+---
+
+## Confirmed rules
+
+### R1 — Two-tier rate limits
+| Tier | Cap | Scope |
+|---|---|---|
+| Global "total actions" | **10 / sliding 5 min** | All 6 mutating tools combined |
+| Per-tool | **5 / sliding 5 min** | Each tool counted independently |
+
+### R2 — Sliding window, per entry
+- Each successful mutation timestamps an entry that lives exactly **300 s**.
+- The window slides per-call. Confirmed by `retry-after = 202s` at T0+102s (expected 300−102 = 198s; +4s offset is server-side burst latency).
+- Confirmed again at T5: `retry-after = 227s` after a 78s gap from the new oldest entry (expected 222s; same 5s offset).
+
+### R3 — Global error reported preferentially
+When both tiers trip simultaneously, the response names the **global** limit (`"total actions (10/10 in last 5 min)"`), not the per-tool one. Reproduced twice.
+
+### R4 — No-op calls do NOT consume budget
+6 calls of `set_studio_attack_status(new_status="draft")` while attack was already draft → all returned `"Set Status Error: Attack already draft"`. A subsequent probe got 5 full successes before hitting 5/5, proving the no-ops added 0 entries.
+
+### R5 — Upstream errors do NOT consume budget
+6 calls of `set_studio_attack_status` against WAF attack 10002222 (publish path broken with 500) → all returned `500 Internal Server Error`. A subsequent probe's first toggle succeeded, proving the 500s added 0 entries (if they had, the probe would have immediately hit 5/5).
+
+### R6 — Parallel bursts cluster server-side
+Calls fired in parallel land within ~1-2 s of each other in the counter, so they expire as a tight cluster (~all-or-nothing). You won't see a slow trickle of freed slots from a parallel burst — they all become available together near the 5-min mark.
+
+### R7 — Concurrent races for the last slot
+Demonstrated earlier in the session: with 5 calls fired in parallel into a fresh window, the first 5 win slots and any 6th gets a rate-limit error in the same response. The MCP serializes the counter check; no burst leakage past 5.
+
+---
+
+## Quantitative measurements
+
+| Measurement | Observed |
+|---|---|
+| Per-tool window length | 300 s ± burst latency |
+| Per-tool cap | 5 entries |
+| Global cap | 10 entries |
+| Retry-after accuracy vs expected | within ~5 s (server-side burst clustering offset) |
+| Failed upstream call cost | 0 |
+| No-op (already in target state) cost | 0 |
+
+---
+
+## Not directly tested (still hypotheses)
+
+1. **Caps on the other 4 mutating tools** (`save_studio_attack_draft`, `update_studio_attack_draft`, `run_studio_attack`, `run_scenario`) — assumed 5/5 per-tool, untested.
+2. **Cross-session scope** — does another MCP client share the same counter? (R7 model says yes if server-side; no if per-client.)
+3. **Cross-console scope** — does the counter aggregate across `pentest01`, `demo`, etc.?
+4. **Schema-validation failures** — does an invalid `new_status` like `"banana"` consume budget? (Hypothesis: no, by analogy with R5.)
+
+---
+
+## State left clean
+- Attack `raz-and-yossi-test` (10003859): **DRAFT** ✅
+- Attack `WAF test` (10002222): unchanged (publish still broken upstream)
+- Test `1778500641730.140`: still PAUSED — was paused during earlier `manage_test` stress test, never resumed because rate limit kept blocking. Now that windows are clean, want me to resume it?
+
+Autonomous test phases done. Want me to (a) resume the still-paused test `1778500641730.140`, (b) burn another window on the untested 4 tools to confirm R1 generalizes, or (c) stop here?

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -19,10 +19,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Draft |
-| **Last Updated** | 2026-05-11 09:15 |
+| **PRD Status** | In Progress |
+| **Last Updated** | 2026-05-11 11:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | N/A |
+| **Current Phase** | Phase 1 of 7 complete |
 
 ---
 
@@ -289,7 +289,7 @@ verified independently.
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: Total action limit on manage_test | ⏳ Pending | - | - | First E2E slice |
+| Phase 1: Total action limit on manage_test | ✅ Complete | 2026-05-11 | pending | 14 unit + 3 gate tests pass |
 | Phase 2: Per-tool-name limit | ⏳ Pending | - | - | Second limit type |
 | Phase 3: Dry-run exclusion (run_scenario) | ⏳ Pending | - | - | Most complex gate |
 | Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
@@ -691,3 +691,4 @@ lifecycle, preventing unbounded memory growth.
 | 2026-05-11 09:15 | PRD created — initial draft |
 | 2026-05-11 09:45 | Revised: informative error messages with limit type + retry-after; added E2E testing |
 | 2026-05-11 10:15 | Restructured to elephant carpaccio TDD slices: 7 thin vertical phases, each with tests-first |
+| 2026-05-11 11:00 | Phase 1 complete: rate_limiter.py + manage_test gates + 17 tests (14 unit + 3 gate) |

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -19,10 +19,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | In Progress |
-| **Last Updated** | 2026-05-11 11:00 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-05-11 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | Phase 3 of 7 complete |
+| **Current Phase** | All phases complete (Phase 6 removed) |
 
 ---
 
@@ -288,10 +288,10 @@ verified independently.
 | Phase 1: Total action limit on manage_test | ✅ Complete | 2026-05-11 | pending | 14 unit + 3 gate tests pass |
 | Phase 2: Per-tool-name limit | ✅ Complete | 2026-05-11 | pending | 6 new tests, 353 total pass |
 | Phase 3: Dry-run exclusion (run_scenario) | ✅ Complete | 2026-05-11 | pending | 4 gate tests, dry_run+not_ready skip verified |
-| Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
-| Phase 5: Hybrid caller identity | ⏳ Pending | - | - | Production-ready identity |
+| Phase 4: Remaining 4 tools | ✅ Complete | 2026-05-11 | e004a6e | 8 new gate tests, all 6 tools gated |
+| Phase 5: Hybrid caller identity | ✅ Complete | 2026-05-11 | 0e2b6b5 | 8 identity tests, SHA256[:16] |
 | Phase 6: ~~Cleanup + server lifecycle~~ | ❌ Removed | - | - | Passive eviction sufficient |
-| Phase 7: Documentation | ⏳ Pending | - | - | CLAUDE.md pattern |
+| Phase 7: Documentation | ✅ Complete | 2026-05-11 | 93825ea | CLAUDE.md pattern + env vars |
 
 ---
 

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -83,10 +83,8 @@ for each tool.
   - External connections: SHA256 hash of auth token (from `get_cache_user_suffix()` pattern)
   - Localhost connections: transport session ID (from `_get_session_id_from_mcp_ctx()`)
   - Fallback: `'anonymous'` if neither is available
-- Sliding window pruning: on every `check_limit` and `record_action` call, timestamps older than
-  the window duration are removed
-- `_cleanup_stale_rate_limits()` — background async task (every 10 minutes) that evicts caller
-  entries with no activity within the TTL period (1 hour, matching existing semaphore cleanup)
+- Sliding window pruning: on every `check_limit` call, timestamps older than
+  the window duration are removed (passive eviction — no background task needed)
 - Configuration read from environment variables at module load time
 
 **Data Structure**:
@@ -96,7 +94,7 @@ _rate_limit_store: Dict[str, CallerRateLimitData]
 CallerRateLimitData:
   total_actions: List[float]          # timestamps of all write tool calls
   per_tool_actions: Dict[str, List[float]]  # tool_name -> timestamps
-  last_activity: float                # for stale cleanup
+  last_activity: float                # tracks last action time
 ```
 
 ### Component B: Per-Tool Gate Integration (Studio Server)
@@ -154,8 +152,10 @@ Note: `create_new_studio_attack` was initially classified as write but is actual
 - **Overhead**: Sliding window check/prune is O(n) where n = number of timestamps in window.
   With max 10 actions per 30 minutes, this is negligible
 - **Memory**: Per-caller storage is bounded by window size × action count. With 10 actions max
-  per caller per 30 minutes, memory per caller is ~80 bytes (10 floats)
-- **Cleanup**: Background task every 10 minutes prevents unbounded growth from disconnected clients
+  per caller per 30 minutes, memory per caller is ~80 bytes (10 floats). Passive eviction via
+  sliding window pruning on each `check_limit` keeps active callers lean. Abandoned callers'
+  entries persist until server restart — at ~80 bytes each, even 10,000 abandoned callers is
+  under 1MB, so active cleanup is not justified
 
 ### Technical Constraints
 
@@ -171,13 +171,12 @@ Note: `create_new_studio_attack` was initially classified as write but is actual
 - **Logging**: Info-level log on each `record_action` (caller masked, tool name, current counts)
 - **Warning log**: When a caller is rate-limited (which limit was hit, current count, limit value)
 - **Debug log**: On `check_limit` pass (for troubleshooting)
-- **Cleanup log**: Info-level when stale entries are evicted
 
 ---
 
 ## 7. Definition of Done
 
-- [ ] `rate_limiter.py` module created with `RateLimiter` class, `get_caller_identity()`, and cleanup task
+- [ ] `rate_limiter.py` module created with `RateLimiter` class and `get_caller_identity()`
 - [ ] Two independent sliding-window limits enforced: total actions (default 10) and
   per-tool-name (default 5) within configurable window (default 30 min)
 - [ ] Hybrid caller identity: auth token hash for external, session ID for localhost, `'anonymous'` fallback
@@ -195,13 +194,12 @@ Note: `create_new_studio_attack` was initially classified as write but is actual
   - `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default: 5)
   - `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
 - [ ] Cross-server shared state verified (module-level dict across all 5 servers)
-- [ ] Stale caller data cleaned up periodically (10-min interval, 1-hour TTL)
 - [ ] CLAUDE.md updated with rate limiting pattern documentation
 - [ ] Unit tests pass for: both limit types, sliding window behavior, two-phase gate (dry-run
   excluded, failures excluded), hybrid identity, informative error messages (limit type +
-  retry-after), configuration overrides, enable/disable, stale cleanup
-- [ ] E2E tests pass: rate limit trigger, dry-run exclusion, disable switch, window expiry
-- [ ] Logging with masked caller ID on record, warning on limit hit, info on cleanup
+  retry-after), configuration overrides, enable/disable
+- [ ] E2E tests pass: rate limit trigger, dry-run exclusion
+- [ ] Logging with masked caller ID on record, warning on limit hit
 
 ---
 
@@ -223,8 +221,6 @@ Note: `create_new_studio_attack` was initially classified as write but is actual
 - Window boundary: action at exactly window edge is counted; action 1ms past is pruned
 - Multiple callers tracked independently
 - Multiple tool names tracked independently per caller
-- Stale cleanup removes entries with no activity past TTL
-- Stale cleanup preserves entries with recent activity
 
 **get_caller_identity()**:
 - Returns auth token hash when auth artifacts available
@@ -294,7 +290,7 @@ verified independently.
 | Phase 3: Dry-run exclusion (run_scenario) | ✅ Complete | 2026-05-11 | pending | 4 gate tests, dry_run+not_ready skip verified |
 | Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
 | Phase 5: Hybrid caller identity | ⏳ Pending | - | - | Production-ready identity |
-| Phase 6: Cleanup + server lifecycle | ⏳ Pending | - | - | Memory management |
+| Phase 6: ~~Cleanup + server lifecycle~~ | ❌ Removed | - | - | Passive eviction sufficient |
 | Phase 7: Documentation | ⏳ Pending | - | - | CLAUDE.md pattern |
 
 ---
@@ -558,50 +554,11 @@ proving the most complex gate pattern.
 
 ### Phase 6: Cleanup + Server Lifecycle
 
-**Semantic Change**: Add stale entry cleanup and integrate rate limiter into the server
-lifecycle, preventing unbounded memory growth.
-
-**Deliverables**: Cleanup task, server integration, disable/enable E2E, window expiry E2E.
-
-**Tests First (TDD)**:
-
-1. **Unit tests** (add to `test_rate_limiter.py`):
-   - Record actions, advance time past TTL (1 hour), run cleanup, verify entries removed
-   - Record recent actions, run cleanup, verify entries preserved
-   - Multiple callers: only stale ones removed, active ones kept
-   - Cleanup singleton: calling `start_rate_limit_cleanup()` twice only starts one task
-
-2. **E2E tests** (add to `test_rate_limiting_e2e.py`):
-   - Set `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=false`: verify tools execute without
-     rate limit interference regardless of call count
-   - Set `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=1`: trigger limit, wait 60+ seconds,
-     verify tool succeeds again (window expiry)
-
-**Implementation (to pass the tests)**:
-
-1. Add `_cleanup_stale_rate_limits()` async function to `rate_limiter.py`:
-   - Infinite loop with `await asyncio.sleep(600)` (every 10 minutes)
-   - Find entries with `last_activity` older than 3600 seconds, remove them
-   - Log eviction count, wrap in try/except
-
-2. Add `start_rate_limit_cleanup()` singleton async function:
-   - Module-level `_cleanup_started: bool = False` flag
-   - First call creates the task, subsequent calls are no-ops
-
-3. In `safebreach_base.py` `run_server()`:
-   - Import and start cleanup task alongside existing tasks
-   - Cancel in `finally` block
-
-**Changes**:
-
-| File | Action | Description |
-|------|--------|-------------|
-| `safebreach_mcp_core/rate_limiter.py` | Modify | Add cleanup task + singleton starter |
-| `safebreach_mcp_core/safebreach_base.py` | Modify | Start cleanup task in run_server() |
-| `safebreach_mcp_core/tests/test_rate_limiter.py` | Modify | Add cleanup + lifecycle tests |
-| `tests/test_rate_limiting_e2e.py` | Modify | Add disable switch + window expiry E2E |
-
-**Git Commit**: `feat: rate limit cleanup task and server lifecycle (TDD)`
+**Status**: Removed — passive eviction via sliding window pruning in `check_limit` is sufficient.
+Active cleanup was implemented and then reverted: at ~80 bytes per caller, even 10,000 abandoned
+callers is under 1MB. The added complexity (async background task, singleton flag, server lifecycle
+integration, 4 tests) was not justified by the marginal memory savings. Rate limit state resets
+on server restart, which is acceptable for a safety guardrail.
 
 ---
 
@@ -692,3 +649,4 @@ lifecycle, preventing unbounded memory growth.
 | 2026-05-11 09:45 | Revised: informative error messages with limit type + retry-after; added E2E testing |
 | 2026-05-11 10:15 | Restructured to elephant carpaccio TDD slices: 7 thin vertical phases, each with tests-first |
 | 2026-05-11 11:00 | Phase 1 complete: rate_limiter.py + manage_test gates + 17 tests (14 unit + 3 gate) |
+| 2026-05-11 | Phase 6 removed: active cleanup task adds complexity with negligible value — passive eviction sufficient |

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -1,0 +1,693 @@
+# Per-Caller Rate Limiting for MCP Write Operations — SAF-29871
+
+## 1. Overview
+
+- **Task Type**: Feature
+- **Purpose**: Prevent misuse of MCP write operations by limiting the rate at which actions can
+  be performed per caller, containing potential damage and enabling detection of suspicious activity
+- **Target Consumer**: Internal — MCP server infrastructure (affects all MCP clients)
+- **Key Benefits**:
+  - Safety guardrail against malicious or misconfigured clients performing unlimited write operations
+  - Enables identification of suspicious repetitive action patterns
+  - Configurable limits allow tuning per deployment environment
+- **Business Alignment**: Part of MCP safety guardrails initiative for responsible AI agent operation
+- **Originating Request**: [SAF-29871](https://safebreach.atlassian.net/browse/SAF-29871)
+
+---
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-05-11 09:15 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution: Explicit Two-Phase Gate with Shared Helper
+
+A new `rate_limiter.py` module in `safebreach_mcp_core/` provides a singleton `RateLimiter` class
+with two methods: `check_limit()` (pre-check, raises `ToolError` if exceeded) and `record_action()`
+(post-success increment). A `get_caller_identity()` helper encapsulates hybrid caller identification
+(auth token hash for external connections, session ID fallback for localhost).
+
+Each write tool explicitly calls both methods at the appropriate points in its code — after
+validation but before the mutating API call (`check_limit`), and after the API call succeeds
+(`record_action`). This per-tool placement ensures dry-run invocations and failures are not counted.
+
+**Data structure**: Module-level dict mapping caller ID to a list of action timestamps.
+On each check/record, entries older than the sliding window are pruned. Cross-server sharing is
+automatic since all 5 servers run in the same process.
+
+### Alternatives Considered
+
+**Approach A — Fully Explicit (no shared helper)**:
+Each tool extracts caller identity and manages gate calls independently.
+- Pros: Maximum clarity, no abstractions
+- Cons: Repeated boilerplate in each tool, caller ID extraction duplicated 6 times
+
+**Approach C — Decorator-Based**:
+A `@rate_limited()` decorator wraps each write tool, with `skip_record_if` lambdas for dry-run.
+- Pros: Minimal boilerplate, hard to forget
+- Cons: Hides gate timing, fights per-tool placement (e.g., `run_scenario` has early returns
+  before real work; `set_studio_attack_status` does pre-check GETs)
+
+### Decision Rationale
+
+Approach B provides explicit control over gate placement (critical for `run_scenario`'s dry-run
+branches and `set_studio_attack_status`'s pre-check reads) while reducing boilerplate through the
+shared `get_caller_identity()` helper. The two-phase pattern (check without increment, then record
+on success) can only work correctly with per-tool placement since "success" is defined differently
+for each tool.
+
+---
+
+## 3. Core Feature Components
+
+### Component A: Rate Limiter Module (`safebreach_mcp_core/rate_limiter.py`)
+
+**Purpose**: New module providing the rate limiting engine and caller identity helper.
+
+**Key Features**:
+- `RateLimiter` singleton class with cross-server shared state (module-level dict)
+- `check_limit(caller_id, tool_name)` — verifies both total and per-tool-name counts are below
+  limits within the sliding window. Raises `ToolError` with user-friendly message if exceeded.
+  Does NOT increment any counter.
+- `record_action(caller_id, tool_name)` — appends current timestamp to both the total actions
+  list and the per-tool-name list for the caller. Called only after successful, non-dry-run execution.
+- `get_caller_identity()` — hybrid caller identification:
+  - External connections: SHA256 hash of auth token (from `get_cache_user_suffix()` pattern)
+  - Localhost connections: transport session ID (from `_get_session_id_from_mcp_ctx()`)
+  - Fallback: `'anonymous'` if neither is available
+- Sliding window pruning: on every `check_limit` and `record_action` call, timestamps older than
+  the window duration are removed
+- `_cleanup_stale_rate_limits()` — background async task (every 10 minutes) that evicts caller
+  entries with no activity within the TTL period (1 hour, matching existing semaphore cleanup)
+- Configuration read from environment variables at module load time
+
+**Data Structure**:
+```
+_rate_limit_store: Dict[str, CallerRateLimitData]
+
+CallerRateLimitData:
+  total_actions: List[float]          # timestamps of all write tool calls
+  per_tool_actions: Dict[str, List[float]]  # tool_name -> timestamps
+  last_activity: float                # for stale cleanup
+```
+
+### Component B: Per-Tool Gate Integration (Studio Server)
+
+**Purpose**: Integrate `check_limit` and `record_action` calls into each of the 6 write tools.
+
+**Key Features**:
+- Each tool calls `get_caller_identity()` to obtain the caller key
+- `check_limit` placed after parameter validation, before the mutating API call
+- `record_action` placed after the API call succeeds and response is parsed
+- Special handling per tool:
+  - `run_scenario`: gates only on the queue-submission branch (skip diagnostic and dry_run returns)
+  - `set_studio_attack_status`: `check_limit` placed after the pre-check GET (allow reads first)
+  - `manage_test`: `record_action` after state change (note append is best-effort, doesn't gate)
+
+**6 Tools Requiring Gates**:
+
+| Tool | check_limit placement | record_action placement | Special handling |
+|------|----------------------|------------------------|------------------|
+| `save_studio_attack_draft` | After param validation | After POST + cache write | None |
+| `update_studio_attack_draft` | After param validation | After PUT + cache update | None |
+| `run_studio_attack` | After input validation | After POST queue response | None |
+| `set_studio_attack_status` | After pre-check GET confirms status | After PUT + cache invalidate | Allow pre-check read first |
+| `run_scenario` | After early returns (not_ready, dry_run) | After POST queue response | Skip gates on non-queue branches |
+| `manage_test` | After input validation | After state change + note | Note append is best-effort |
+
+Note: `create_new_studio_attack` was initially classified as write but is actually read-only
+(returns static boilerplate templates, no API calls). It does NOT need rate limiting gates.
+
+### Component C: Documentation Update (CLAUDE.md)
+
+**Purpose**: Document the two-phase gate pattern so future write tools follow it consistently.
+
+**Key Features**:
+- Add a "Rate Limiting" section to CLAUDE.md under Key Design Patterns
+- Document the `check_limit` / `record_action` API and gate placement rules
+- Include the gate placement table for existing tools as reference
+- Specify that any new non-readOnly tool must integrate rate limiting gates
+
+---
+
+## 6. Non-Functional Requirements
+
+### Security & Compliance
+
+- **Caller Identity**: Auth token hash provides stable identity that survives reconnection,
+  preventing rate limit bypass via session reset
+- **Logging**: Rate limit events logged with masked caller ID (first 8 chars of hash) —
+  never log raw tokens
+- **Fail-open vs fail-closed**: If caller identity cannot be determined, rate limiting still
+  applies using `'anonymous'` as the caller key (fail-closed)
+
+### Performance Requirements
+
+- **Overhead**: Sliding window check/prune is O(n) where n = number of timestamps in window.
+  With max 10 actions per 30 minutes, this is negligible
+- **Memory**: Per-caller storage is bounded by window size × action count. With 10 actions max
+  per caller per 30 minutes, memory per caller is ~80 bytes (10 floats)
+- **Cleanup**: Background task every 10 minutes prevents unbounded growth from disconnected clients
+
+### Technical Constraints
+
+- **Thread safety**: All servers run in the same asyncio event loop (single-threaded).
+  Module-level dict operations are safe. No explicit locking needed for the rate limit store.
+- **Cross-server**: Module-level dict is automatically shared across all 5 servers since
+  `MultiServerLauncher` runs them in the same process via `asyncio.gather()`
+- **Backward Compatibility**: No breaking changes. Rate limiter is transparent to read-only tools.
+  Write tools get gates added but behavior is unchanged when within limits.
+
+### Monitoring & Observability
+
+- **Logging**: Info-level log on each `record_action` (caller masked, tool name, current counts)
+- **Warning log**: When a caller is rate-limited (which limit was hit, current count, limit value)
+- **Debug log**: On `check_limit` pass (for troubleshooting)
+- **Cleanup log**: Info-level when stale entries are evicted
+
+---
+
+## 7. Definition of Done
+
+- [ ] `rate_limiter.py` module created with `RateLimiter` class, `get_caller_identity()`, and cleanup task
+- [ ] Two independent sliding-window limits enforced: total actions (default 10) and
+  per-tool-name (default 5) within configurable window (default 30 min)
+- [ ] Hybrid caller identity: auth token hash for external, session ID for localhost, `'anonymous'` fallback
+- [ ] `check_limit` raises `ToolError` with an informative message that includes:
+  which limit was exceeded (total actions or specific tool name), and how many seconds
+  until the oldest action in the window expires (computed retry-after).
+  Example: "Rate limit exceeded: total actions (10/10 in last 30 min). Try again in 847 seconds."
+  or: "Rate limit exceeded: run_scenario (5/5 in last 30 min). Try again in 423 seconds."
+- [ ] `record_action` only increments on successful, non-dry-run execution
+- [ ] All 6 write tools in Studio server have gates at correct positions
+- [ ] `run_scenario` dry-run and diagnostic branches do not trigger gates
+- [ ] Configuration via environment variables:
+  - `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` (default: true)
+  - `SAFEBREACH_MCP_ACTION_LIMIT` (default: 10)
+  - `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default: 5)
+  - `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
+- [ ] Cross-server shared state verified (module-level dict across all 5 servers)
+- [ ] Stale caller data cleaned up periodically (10-min interval, 1-hour TTL)
+- [ ] CLAUDE.md updated with rate limiting pattern documentation
+- [ ] Unit tests pass for: both limit types, sliding window behavior, two-phase gate (dry-run
+  excluded, failures excluded), hybrid identity, informative error messages (limit type +
+  retry-after), configuration overrides, enable/disable, stale cleanup
+- [ ] E2E tests pass: rate limit trigger, dry-run exclusion, disable switch, window expiry
+- [ ] Logging with masked caller ID on record, warning on limit hit, info on cleanup
+
+---
+
+## 8. Testing Strategy
+
+### Unit Testing
+
+**Scope**: `safebreach_mcp_core/rate_limiter.py` and gate integration in Studio server tools
+
+**Key Scenarios**:
+
+**RateLimiter class**:
+- `check_limit` passes when count is below both limits
+- `check_limit` raises `ToolError` when total action limit exceeded
+- `check_limit` raises `ToolError` when per-tool-name limit exceeded
+- `check_limit` does NOT increment counters (verify count unchanged after call)
+- `record_action` increments both total and per-tool-name counters
+- Sliding window correctly prunes timestamps older than window duration
+- Window boundary: action at exactly window edge is counted; action 1ms past is pruned
+- Multiple callers tracked independently
+- Multiple tool names tracked independently per caller
+- Stale cleanup removes entries with no activity past TTL
+- Stale cleanup preserves entries with recent activity
+
+**get_caller_identity()**:
+- Returns auth token hash when auth artifacts available
+- Returns session ID when no auth artifacts (localhost)
+- Returns `'anonymous'` when neither is available
+- Hash is stable: same token always produces same identity
+
+**Configuration**:
+- Custom limits via environment variables are respected
+- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=false` disables all rate limiting
+- Default values used when env vars not set
+
+**Gate integration (per-tool)**:
+- `check_limit` called before API mutation (mock API, verify check happens first)
+- `record_action` called after successful API response
+- `record_action` NOT called on API failure (exception path)
+- `run_scenario`: gates NOT called on dry_run or not_ready branches
+- `set_studio_attack_status`: pre-check GET allowed before `check_limit`
+
+**Cross-server**:
+- Actions recorded on one server instance are visible to another
+  (import same module, verify shared state)
+
+**Framework**: pytest with unittest.mock
+
+### Integration Testing
+
+**Scope**: Multi-server rate limit enforcement
+
+**Key Scenarios**:
+- Rate limit state shared across Config and Studio server instances
+- Cleanup task runs and evicts stale entries
+- Rate limiter disabled via env var does not interfere with tool execution
+
+### E2E Testing
+
+**Scope**: End-to-end rate limit enforcement against a real SafeBreach environment.
+Marked with `@pytest.mark.e2e`, excluded by default. Use a short sliding window
+(`SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=1`) to keep tests fast.
+
+**Key Scenarios**:
+- Call a write tool (e.g., `run_scenario` with `dry_run=False` or `manage_test`) multiple times
+  against a real console and verify rate limit triggers after exceeding the configured limit
+- Verify dry-run invocations (`run_scenario` with `dry_run=True`) do NOT count toward limits
+- Verify the error message includes which limit was exceeded and retry-after seconds
+- Verify that after the window expires, the tool can be called again successfully
+- Verify rate limiter can be disabled via `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=false`
+
+**Test Environment**:
+- Requires `source .vscode/set_env.sh` for real SafeBreach credentials
+- Use `E2E_CONSOLE` env var for target console
+- Set `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=1` and `SAFEBREACH_MCP_ACTION_LIMIT=2`
+  / `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT=1` to trigger limits quickly
+
+---
+
+## 9. Implementation Phases
+
+Each phase is a thin vertical slice following TDD: write tests first, then implement the minimum
+code to pass them. Every phase produces a working, tested increment that can be committed and
+verified independently.
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Total action limit on manage_test | ⏳ Pending | - | - | First E2E slice |
+| Phase 2: Per-tool-name limit | ⏳ Pending | - | - | Second limit type |
+| Phase 3: Dry-run exclusion (run_scenario) | ⏳ Pending | - | - | Most complex gate |
+| Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
+| Phase 5: Hybrid caller identity | ⏳ Pending | - | - | Production-ready identity |
+| Phase 6: Cleanup + server lifecycle | ⏳ Pending | - | - | Memory management |
+| Phase 7: Documentation | ⏳ Pending | - | - | CLAUDE.md pattern |
+
+---
+
+### Phase 1: Total Action Limit on `manage_test`
+
+**Semantic Change**: Deliver a working rate limiter that enforces the total action limit on
+the simplest write tool (`manage_test`), fully tested end-to-end.
+
+**Deliverables**: `rate_limiter.py` with `RateLimiter` class + `get_caller_identity()`,
+`manage_test` with gates, unit tests, E2E test.
+
+**Tests First (TDD)**:
+
+1. **Unit tests** (`safebreach_mcp_core/tests/test_rate_limiter.py`):
+   - `check_limit` passes when count is zero
+   - `check_limit` passes when count is below total limit
+   - `check_limit` raises `ToolError` when total limit reached
+   - `check_limit` does NOT increment counters
+   - `record_action` increments total count
+   - Sliding window: record actions, advance time past window, verify pruned
+   - Error message contains "total actions", count/limit, and retry-after seconds
+   - Multiple callers are independent
+   - Disabled via env var: `check_limit` passes, `record_action` is no-op
+   - Custom limit via `SAFEBREACH_MCP_ACTION_LIMIT` env var is respected
+   - Custom window via `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` is respected
+
+2. **Unit tests** for `get_caller_identity()`:
+   - Returns session ID when no auth artifacts (localhost)
+   - Returns `'anonymous'` when neither available
+   - (Auth token hash tests deferred to Phase 5)
+
+3. **Gate integration test** (`safebreach_mcp_studio/tests/test_rate_limiting.py`):
+   - `manage_test`: mock API, verify `check_limit` called before `_set_test_state`
+   - `manage_test`: mock API, verify `record_action` called after success
+   - `manage_test`: mock API to raise exception, verify `record_action` NOT called
+
+4. **E2E test** (`tests/test_rate_limiting_e2e.py`):
+   - Set `SAFEBREACH_MCP_ACTION_LIMIT=2`, `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=1`
+   - Call `manage_test` 2 times successfully, 3rd call raises `ToolError`
+   - Verify error message contains "total actions" and retry-after seconds
+
+**Implementation (to pass the tests)**:
+
+1. Create `safebreach_mcp_core/rate_limiter.py`:
+   - `CallerRateLimitData` dataclass: `total_actions: List[float]`,
+     `per_tool_actions: Dict[str, List[float]]`, `last_activity: float`
+   - Module-level `_rate_limit_store: Dict[str, CallerRateLimitData]`
+   - Configuration from env vars: `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` (default True),
+     `SAFEBREACH_MCP_ACTION_LIMIT` (default 10),
+     `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default 5),
+     `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default 30, convert to seconds)
+   - `RateLimiter.check_limit(caller_id, tool_name)`:
+     prune total_actions older than window, check `len(total_actions) >= ACTION_LIMIT`,
+     compute `retry_after = window_seconds - (now - oldest_timestamp)`,
+     raise `ToolError` with informative message. No increment.
+   - `RateLimiter.record_action(caller_id, tool_name)`:
+     append `time.time()` to `total_actions` and `per_tool_actions[tool_name]`,
+     update `last_activity`, log with masked caller ID
+   - `get_caller_identity()`: try `_get_session_id_from_mcp_ctx()`, fallback `'anonymous'`
+     (minimal — auth token hash added in Phase 5)
+   - Module-level `rate_limiter` singleton instance
+
+2. Add gates to `manage_test` in `studio_server.py`:
+   - `caller_id = get_caller_identity()` + `rate_limiter.check_limit(caller_id, "manage_test")`
+     after input validation, before `_set_test_state()`
+   - `rate_limiter.record_action(caller_id, "manage_test")` after `_set_test_state()` succeeds
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_core/rate_limiter.py` | Create | Rate limiter with total limit + session identity |
+| `safebreach_mcp_studio/studio_server.py` | Modify | Add gates to manage_test |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Create | Core rate limiter + identity unit tests |
+| `safebreach_mcp_studio/tests/test_rate_limiting.py` | Create | manage_test gate integration tests |
+| `tests/test_rate_limiting_e2e.py` | Create | E2E: total action limit on manage_test |
+
+**Git Commit**: `feat: rate limiter with total action limit on manage_test (TDD)`
+
+---
+
+### Phase 2: Per-Tool-Name Limit
+
+**Semantic Change**: Add the second limit type — per-tool-name count — and verify it works
+alongside the total action limit.
+
+**Deliverables**: Per-tool-name enforcement in `check_limit`, tests for both limits interacting.
+
+**Tests First (TDD)**:
+
+1. **Unit tests** (add to `test_rate_limiter.py`):
+   - `check_limit` raises `ToolError` when per-tool limit reached (5 identical actions)
+   - Error message contains tool name, count/limit, and retry-after seconds
+   - Per-tool limit enforced independently from total limit (can hit per-tool before total)
+   - Multiple tool names tracked independently per caller
+   - Custom `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` env var is respected
+   - Window boundary: per-tool timestamps pruned correctly
+
+2. **E2E test** (add to `test_rate_limiting_e2e.py`):
+   - Set `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT=1`, `SAFEBREACH_MCP_ACTION_LIMIT=10`
+   - Call `manage_test` 1 time successfully, 2nd call raises `ToolError`
+   - Verify error message contains "manage_test" (tool name) and retry-after seconds
+
+**Implementation (to pass the tests)**:
+
+1. Extend `RateLimiter.check_limit()`:
+   - After total limit check, prune `per_tool_actions[tool_name]`
+   - If `len(per_tool_actions[tool_name]) >= IDENTICAL_ACTION_LIMIT`:
+     compute retry_after from oldest per-tool timestamp,
+     raise `ToolError` with per-tool message
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_core/rate_limiter.py` | Modify | Add per-tool-name limit to check_limit |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Modify | Add per-tool limit tests |
+| `tests/test_rate_limiting_e2e.py` | Modify | Add per-tool E2E test |
+
+**Git Commit**: `feat: add per-tool-name rate limit (TDD)`
+
+---
+
+### Phase 3: Dry-Run Exclusion (`run_scenario`)
+
+**Semantic Change**: Add gates to `run_scenario` with dry-run and diagnostic exclusion —
+proving the most complex gate pattern.
+
+**Deliverables**: `run_scenario` gates with dry-run awareness, tested E2E.
+
+**Tests First (TDD)**:
+
+1. **Gate integration tests** (add to `test_rate_limiting.py`):
+   - `run_scenario` with `dry_run=False`: verify `check_limit` called before queue POST,
+     `record_action` called after success
+   - `run_scenario` with `dry_run=True`: verify neither `check_limit` nor `record_action` called
+   - `run_scenario` with not_ready diagnostic: verify gates NOT called
+   - `run_scenario` API failure: verify `record_action` NOT called
+
+2. **E2E test** (add to `test_rate_limiting_e2e.py`):
+   - Set `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT=1`
+   - Call `run_scenario` with `dry_run=True` multiple times — no rate limit triggered
+   - Call `run_scenario` with `dry_run=False` once, second call triggers limit
+   - Verify dry-run calls did not consume rate limit budget
+
+**Implementation (to pass the tests)**:
+
+1. Add gates to `run_scenario` in `studio_server.py`:
+   - `check_limit` placed AFTER all early return branches (not_ready diagnostic return,
+     dry_run prediction return, simulation count validation), immediately before the POST
+     to `/api/orch/v4/accounts/{id}/queue`
+   - `record_action` after the POST response is parsed and result with status='queued' is built
+   - The key: gates only exist on the queue-submission code path, not on the diagnostic or
+     dry-run branches
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_studio/studio_server.py` | Modify | Add gates to run_scenario |
+| `safebreach_mcp_studio/tests/test_rate_limiting.py` | Modify | Add run_scenario gate tests |
+| `tests/test_rate_limiting_e2e.py` | Modify | Add dry-run exclusion E2E test |
+
+**Git Commit**: `feat: rate limit run_scenario with dry-run exclusion (TDD)`
+
+---
+
+### Phase 4: Remaining 4 Tools
+
+**Semantic Change**: Add gates to the remaining 4 write tools, achieving full tool coverage.
+
+**Deliverables**: All 6 write tools gated and tested.
+
+**Tests First (TDD)**:
+
+1. **Gate integration tests** (add to `test_rate_limiting.py`), for each tool:
+   - `save_studio_attack_draft`: `check_limit` before POST, `record_action` after cache write,
+     NOT called on validation failure
+   - `update_studio_attack_draft`: `check_limit` before PUT, `record_action` after cache update,
+     NOT called on validation failure
+   - `run_studio_attack`: `check_limit` before queue POST, `record_action` after response parsed,
+     NOT called on API error
+   - `set_studio_attack_status`: `check_limit` AFTER pre-check GET (allow read first),
+     before PUT. `record_action` after PUT + cache invalidate. NOT called on pre-check failure.
+
+**Implementation (to pass the tests)**:
+
+1. Add gates to `save_studio_attack_draft`:
+   - `check_limit` after param validation (OS, dual-script), before POST to customMethods
+   - `record_action` after POST response parsed, transformed, and cached
+
+2. Add gates to `update_studio_attack_draft`:
+   - `check_limit` after param validation, before PUT to customMethods
+   - `record_action` after PUT response parsed and cache updated
+
+3. Add gates to `run_studio_attack`:
+   - `check_limit` after input validation (attack_id, simulators, filters), before queue POST
+   - `record_action` after POST response parsed with planRunId/stepRunId
+
+4. Add gates to `set_studio_attack_status`:
+   - `check_limit` AFTER pre-check GET confirms attack exists and status validated,
+     before PUT to customMethods
+   - `record_action` after PUT succeeds and cache invalidated
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_studio/studio_server.py` | Modify | Add gates to 4 remaining write tools |
+| `safebreach_mcp_studio/tests/test_rate_limiting.py` | Modify | Add gate tests for 4 tools |
+
+**Git Commit**: `feat: rate limit all remaining write tools (TDD)`
+
+---
+
+### Phase 5: Hybrid Caller Identity
+
+**Semantic Change**: Upgrade caller identity from session-only to hybrid
+(auth token hash for external, session fallback for localhost).
+
+**Deliverables**: Production-ready `get_caller_identity()` with auth token support.
+
+**Tests First (TDD)**:
+
+1. **Unit tests** (add to `test_rate_limiter.py`):
+   - Mock `_user_auth_artifacts` with `x-apitoken` → returns SHA256 hash (first 16 chars)
+   - Mock `_get_auth_from_mcp_request_ctx()` as fallback → returns hash
+   - Priority: x-apitoken > x-token > cookie value
+   - Same token always produces same hash (stability)
+   - Auth token identity survives across session reconnection (same hash)
+   - Empty auth bundle with session ID → returns session ID
+   - No auth, no session → returns `'anonymous'`
+
+2. **E2E test** (add to `test_rate_limiting_e2e.py`):
+   - Verify rate limits are enforced correctly when auth token is present
+     (external connection scenario)
+
+**Implementation (to pass the tests)**:
+
+1. Upgrade `get_caller_identity()` in `rate_limiter.py`:
+   - Try `_user_auth_artifacts` ContextVar first
+   - Fallback to `_get_auth_from_mcp_request_ctx()`
+   - If auth artifacts found, hash the most stable value
+     (priority: x-apitoken > x-token > cookie), return `SHA256[:16]`
+   - If no auth, fall back to `_get_session_id_from_mcp_ctx()`
+   - Final fallback: `'anonymous'`
+   - Debug logging for which identity source was used
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_core/rate_limiter.py` | Modify | Upgrade get_caller_identity() with auth token hash |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Modify | Add hybrid identity tests |
+| `tests/test_rate_limiting_e2e.py` | Modify | Add auth-token identity E2E test |
+
+**Git Commit**: `feat: hybrid caller identity for rate limiting (TDD)`
+
+---
+
+### Phase 6: Cleanup + Server Lifecycle
+
+**Semantic Change**: Add stale entry cleanup and integrate rate limiter into the server
+lifecycle, preventing unbounded memory growth.
+
+**Deliverables**: Cleanup task, server integration, disable/enable E2E, window expiry E2E.
+
+**Tests First (TDD)**:
+
+1. **Unit tests** (add to `test_rate_limiter.py`):
+   - Record actions, advance time past TTL (1 hour), run cleanup, verify entries removed
+   - Record recent actions, run cleanup, verify entries preserved
+   - Multiple callers: only stale ones removed, active ones kept
+   - Cleanup singleton: calling `start_rate_limit_cleanup()` twice only starts one task
+
+2. **E2E tests** (add to `test_rate_limiting_e2e.py`):
+   - Set `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=false`: verify tools execute without
+     rate limit interference regardless of call count
+   - Set `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=1`: trigger limit, wait 60+ seconds,
+     verify tool succeeds again (window expiry)
+
+**Implementation (to pass the tests)**:
+
+1. Add `_cleanup_stale_rate_limits()` async function to `rate_limiter.py`:
+   - Infinite loop with `await asyncio.sleep(600)` (every 10 minutes)
+   - Find entries with `last_activity` older than 3600 seconds, remove them
+   - Log eviction count, wrap in try/except
+
+2. Add `start_rate_limit_cleanup()` singleton async function:
+   - Module-level `_cleanup_started: bool = False` flag
+   - First call creates the task, subsequent calls are no-ops
+
+3. In `safebreach_base.py` `run_server()`:
+   - Import and start cleanup task alongside existing tasks
+   - Cancel in `finally` block
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_core/rate_limiter.py` | Modify | Add cleanup task + singleton starter |
+| `safebreach_mcp_core/safebreach_base.py` | Modify | Start cleanup task in run_server() |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Modify | Add cleanup + lifecycle tests |
+| `tests/test_rate_limiting_e2e.py` | Modify | Add disable switch + window expiry E2E |
+
+**Git Commit**: `feat: rate limit cleanup task and server lifecycle (TDD)`
+
+---
+
+### Phase 7: Documentation
+
+**Semantic Change**: Document the rate limiting pattern in CLAUDE.md for future write tools.
+
+**Deliverables**: Updated CLAUDE.md with rate limiting design pattern.
+
+**Implementation Details**:
+
+1. Add a "Rate Limiting" subsection under "Key Design Patterns" in `CLAUDE.md`
+2. Document:
+   - Two-phase gate pattern: `check_limit` (pre-check) + `record_action` (post-success)
+   - Gate placement rules (5 rules from investigation)
+   - Configuration environment variables and their defaults
+   - The `get_caller_identity()` helper and hybrid identity approach
+   - The gate placement table for existing 6 tools as reference
+   - Instruction: any new tool with `readOnlyHint=False` MUST add rate limiting gates
+3. Add `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` to the environment variable documentation section
+4. Update the "MCP Tools Available" section to note which tools are rate-limited
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `CLAUDE.md` | Modify | Add rate limiting pattern documentation |
+
+**Git Commit**: `docs: add rate limiting pattern to CLAUDE.md`
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `get_caller_identity()` returns empty/anonymous for legitimate callers | Medium — all anonymous callers share one bucket | Log warnings when anonymous identity used; monitor in production |
+| Sliding window pruning on every check adds latency | Low — max 10 entries per caller, O(10) is negligible | Benchmark if concerns arise |
+| Module-level dict not persisted across server restarts | Low — rate limits reset on restart (acceptable for safety guardrail) | Documented as expected behavior |
+
+### Assumptions
+
+- All 5 MCP servers will continue to run in the same process (cross-server sharing depends on this)
+- `time.time()` provides sufficient precision for sliding window (float seconds)
+- The existing `_get_auth_from_mcp_request_ctx()` and `_get_session_id_from_mcp_ctx()` functions
+  are accessible from within tool handlers (verified during investigation)
+- `create_new_studio_attack` is genuinely read-only (confirmed: returns static boilerplate)
+
+---
+
+## 11. Future Enhancements
+
+- **Bulk action rate limiting**: The original ticket mentions future bulk action APIs that should
+  also be capped. When bulk endpoints are added, apply similar per-tool gate placement.
+- **Persistent rate limit state**: If servers move to multi-process deployment, rate limit state
+  would need Redis or similar shared storage.
+- **Per-console rate limiting**: Currently rate limits are per-caller across all consoles.
+  Could be refined to per-caller-per-console if needed.
+- **Configurable per-tool limits**: Allow different limits for different tools
+  (e.g., `run_scenario` might have a tighter limit than `save_studio_attack_draft`).
+- **Rate limit metrics endpoint**: Expose current rate limit state via a monitoring endpoint.
+
+---
+
+## 12. Executive Summary
+
+- **Issue/Feature Description**: MCP servers have no rate limiting on write operations, allowing
+  unlimited repetitive actions by a single client.
+- **What Will Be Built**: A two-phase rate limiter (`check_limit` + `record_action`) integrated
+  into 6 Studio server write tools, with hybrid caller identity and cross-server shared state.
+- **Key Technical Decisions**: Explicit per-tool gate placement over decorator-based approach;
+  ToolError (MCP-level) over HTTP 429; auth token hash identity with session fallback;
+  module-level dict for cross-server sharing (same process).
+- **Scope**: 6 write tools in Studio server, new `rate_limiter.py` module, CLAUDE.md documentation.
+  Future bulk action APIs are out of scope.
+- **Business Value**: Safety guardrail preventing abuse of MCP write operations, enabling
+  detection of suspicious activity patterns, configurable per deployment.
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-05-11 09:15 | PRD created — initial draft |
+| 2026-05-11 09:45 | Revised: informative error messages with limit type + retry-after; added E2E testing |
+| 2026-05-11 10:15 | Restructured to elephant carpaccio TDD slices: 7 thin vertical phases, each with tests-first |

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -22,7 +22,7 @@
 | **PRD Status** | In Progress |
 | **Last Updated** | 2026-05-11 11:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | Phase 1 of 7 complete |
+| **Current Phase** | Phase 2 of 7 complete |
 
 ---
 
@@ -290,7 +290,7 @@ verified independently.
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
 | Phase 1: Total action limit on manage_test | ✅ Complete | 2026-05-11 | pending | 14 unit + 3 gate tests pass |
-| Phase 2: Per-tool-name limit | ⏳ Pending | - | - | Second limit type |
+| Phase 2: Per-tool-name limit | ✅ Complete | 2026-05-11 | pending | 6 new tests, 353 total pass |
 | Phase 3: Dry-run exclusion (run_scenario) | ⏳ Pending | - | - | Most complex gate |
 | Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
 | Phase 5: Hybrid caller identity | ⏳ Pending | - | - | Production-ready identity |

--- a/prds/SAF-29871-actions-rate-limit/prd.md
+++ b/prds/SAF-29871-actions-rate-limit/prd.md
@@ -22,7 +22,7 @@
 | **PRD Status** | In Progress |
 | **Last Updated** | 2026-05-11 11:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | Phase 2 of 7 complete |
+| **Current Phase** | Phase 3 of 7 complete |
 
 ---
 
@@ -291,7 +291,7 @@ verified independently.
 |-------|--------|-----------|------------|-------|
 | Phase 1: Total action limit on manage_test | ✅ Complete | 2026-05-11 | pending | 14 unit + 3 gate tests pass |
 | Phase 2: Per-tool-name limit | ✅ Complete | 2026-05-11 | pending | 6 new tests, 353 total pass |
-| Phase 3: Dry-run exclusion (run_scenario) | ⏳ Pending | - | - | Most complex gate |
+| Phase 3: Dry-run exclusion (run_scenario) | ✅ Complete | 2026-05-11 | pending | 4 gate tests, dry_run+not_ready skip verified |
 | Phase 4: Remaining 4 tools | ⏳ Pending | - | - | Full tool coverage |
 | Phase 5: Hybrid caller identity | ⏳ Pending | - | - | Production-ready identity |
 | Phase 6: Cleanup + server lifecycle | ⏳ Pending | - | - | Memory management |

--- a/prds/SAF-29871-actions-rate-limit/summary.md
+++ b/prds/SAF-29871-actions-rate-limit/summary.md
@@ -95,6 +95,22 @@ This prevents rate limit bypass via session reconnection for external clients.
 
 All other servers (Config, Data, Utilities, Playbook) currently have only readOnly tools.
 
+**Two-Phase Gate Pattern**
+Rate limiting uses a check-then-commit pattern with per-tool placement:
+* **Phase 1 — Pre-check (`check_limit`)**: Called early in the tool, before real work begins.
+  Verifies the caller's current count is below the limit. Rejects immediately if exceeded.
+  Does NOT increment the counter.
+* **Phase 2 — Post-increment (`record_action`)**: Called after the action is truly applied
+  (e.g., after the API call succeeds). Only increments if the invocation was both successful
+  and not a dry-run.
+
+This ensures that:
+* Dry-run invocations (e.g., `run_scenario` with `dry_run=True`) do not count toward limits
+* Failed invocations (wrong parameters, API errors) do not count toward limits
+* Only real, successfully-applied actions consume rate limit budget
+* Gate placement is per-tool — each tool's code must be reviewed to determine the correct
+  locations for `check_limit` (before work) and `record_action` (after success)
+
 **Problem Description**
 * Currently no rate limiting exists on MCP tool invocations
 * A client can call write tools without any frequency restriction
@@ -105,22 +121,28 @@ All other servers (Config, Data, Utilities, Playbook) currently have only readOn
 * Rate limiter installed on all servers (future-proofing for when other servers add write tools)
 
 **Affected Areas**
-* `safebreach_mcp_core/` — new `rate_limiter.py` module + integration into `safebreach_base.py`
+* `safebreach_mcp_core/` — new `rate_limiter.py` module (check_limit + record_action API)
 * `safebreach_mcp_core/token_context.py` — caller identity extraction
-* All 5 server modules — rate limiter installed in middleware stack
+* Each write tool in Studio server — per-tool gate placement (7 tools)
 
 ### Acceptance Criteria
 
 * A new `rate_limiter.py` module in `safebreach_mcp_core/` implements sliding-window rate limiting
+  with a two-phase gate API: `check_limit(caller_id, tool_name)` and
+  `record_action(caller_id, tool_name)`
 * Two independent limits enforced per caller identity:
   * Total non-readOnly tool calls limited to configurable max (default: 10) within a sliding window
   * Per-tool-name non-readOnly calls limited to configurable max (default: 5) within the same window
+* Two-phase gate pattern:
+  * `check_limit` verifies count < limit before tool execution (rejects if exceeded, no increment)
+  * `record_action` increments count only after successful, non-dry-run execution
+  * Dry-run invocations and failed invocations do NOT count toward limits
+* Gate placement is per-tool: each write tool's code reviewed for correct `check_limit` (early)
+  and `record_action` (after success) placement
 * Caller identity uses hybrid approach: auth token hash for external connections, session ID
   for localhost connections
 * Sliding window duration is configurable (default: 30 minutes)
-* Rate limiter uses tool annotations (`readOnlyHint`) to classify tools — read-only tools are exempt
 * Rate limiting state is shared across all 5 servers (cross-server enforcement)
-* Rate limiter is installed on all servers regardless of current tool classification
 * When a limit is exceeded, the client receives a clear error message:
   "You exceeded the allowed rate of actions. Please try again in a few minutes."
 * Configuration via environment variables:
@@ -128,9 +150,9 @@ All other servers (Config, Data, Utilities, Playbook) currently have only readOn
   * `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default: 5)
   * `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
 * Stale caller rate-limit data is cleaned up periodically (reuse existing cleanup pattern)
-* Unit tests cover: both limit types, sliding window behavior, cross-server shared state,
-  read-only exemption, hybrid identity (auth token + session fallback), error messages,
-  configuration overrides, stale cleanup
+* Unit tests cover: both limit types, sliding window behavior, two-phase gate (dry-run excluded,
+  failures excluded), cross-server shared state, hybrid identity (auth token + session fallback),
+  error messages, configuration overrides, stale cleanup
 * Logging: rate limit events logged with masked caller ID, action name, and current count
 
 ---
@@ -162,6 +184,15 @@ Rate limits tracked per caller using hybrid approach:
 `create_new_studio_attack`, `run_studio_attack`, `set_studio_attack_status`,
 `run_scenario`, `manage_test`. All other servers currently read-only.
 
+### Two-Phase Gate Pattern
+Rate limiting uses check-then-commit with per-tool placement:
+* **`check_limit(caller_id, tool_name)`**: called before real work. Rejects if limit exceeded.
+  Does NOT increment counter.
+* **`record_action(caller_id, tool_name)`**: called after action truly applied. Increments only
+  on successful, non-dry-run execution.
+* Dry-run and failed invocations do NOT count toward limits.
+* Each write tool reviewed for correct gate placement.
+
 ### Functional Requirements
 1. Two independent sliding-window counters per caller:
    * **Total actions count**: all non-readOnly tool calls — default limit: 10 per 30 minutes
@@ -178,21 +209,23 @@ Rate limits tracked per caller using hybrid approach:
 * `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
 
 ### Affected Areas
-* `safebreach_mcp_core/` — new `rate_limiter.py` module + `safebreach_base.py` integration
+* `safebreach_mcp_core/` — new `rate_limiter.py` module (check_limit + record_action API)
 * `safebreach_mcp_core/token_context.py` — caller identity extraction
-* All 5 server modules — rate limiter in middleware stack
+* Each write tool in Studio server — per-tool gate placement (7 tools)
 ```
 
 **Acceptance Criteria:**
 ```markdown
-* Two independent sliding-window limits enforced per caller (total actions + per-tool-name)
+* Two-phase gate: `check_limit` (pre-check, no increment) + `record_action` (post-success increment)
+* Dry-run and failed invocations do NOT count toward limits
+* Per-tool gate placement in each write tool's code
+* Two independent sliding-window limits per caller (total actions + per-tool-name)
 * Hybrid caller identity: auth token hash (external) / session ID (localhost)
-* Read-only tools exempt via `readOnlyHint` annotation
 * Cross-server shared state (all 5 servers share rate limit counters)
-* Rate limiter installed on all servers
 * Clear error message on limit exceeded
 * Configurable via environment variables (limits + window duration)
 * Stale caller data cleanup (reuse existing pattern)
-* Unit tests for both limits, sliding window, cross-server, identity, exemption, errors, config, cleanup
+* Unit tests: both limits, sliding window, two-phase gate, dry-run excluded, failures excluded,
+  cross-server, identity, errors, config, cleanup
 * Logging with masked caller ID
 ```

--- a/prds/SAF-29871-actions-rate-limit/summary.md
+++ b/prds/SAF-29871-actions-rate-limit/summary.md
@@ -1,0 +1,198 @@
+# Ticket Summary: SAF-29871
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repository**: safebreach-mcp
+
+---
+
+## Current State
+**Summary**: MCP: Limit the rate of repeated actions
+**Issues Identified**: Ticket has functional requirements but lacks technical context,
+acceptance criteria, and definition of done.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- All 5 MCP servers inherit from `SafeBreachMCPBase` and share core middleware
+- Existing concurrency limiter (`_create_concurrency_limited_app()`) provides the exact pattern
+  to reuse: per-session tracking, stale cleanup, HTTP 429 responses
+- Session IDs tracked via `_mcp_session_id` ContextVar (SSE UUID / streamable-http header)
+- Tool annotations (`readOnlyHint`, `destructiveHint`) already classify tools
+- Currently only Studio server has non-readOnly tools (7 tools), all other servers are read-only
+- All servers run in same process via `MultiServerLauncher` — module-level dicts enable
+  cross-server shared state without external storage
+- Relevant files:
+  - `safebreach_mcp_core/safebreach_base.py` (concurrency limiter, session tracking)
+  - `safebreach_mcp_core/safebreach_cache.py` (TTL cache pattern)
+  - `safebreach_mcp_core/token_context.py` (per-session auth artifacts)
+  - `safebreach_mcp_studio/studio_server.py` (write tools with annotations)
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The MCP servers have no rate limiting on tool invocations. A malicious or misconfigured MCP client
+could repeatedly call write operations (run tests, manage tests, publish attacks, create drafts)
+without restriction, causing operational damage before detection.
+
+### Impact Assessment
+- **Security**: Unrestricted write operations could be exploited to run mass tests, cancel running
+  tests, or publish untested attacks
+- **Operational**: Without rate limiting, a single client could overwhelm SafeBreach environments
+  with test executions
+
+### Risks & Edge Cases
+- ASGI middleware doesn't have visibility into MCP tool names — interception must happen at the
+  MCP SDK level (tool call wrapper or middleware hook)
+- Sliding window implementation must be thread-safe (asyncio Lock or threading Lock) since all
+  servers share the same process
+- Session cleanup must handle abrupt disconnections
+- Rate limits should reset cleanly when the sliding window advances
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+MCP: Implement per-caller rate limiting for write operations
+
+### Description
+
+**Background**
+As part of the MCP safety guardrails, we need to limit the rate at which actions (non-readOnly
+tool calls) can be performed. This prevents misuse through repetitive requests and allows
+identification of suspicious activity.
+
+**Technical Context**
+* All 5 MCP servers share `SafeBreachMCPBase` with existing concurrency limiter infrastructure
+* Tool annotations (`readOnlyHint`) already classify tools as read-only vs write operations
+* `token_context.py` provides `get_cache_user_suffix()` — SHA256 hash of auth token for identity
+* All servers run in the same process — module-level shared state enables cross-server rate limiting
+* Existing patterns: per-session semaphores, 10-min cleanup tasks, HTTP 429 responses
+
+**Caller Identity (Hybrid Approach)**
+Rate limits are tracked per caller identity using a hybrid approach:
+* **External connections**: identity = SHA256 hash of auth token (from `get_cache_user_suffix()`)
+  — survives reconnection, tied to real user identity
+* **Localhost connections**: identity = transport session ID (from `_mcp_session_id`)
+  — fallback for dev environments where auth is bypassed
+This prevents rate limit bypass via session reconnection for external clients.
+
+**Current Write Tools (non-readOnly)**
+7 tools in Studio server are currently classified as write operations:
+1. `save_studio_attack_draft` — create draft (mutating)
+2. `update_studio_attack_draft` — edit draft (mutating)
+3. `create_new_studio_attack` — create attack (mutating)
+4. `run_studio_attack` — execute attack (destructive)
+5. `set_studio_attack_status` — publish attack (destructive)
+6. `run_scenario` — execute scenario test (destructive)
+7. `manage_test` — pause/resume/cancel test (destructive)
+
+All other servers (Config, Data, Utilities, Playbook) currently have only readOnly tools.
+
+**Problem Description**
+* Currently no rate limiting exists on MCP tool invocations
+* A client can call write tools without any frequency restriction
+* Need two independent sliding-window counters per caller:
+  1. Total actions count (all non-readOnly calls) — default limit: 10 per 30 minutes
+  2. Per-action-name count (same tool name) — default limit: 5 per 30 minutes
+* Rate limiting must be cross-server (shared state across all 5 servers)
+* Rate limiter installed on all servers (future-proofing for when other servers add write tools)
+
+**Affected Areas**
+* `safebreach_mcp_core/` — new `rate_limiter.py` module + integration into `safebreach_base.py`
+* `safebreach_mcp_core/token_context.py` — caller identity extraction
+* All 5 server modules — rate limiter installed in middleware stack
+
+### Acceptance Criteria
+
+* A new `rate_limiter.py` module in `safebreach_mcp_core/` implements sliding-window rate limiting
+* Two independent limits enforced per caller identity:
+  * Total non-readOnly tool calls limited to configurable max (default: 10) within a sliding window
+  * Per-tool-name non-readOnly calls limited to configurable max (default: 5) within the same window
+* Caller identity uses hybrid approach: auth token hash for external connections, session ID
+  for localhost connections
+* Sliding window duration is configurable (default: 30 minutes)
+* Rate limiter uses tool annotations (`readOnlyHint`) to classify tools — read-only tools are exempt
+* Rate limiting state is shared across all 5 servers (cross-server enforcement)
+* Rate limiter is installed on all servers regardless of current tool classification
+* When a limit is exceeded, the client receives a clear error message:
+  "You exceeded the allowed rate of actions. Please try again in a few minutes."
+* Configuration via environment variables:
+  * `SAFEBREACH_MCP_ACTION_LIMIT` (default: 10)
+  * `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default: 5)
+  * `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
+* Stale caller rate-limit data is cleaned up periodically (reuse existing cleanup pattern)
+* Unit tests cover: both limit types, sliding window behavior, cross-server shared state,
+  read-only exemption, hybrid identity (auth token + session fallback), error messages,
+  configuration overrides, stale cleanup
+* Logging: rate limit events logged with masked caller ID, action name, and current count
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+As part of the MCP safety guardrails, we need to limit the rate at which actions
+(non-readOnly tool calls) can be performed. This prevents misuse through repetitive
+requests and allows identification of suspicious activity.
+
+### Technical Context
+* All 5 MCP servers share `SafeBreachMCPBase` with existing concurrency limiter infrastructure
+* Tool annotations (`readOnlyHint`) already classify tools as read-only vs write operations
+* `token_context.py` provides auth token hash for caller identity
+* All servers run in the same process — module-level shared state enables cross-server rate limiting
+
+### Caller Identity
+Rate limits tracked per caller using hybrid approach:
+* **External connections**: SHA256 hash of auth token (survives reconnection)
+* **Localhost connections**: transport session ID (fallback for dev environments)
+
+### Current Write Tools
+7 tools in Studio server: `save_studio_attack_draft`, `update_studio_attack_draft`,
+`create_new_studio_attack`, `run_studio_attack`, `set_studio_attack_status`,
+`run_scenario`, `manage_test`. All other servers currently read-only.
+
+### Functional Requirements
+1. Two independent sliding-window counters per caller:
+   * **Total actions count**: all non-readOnly tool calls — default limit: 10 per 30 minutes
+   * **Per-action-name count**: same tool name — default limit: 5 per 30 minutes
+2. Sliding window duration: configurable (default: 30 minutes)
+3. Rate limiting is cross-server (shared state across all 5 servers)
+4. Rate limiter installed on all servers (future-proofing)
+5. Clear error message when limit exceeded:
+   "You exceeded the allowed rate of actions. Please try again in a few minutes."
+
+### Configuration
+* `SAFEBREACH_MCP_ACTION_LIMIT` (default: 10)
+* `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` (default: 5)
+* `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` (default: 30)
+
+### Affected Areas
+* `safebreach_mcp_core/` — new `rate_limiter.py` module + `safebreach_base.py` integration
+* `safebreach_mcp_core/token_context.py` — caller identity extraction
+* All 5 server modules — rate limiter in middleware stack
+```
+
+**Acceptance Criteria:**
+```markdown
+* Two independent sliding-window limits enforced per caller (total actions + per-tool-name)
+* Hybrid caller identity: auth token hash (external) / session ID (localhost)
+* Read-only tools exempt via `readOnlyHint` annotation
+* Cross-server shared state (all 5 servers share rate limit counters)
+* Rate limiter installed on all servers
+* Clear error message on limit exceeded
+* Configurable via environment variables (limits + window duration)
+* Stale caller data cleanup (reuse existing pattern)
+* Unit tests for both limits, sliding window, cross-server, identity, exemption, errors, config, cleanup
+* Logging with masked caller ID
+```

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -8,6 +8,7 @@ Two-phase gate pattern:
 Cross-server shared state via module-level dict (all servers in same process).
 """
 
+import hashlib
 import logging
 import math
 import os
@@ -18,7 +19,9 @@ from typing import Dict, List
 from mcp.server.fastmcp.exceptions import ToolError
 
 from safebreach_mcp_core.token_context import (
+    _get_auth_from_mcp_request_ctx,
     _get_session_id_from_mcp_ctx,
+    _user_auth_artifacts,
 )
 
 logger = logging.getLogger(__name__)
@@ -146,8 +149,29 @@ def get_caller_identity() -> str:
     """
     Hybrid caller identification.
 
-    Phase 1: session ID only. Auth token hash added in Phase 5.
+    Priority: auth token hash (survives reconnection) > session ID > anonymous.
+    Auth token priority: x-apitoken > x-token > cookie value.
     """
+    # Try auth artifacts — ContextVar first, MCP request context fallback
+    bundle = _user_auth_artifacts.get()
+    if not bundle:
+        bundle = _get_auth_from_mcp_request_ctx()
+
+    if bundle:
+        # Priority: x-apitoken > x-token > cookie value
+        value = bundle.get("x-apitoken")
+        if not value:
+            value = bundle.get("x-token")
+        if not value:
+            cookie = bundle.get("cookie", "")
+            if "=" in cookie:
+                value = cookie.split("=", 1)[1]
+        if value:
+            identity = hashlib.sha256(value.encode()).hexdigest()[:16]
+            logger.debug("Caller identity from auth token: %s...", identity[:8])
+            return identity
+
+    # Fallback: session ID
     session_id = _get_session_id_from_mcp_ctx()
     if session_id:
         logger.debug("Caller identity from session: %s...", session_id[:8])

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -91,6 +91,22 @@ class RateLimiter:
                 f"Try again in {retry_after} seconds."
             )
 
+        # Per-tool-name limit
+        tool_actions = data.per_tool_actions.get(tool_name, [])
+        tool_actions = self._prune(tool_actions, now)
+        data.per_tool_actions[tool_name] = tool_actions
+
+        tool_count = len(tool_actions)
+        if tool_count >= _identical_action_limit:
+            oldest = tool_actions[0]
+            retry_after = math.ceil(_window_seconds - (now - oldest))
+            raise ToolError(
+                f"Rate limit exceeded: {tool_name} "
+                f"({tool_count}/{_identical_action_limit} in last "
+                f"{_window_seconds // 60} min). "
+                f"Try again in {retry_after} seconds."
+            )
+
     def record_action(self, caller_id: str, tool_name: str) -> None:
         """Post-success: increment counters after action truly applied."""
         if not _rate_limit_enabled:

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -1,0 +1,141 @@
+"""
+Per-caller rate limiting for MCP write operations.
+
+Two-phase gate pattern:
+  - check_limit(caller_id, tool_name): pre-check, raises ToolError if exceeded
+  - record_action(caller_id, tool_name): post-success increment
+
+Cross-server shared state via module-level dict (all servers in same process).
+"""
+
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from safebreach_mcp_core.token_context import (
+    _get_session_id_from_mcp_ctx,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration (read at module load, patchable in tests)
+# ---------------------------------------------------------------------------
+_rate_limit_enabled: bool = os.environ.get(
+    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "true"
+).strip().lower() in ("true", "1", "yes")
+
+_action_limit: int = int(os.environ.get("SAFEBREACH_MCP_ACTION_LIMIT", "10"))
+
+_identical_action_limit: int = int(
+    os.environ.get("SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT", "5")
+)
+
+_window_seconds: int = (
+    int(os.environ.get("SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES", "30")) * 60
+)
+
+# ---------------------------------------------------------------------------
+# Shared state (cross-server via module-level dict)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CallerRateLimitData:
+    total_actions: List[float] = field(default_factory=list)
+    per_tool_actions: Dict[str, List[float]] = field(default_factory=dict)
+    last_activity: float = 0.0
+
+
+_rate_limit_store: Dict[str, CallerRateLimitData] = {}
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter
+# ---------------------------------------------------------------------------
+class RateLimiter:
+    """Sliding-window rate limiter with two-phase gate API."""
+
+    def _prune(self, timestamps: List[float], now: float) -> List[float]:
+        """Remove timestamps older than the sliding window."""
+        cutoff = now - _window_seconds
+        return [t for t in timestamps if t > cutoff]
+
+    def check_limit(self, caller_id: str, tool_name: str) -> None:
+        """Pre-check: verify counts are below limits. Raises ToolError if exceeded."""
+        if not _rate_limit_enabled:
+            return
+
+        data = _rate_limit_store.get(caller_id)
+        if data is None:
+            return  # no actions recorded yet
+
+        now = time.time()
+
+        # Prune and update in-place
+        data.total_actions = self._prune(data.total_actions, now)
+
+        total_count = len(data.total_actions)
+        if total_count >= _action_limit:
+            oldest = data.total_actions[0]
+            retry_after = math.ceil(_window_seconds - (now - oldest))
+            raise ToolError(
+                f"Rate limit exceeded: total actions "
+                f"({total_count}/{_action_limit} in last "
+                f"{_window_seconds // 60} min). "
+                f"Try again in {retry_after} seconds."
+            )
+
+    def record_action(self, caller_id: str, tool_name: str) -> None:
+        """Post-success: increment counters after action truly applied."""
+        if not _rate_limit_enabled:
+            return
+
+        now = time.time()
+        data = _rate_limit_store.get(caller_id)
+        if data is None:
+            data = CallerRateLimitData()
+            _rate_limit_store[caller_id] = data
+
+        data.total_actions.append(now)
+
+        if tool_name not in data.per_tool_actions:
+            data.per_tool_actions[tool_name] = []
+        data.per_tool_actions[tool_name].append(now)
+
+        data.last_activity = now
+
+        logger.info(
+            "Rate limit recorded: caller=%s... tool=%s total=%d per_tool=%d",
+            caller_id[:8],
+            tool_name,
+            len(data.total_actions),
+            len(data.per_tool_actions[tool_name]),
+        )
+
+
+# Module-level singleton
+rate_limiter = RateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# Caller identity helper
+# ---------------------------------------------------------------------------
+def get_caller_identity() -> str:
+    """
+    Hybrid caller identification.
+
+    Phase 1: session ID only. Auth token hash added in Phase 5.
+    """
+    session_id = _get_session_id_from_mcp_ctx()
+    if session_id:
+        logger.debug("Caller identity from session: %s...", session_id[:8])
+        return session_id
+
+    logger.debug("Caller identity: anonymous (no session)")
+    return "anonymous"

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -8,14 +8,13 @@ Two-phase gate pattern:
 Cross-server shared state via module-level dict (all servers in same process).
 """
 
-import asyncio
 import hashlib
 import logging
 import math
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from mcp.server.fastmcp.exceptions import ToolError
 
@@ -180,57 +179,3 @@ def get_caller_identity() -> str:
 
     logger.debug("Caller identity: anonymous (no session)")
     return "anonymous"
-
-
-# ---------------------------------------------------------------------------
-# Stale entry cleanup
-# ---------------------------------------------------------------------------
-_STALE_TTL = 3600  # 1 hour — matches existing semaphore cleanup TTL
-_CLEANUP_INTERVAL = 600  # 10 minutes
-
-
-def cleanup_stale_rate_limits() -> int:
-    """Remove caller entries with no activity within the TTL period.
-
-    Returns the number of evicted entries.
-    """
-    now = time.time()
-    stale = [
-        caller_id
-        for caller_id, data in _rate_limit_store.items()
-        if (now - data.last_activity) > _STALE_TTL
-    ]
-    for caller_id in stale:
-        del _rate_limit_store[caller_id]
-    if stale:
-        logger.info(
-            "🧹 Rate limit cleanup: evicted %d stale caller(s), %d remaining",
-            len(stale),
-            len(_rate_limit_store),
-        )
-    return len(stale)
-
-
-_cleanup_started: bool = False
-_cleanup_task: Optional[asyncio.Task] = None
-
-
-async def _cleanup_loop() -> None:
-    """Background loop that periodically evicts stale rate limit entries."""
-    while True:
-        await asyncio.sleep(_CLEANUP_INTERVAL)
-        try:
-            cleanup_stale_rate_limits()
-        except Exception:
-            logger.exception("Rate limit cleanup error")
-
-
-def start_rate_limit_cleanup() -> asyncio.Task:
-    """Start the background cleanup task (singleton — idempotent)."""
-    global _cleanup_started, _cleanup_task
-    if not _cleanup_started:
-        _cleanup_task = asyncio.create_task(_cleanup_loop())
-        _cleanup_started = True
-        logger.info("🧹 Rate limit cleanup task started (interval=%ds, TTL=%ds)",
-                     _CLEANUP_INTERVAL, _STALE_TTL)
-    return _cleanup_task

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -8,13 +8,14 @@ Two-phase gate pattern:
 Cross-server shared state via module-level dict (all servers in same process).
 """
 
+import asyncio
 import hashlib
 import logging
 import math
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mcp.server.fastmcp.exceptions import ToolError
 
@@ -179,3 +180,57 @@ def get_caller_identity() -> str:
 
     logger.debug("Caller identity: anonymous (no session)")
     return "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Stale entry cleanup
+# ---------------------------------------------------------------------------
+_STALE_TTL = 3600  # 1 hour — matches existing semaphore cleanup TTL
+_CLEANUP_INTERVAL = 600  # 10 minutes
+
+
+def cleanup_stale_rate_limits() -> int:
+    """Remove caller entries with no activity within the TTL period.
+
+    Returns the number of evicted entries.
+    """
+    now = time.time()
+    stale = [
+        caller_id
+        for caller_id, data in _rate_limit_store.items()
+        if (now - data.last_activity) > _STALE_TTL
+    ]
+    for caller_id in stale:
+        del _rate_limit_store[caller_id]
+    if stale:
+        logger.info(
+            "🧹 Rate limit cleanup: evicted %d stale caller(s), %d remaining",
+            len(stale),
+            len(_rate_limit_store),
+        )
+    return len(stale)
+
+
+_cleanup_started: bool = False
+_cleanup_task: Optional[asyncio.Task] = None
+
+
+async def _cleanup_loop() -> None:
+    """Background loop that periodically evicts stale rate limit entries."""
+    while True:
+        await asyncio.sleep(_CLEANUP_INTERVAL)
+        try:
+            cleanup_stale_rate_limits()
+        except Exception:
+            logger.exception("Rate limit cleanup error")
+
+
+def start_rate_limit_cleanup() -> asyncio.Task:
+    """Start the background cleanup task (singleton — idempotent)."""
+    global _cleanup_started, _cleanup_task
+    if not _cleanup_started:
+        _cleanup_task = asyncio.create_task(_cleanup_loop())
+        _cleanup_started = True
+        logger.info("🧹 Rate limit cleanup task started (interval=%ds, TTL=%ds)",
+                     _CLEANUP_INTERVAL, _STALE_TTL)
+    return _cleanup_task

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -256,8 +256,6 @@ class SafeBreachMCPBase:
         # Start background tasks
         cleanup_task = asyncio.create_task(_cleanup_stale_semaphores())
         monitoring_task = asyncio.create_task(start_cache_monitoring())
-        from safebreach_mcp_core.rate_limiter import start_rate_limit_cleanup
-        rate_limit_cleanup_task = start_rate_limit_cleanup()
 
         config = uvicorn.Config(app=app, host=bind_host, port=port, log_level="info",
                                 timeout_graceful_shutdown=3)
@@ -269,7 +267,6 @@ class SafeBreachMCPBase:
             self._uvicorn_server = None
             cleanup_task.cancel()
             monitoring_task.cancel()
-            rate_limit_cleanup_task.cancel()
     
     def _determine_bind_host(self, host: str, allow_external: bool) -> str:
         """Determine the appropriate bind host based on configuration."""

--- a/safebreach_mcp_core/safebreach_base.py
+++ b/safebreach_mcp_core/safebreach_base.py
@@ -256,6 +256,8 @@ class SafeBreachMCPBase:
         # Start background tasks
         cleanup_task = asyncio.create_task(_cleanup_stale_semaphores())
         monitoring_task = asyncio.create_task(start_cache_monitoring())
+        from safebreach_mcp_core.rate_limiter import start_rate_limit_cleanup
+        rate_limit_cleanup_task = start_rate_limit_cleanup()
 
         config = uvicorn.Config(app=app, host=bind_host, port=port, log_level="info",
                                 timeout_graceful_shutdown=3)
@@ -267,6 +269,7 @@ class SafeBreachMCPBase:
             self._uvicorn_server = None
             cleanup_task.cancel()
             monitoring_task.cancel()
+            rate_limit_cleanup_task.cancel()
     
     def _determine_bind_host(self, host: str, allow_external: bool) -> str:
         """Determine the appropriate bind host based on configuration."""

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -215,16 +215,134 @@ class TestPerToolNameLimit:
 # get_caller_identity
 # ---------------------------------------------------------------------------
 class TestGetCallerIdentity:
+    """Hybrid caller identity: auth token hash > session ID > anonymous."""
+
+    # -- Auth token hash (highest priority) --
+
     @patch(
         "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
-        return_value="test-session-123",
+        return_value="session-abc",
     )
-    def test_returns_session_id_when_no_auth(self, _mock_session):
-        assert get_caller_identity() == "test-session-123"
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    def test_returns_apitoken_hash_when_auth_present(
+        self, mock_auth_var, _mock_session
+    ):
+        mock_auth_var.get.return_value = {"x-apitoken": "my-secret-token"}
+        result = get_caller_identity()
+        # Should be SHA256[:16] of "my-secret-token", NOT the session ID
+        import hashlib
+        expected = hashlib.sha256("my-secret-token".encode()).hexdigest()[:16]
+        assert result == expected
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value="session-abc",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    def test_x_token_fallback_when_no_apitoken(self, mock_auth_var, _mock_session):
+        mock_auth_var.get.return_value = {"x-token": "x-token-value"}
+        import hashlib
+        expected = hashlib.sha256("x-token-value".encode()).hexdigest()[:16]
+        assert get_caller_identity() == expected
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value="session-abc",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    def test_cookie_fallback_when_no_tokens(self, mock_auth_var, _mock_session):
+        mock_auth_var.get.return_value = {"cookie": "X-Token=cookie-secret"}
+        import hashlib
+        expected = hashlib.sha256("cookie-secret".encode()).hexdigest()[:16]
+        assert get_caller_identity() == expected
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value="session-abc",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    def test_priority_apitoken_over_x_token(self, mock_auth_var, _mock_session):
+        """x-apitoken wins over x-token when both present."""
+        mock_auth_var.get.return_value = {
+            "x-apitoken": "apitoken-val",
+            "x-token": "xtoken-val",
+        }
+        import hashlib
+        expected = hashlib.sha256("apitoken-val".encode()).hexdigest()[:16]
+        assert get_caller_identity() == expected
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    def test_hash_is_stable(self, mock_auth_var):
+        """Same token always produces the same identity."""
+        mock_auth_var.get.return_value = {"x-apitoken": "stable-token"}
+        first = get_caller_identity()
+        second = get_caller_identity()
+        assert first == second
 
     @patch(
         "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
         return_value=None,
     )
-    def test_returns_anonymous_when_neither_available(self, _mock_session):
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_auth_from_mcp_request_ctx",
+        return_value={"x-apitoken": "from-request-ctx"},
+    )
+    def test_mcp_request_ctx_fallback(
+        self, _mock_req_ctx, mock_auth_var, _mock_session
+    ):
+        """Falls back to _get_auth_from_mcp_request_ctx when ContextVar is empty."""
+        mock_auth_var.get.return_value = None
+        import hashlib
+        expected = hashlib.sha256("from-request-ctx".encode()).hexdigest()[:16]
+        assert get_caller_identity() == expected
+
+    # -- Session ID fallback --
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value="test-session-123",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_auth_from_mcp_request_ctx",
+        return_value=None,
+    )
+    def test_returns_session_id_when_no_auth(
+        self, _mock_req_ctx, mock_auth_var, _mock_session
+    ):
+        mock_auth_var.get.return_value = None
+        assert get_caller_identity() == "test-session-123"
+
+    # -- Anonymous fallback --
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value=None,
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._user_auth_artifacts",
+    )
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_auth_from_mcp_request_ctx",
+        return_value=None,
+    )
+    def test_returns_anonymous_when_neither_available(
+        self, _mock_req_ctx, mock_auth_var, _mock_session
+    ):
+        mock_auth_var.get.return_value = None
         assert get_caller_identity() == "anonymous"

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -32,9 +32,10 @@ class TestCheckLimitBasic:
         limiter.check_limit("caller-1", "manage_test")  # should not raise
 
     def test_check_limit_passes_when_count_below_total_limit(self, limiter):
-        for _ in range(9):
-            limiter.record_action("caller-1", "manage_test")
-        limiter.check_limit("caller-1", "manage_test")  # should not raise
+        # Use different tool names to avoid per-tool limit (5) while testing total (10)
+        for i in range(9):
+            limiter.record_action("caller-1", f"tool_{i}")
+        limiter.check_limit("caller-1", "manage_test")  # 9 < 10, should not raise
 
     def test_check_limit_raises_tool_error_when_total_limit_reached(self, limiter):
         for _ in range(10):
@@ -143,6 +144,68 @@ class TestConfiguration:
         for _ in range(10):
             limiter.record_action("caller-1", "manage_test")
 
+        # Advance past 60s window
+        mock_time.time.return_value = 1061.0
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Per-tool-name limit (Phase 2)
+# ---------------------------------------------------------------------------
+class TestPerToolNameLimit:
+    def test_check_limit_raises_when_per_tool_limit_reached(self, limiter):
+        for _ in range(5):
+            limiter.record_action("caller-1", "manage_test")
+        with pytest.raises(ToolError, match="manage_test"):
+            limiter.check_limit("caller-1", "manage_test")
+
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_error_message_contains_tool_name_and_retry_after(
+        self, mock_time, limiter
+    ):
+        mock_time.time.return_value = 1000.0
+        for _ in range(5):
+            limiter.record_action("caller-1", "manage_test")
+
+        mock_time.time.return_value = 1100.0  # 100s later
+        # retry_after = 1800 - (1100 - 1000) = 1700
+        with pytest.raises(ToolError, match="manage_test") as exc_info:
+            limiter.check_limit("caller-1", "manage_test")
+        error_msg = str(exc_info.value)
+        assert "5/5" in error_msg
+        assert "1700" in error_msg
+
+    def test_per_tool_limit_independent_from_total(self, limiter):
+        """Hit per-tool limit (5) before total limit (10)."""
+        for _ in range(5):
+            limiter.record_action("caller-1", "manage_test")
+        # Per-tool at 5/5, total at 5/10
+        with pytest.raises(ToolError, match="manage_test"):
+            limiter.check_limit("caller-1", "manage_test")
+
+    def test_multiple_tool_names_tracked_independently(self, limiter):
+        for _ in range(4):
+            limiter.record_action("caller-1", "manage_test")
+        for _ in range(4):
+            limiter.record_action("caller-1", "run_scenario")
+        # Both tools at 4, below per-tool limit of 5
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+        limiter.check_limit("caller-1", "run_scenario")  # should not raise
+
+    @patch("safebreach_mcp_core.rate_limiter._identical_action_limit", 2)
+    def test_custom_identical_action_limit(self, limiter):
+        limiter.record_action("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")  # 1 < 2, should pass
+        limiter.record_action("caller-1", "manage_test")  # now 2
+        with pytest.raises(ToolError):
+            limiter.check_limit("caller-1", "manage_test")
+
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_per_tool_window_pruning(self, mock_time, limiter):
+        mock_time.time.return_value = 1000.0
+        for _ in range(5):
+            limiter.record_action("caller-1", "manage_test")
         # Advance past 60s window
         mock_time.time.return_value = 1061.0
         limiter.check_limit("caller-1", "manage_test")  # should not raise

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -1,4 +1,6 @@
-"""Unit tests for rate_limiter module — Phase 1: total action limit + get_caller_identity."""
+"""Unit tests for rate_limiter module."""
+
+import asyncio
 
 import pytest
 from unittest.mock import patch
@@ -8,6 +10,8 @@ from safebreach_mcp_core.rate_limiter import (
     RateLimiter,
     get_caller_identity,
     _rate_limit_store,
+    cleanup_stale_rate_limits,
+    start_rate_limit_cleanup,
 )
 
 
@@ -346,3 +350,67 @@ class TestGetCallerIdentity:
     ):
         mock_auth_var.get.return_value = None
         assert get_caller_identity() == "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Stale entry cleanup
+# ---------------------------------------------------------------------------
+class TestCleanupStaleRateLimits:
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_stale_entries_removed(self, mock_time, limiter):
+        """Entries with last_activity older than TTL are evicted."""
+        mock_time.time.return_value = 1000.0
+        limiter.record_action("stale-caller", "manage_test")
+
+        # Advance past 1-hour TTL (3600s)
+        mock_time.time.return_value = 1000.0 + 3601.0
+        removed = cleanup_stale_rate_limits()
+        assert removed == 1
+        assert "stale-caller" not in _rate_limit_store
+
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_recent_entries_preserved(self, mock_time, limiter):
+        """Entries with recent activity are kept."""
+        mock_time.time.return_value = 1000.0
+        limiter.record_action("active-caller", "manage_test")
+
+        # Only 100s later — well within TTL
+        mock_time.time.return_value = 1100.0
+        removed = cleanup_stale_rate_limits()
+        assert removed == 0
+        assert "active-caller" in _rate_limit_store
+
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_mixed_callers_only_stale_removed(self, mock_time, limiter):
+        """Only stale callers removed; active ones kept."""
+        mock_time.time.return_value = 1000.0
+        limiter.record_action("old-caller", "manage_test")
+
+        mock_time.time.return_value = 5000.0
+        limiter.record_action("new-caller", "manage_test")
+
+        # At t=5000, old-caller last_activity=1000 (4000s ago > 3600 TTL)
+        removed = cleanup_stale_rate_limits()
+        assert removed == 1
+        assert "old-caller" not in _rate_limit_store
+        assert "new-caller" in _rate_limit_store
+
+
+class TestStartRateLimitCleanup:
+    @pytest.fixture(autouse=True)
+    def reset_cleanup_flag(self):
+        """Reset the singleton flag between tests."""
+        import safebreach_mcp_core.rate_limiter as rl
+        rl._cleanup_started = False
+        yield
+        rl._cleanup_started = False
+
+    def test_singleton_only_starts_once(self):
+        """Calling start_rate_limit_cleanup() twice returns same task."""
+        async def _run():
+            task1 = start_rate_limit_cleanup()
+            task2 = start_rate_limit_cleanup()
+            assert task1 is task2
+            task1.cancel()
+
+        asyncio.run(_run())

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -1,0 +1,167 @@
+"""Unit tests for rate_limiter module — Phase 1: total action limit + get_caller_identity."""
+
+import pytest
+from unittest.mock import patch
+
+from mcp.server.fastmcp.exceptions import ToolError
+from safebreach_mcp_core.rate_limiter import (
+    RateLimiter,
+    get_caller_identity,
+    _rate_limit_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Clear shared rate limit state between tests."""
+    _rate_limit_store.clear()
+    yield
+    _rate_limit_store.clear()
+
+
+@pytest.fixture
+def limiter():
+    return RateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# check_limit basics
+# ---------------------------------------------------------------------------
+class TestCheckLimitBasic:
+    def test_check_limit_passes_when_count_is_zero(self, limiter):
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+
+    def test_check_limit_passes_when_count_below_total_limit(self, limiter):
+        for _ in range(9):
+            limiter.record_action("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+
+    def test_check_limit_raises_tool_error_when_total_limit_reached(self, limiter):
+        for _ in range(10):
+            limiter.record_action("caller-1", "manage_test")
+        with pytest.raises(ToolError):
+            limiter.check_limit("caller-1", "manage_test")
+
+    def test_check_limit_does_not_increment_counters(self, limiter):
+        limiter.record_action("caller-1", "manage_test")  # 1 action
+        limiter.check_limit("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")
+        assert len(_rate_limit_store["caller-1"].total_actions) == 1
+
+
+# ---------------------------------------------------------------------------
+# record_action
+# ---------------------------------------------------------------------------
+class TestRecordAction:
+    def test_record_action_increments_total_count(self, limiter):
+        for _ in range(3):
+            limiter.record_action("caller-1", "manage_test")
+        assert len(_rate_limit_store["caller-1"].total_actions) == 3
+
+
+# ---------------------------------------------------------------------------
+# Sliding window
+# ---------------------------------------------------------------------------
+class TestSlidingWindow:
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_sliding_window_prunes_expired_actions(self, mock_time, limiter):
+        mock_time.time.return_value = 1000.0
+        for _ in range(10):
+            limiter.record_action("caller-1", "manage_test")
+
+        # Advance past default 30-min window (1800s)
+        mock_time.time.return_value = 1000.0 + 1801.0
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+        assert len(_rate_limit_store["caller-1"].total_actions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Error message content
+# ---------------------------------------------------------------------------
+class TestErrorMessage:
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_error_message_contains_total_actions_and_retry_after(
+        self, mock_time, limiter
+    ):
+        mock_time.time.return_value = 1000.0
+        for _ in range(10):
+            limiter.record_action("caller-1", "manage_test")
+
+        # 100s later — retry_after = 1800 - (1100 - 1000) = 1700
+        mock_time.time.return_value = 1100.0
+        with pytest.raises(ToolError, match="total actions") as exc_info:
+            limiter.check_limit("caller-1", "manage_test")
+
+        error_msg = str(exc_info.value)
+        assert "10/10" in error_msg
+        assert "1700" in error_msg
+
+
+# ---------------------------------------------------------------------------
+# Multiple callers
+# ---------------------------------------------------------------------------
+class TestMultipleCallers:
+    def test_multiple_callers_are_independent(self, limiter):
+        for _ in range(10):
+            limiter.record_action("caller-a", "manage_test")
+        with pytest.raises(ToolError):
+            limiter.check_limit("caller-a", "manage_test")
+        # caller-b should be unaffected
+        limiter.check_limit("caller-b", "manage_test")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+class TestConfiguration:
+    @patch("safebreach_mcp_core.rate_limiter._rate_limit_enabled", False)
+    def test_disabled_check_limit_passes(self, limiter):
+        for _ in range(15):
+            limiter.record_action("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+
+    @patch("safebreach_mcp_core.rate_limiter._rate_limit_enabled", False)
+    def test_disabled_record_action_is_noop(self, limiter):
+        limiter.record_action("caller-1", "manage_test")
+        assert "caller-1" not in _rate_limit_store
+
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 3)
+    def test_custom_action_limit(self, limiter):
+        for _ in range(2):
+            limiter.record_action("caller-1", "manage_test")
+        limiter.check_limit("caller-1", "manage_test")  # 2 < 3, should pass
+
+        limiter.record_action("caller-1", "manage_test")  # now 3
+        with pytest.raises(ToolError):
+            limiter.check_limit("caller-1", "manage_test")
+
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    @patch("safebreach_mcp_core.rate_limiter.time")
+    def test_custom_window(self, mock_time, limiter):
+        mock_time.time.return_value = 1000.0
+        for _ in range(10):
+            limiter.record_action("caller-1", "manage_test")
+
+        # Advance past 60s window
+        mock_time.time.return_value = 1061.0
+        limiter.check_limit("caller-1", "manage_test")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# get_caller_identity
+# ---------------------------------------------------------------------------
+class TestGetCallerIdentity:
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value="test-session-123",
+    )
+    def test_returns_session_id_when_no_auth(self, _mock_session):
+        assert get_caller_identity() == "test-session-123"
+
+    @patch(
+        "safebreach_mcp_core.rate_limiter._get_session_id_from_mcp_ctx",
+        return_value=None,
+    )
+    def test_returns_anonymous_when_neither_available(self, _mock_session):
+        assert get_caller_identity() == "anonymous"

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -1,7 +1,5 @@
 """Unit tests for rate_limiter module."""
 
-import asyncio
-
 import pytest
 from unittest.mock import patch
 
@@ -10,8 +8,6 @@ from safebreach_mcp_core.rate_limiter import (
     RateLimiter,
     get_caller_identity,
     _rate_limit_store,
-    cleanup_stale_rate_limits,
-    start_rate_limit_cleanup,
 )
 
 
@@ -350,67 +346,3 @@ class TestGetCallerIdentity:
     ):
         mock_auth_var.get.return_value = None
         assert get_caller_identity() == "anonymous"
-
-
-# ---------------------------------------------------------------------------
-# Stale entry cleanup
-# ---------------------------------------------------------------------------
-class TestCleanupStaleRateLimits:
-    @patch("safebreach_mcp_core.rate_limiter.time")
-    def test_stale_entries_removed(self, mock_time, limiter):
-        """Entries with last_activity older than TTL are evicted."""
-        mock_time.time.return_value = 1000.0
-        limiter.record_action("stale-caller", "manage_test")
-
-        # Advance past 1-hour TTL (3600s)
-        mock_time.time.return_value = 1000.0 + 3601.0
-        removed = cleanup_stale_rate_limits()
-        assert removed == 1
-        assert "stale-caller" not in _rate_limit_store
-
-    @patch("safebreach_mcp_core.rate_limiter.time")
-    def test_recent_entries_preserved(self, mock_time, limiter):
-        """Entries with recent activity are kept."""
-        mock_time.time.return_value = 1000.0
-        limiter.record_action("active-caller", "manage_test")
-
-        # Only 100s later — well within TTL
-        mock_time.time.return_value = 1100.0
-        removed = cleanup_stale_rate_limits()
-        assert removed == 0
-        assert "active-caller" in _rate_limit_store
-
-    @patch("safebreach_mcp_core.rate_limiter.time")
-    def test_mixed_callers_only_stale_removed(self, mock_time, limiter):
-        """Only stale callers removed; active ones kept."""
-        mock_time.time.return_value = 1000.0
-        limiter.record_action("old-caller", "manage_test")
-
-        mock_time.time.return_value = 5000.0
-        limiter.record_action("new-caller", "manage_test")
-
-        # At t=5000, old-caller last_activity=1000 (4000s ago > 3600 TTL)
-        removed = cleanup_stale_rate_limits()
-        assert removed == 1
-        assert "old-caller" not in _rate_limit_store
-        assert "new-caller" in _rate_limit_store
-
-
-class TestStartRateLimitCleanup:
-    @pytest.fixture(autouse=True)
-    def reset_cleanup_flag(self):
-        """Reset the singleton flag between tests."""
-        import safebreach_mcp_core.rate_limiter as rl
-        rl._cleanup_started = False
-        yield
-        rl._cleanup_started = False
-
-    def test_singleton_only_starts_once(self):
-        """Calling start_rate_limit_cleanup() twice returns same task."""
-        async def _run():
-            task1 = start_rate_limit_cleanup()
-            task2 = start_rate_limit_cleanup()
-            assert task1 is task2
-            task1.cancel()
-
-        asyncio.run(_run())

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -17,6 +17,7 @@ from safebreach_mcp_core.safebreach_cache import SafeBreachCache
 from safebreach_mcp_core.secret_utils import get_secret_for_console, get_auth_headers_for_console, check_rbac_response
 from safebreach_mcp_core.token_context import get_cache_user_suffix
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
+from safebreach_mcp_core.rate_limiter import rate_limiter, get_caller_identity
 from .studio_types import (
     get_validation_response_mapping,
     get_draft_response_mapping,
@@ -2649,7 +2650,14 @@ def sb_manage_test(
 
     logger.info(f"Managing test {test_id}: action={action}, console={console}")
 
+    # Rate limiting gate — check before mutating
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "manage_test")
+
     result = _set_test_state(test_id, action, console)
+
+    # Rate limiting gate — record after successful state change
+    rate_limiter.record_action(caller_id, "manage_test")
 
     if reason and reason.strip():
         note_result = _append_test_note(test_id, action, reason, console)

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2480,6 +2480,10 @@ def sb_run_scenario(
     }
     logger.info(f"Calling queue API: {api_url}")
 
+    # Rate limiting gate — check before queuing (after dry_run/not_ready early returns)
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "run_scenario")
+
     try:
         response = requests.post(api_url, headers=headers, params=params, json=payload, timeout=120)
         if response.status_code >= 400:
@@ -2509,6 +2513,9 @@ def sb_run_scenario(
         'empty_steps': empty_steps,
         'status': 'queued',
     }
+
+    # Rate limiting gate — record after successful queue
+    rate_limiter.record_action(caller_id, "run_scenario")
 
     logger.info(
         f"Successfully queued scenario '{scenario['name']}' "

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -637,6 +637,10 @@ def sb_save_studio_attack_draft(
 
     logger.info(f"Saving draft attack '{name}' (type={attack_type}) for console: {console}")
 
+    # Rate limiting gate — check before mutating
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "save_studio_attack_draft")
+
     # Get authentication and base URL
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
@@ -700,6 +704,9 @@ def sb_save_studio_attack_draft(
         cache_key = f"studio_draft_{console}_{result['draft_id']}{get_cache_user_suffix()}"
         studio_draft_cache.set(cache_key, result)
         logger.debug(f"Cached draft with key: {cache_key}")
+
+    # Rate limiting gate — record after successful save
+    rate_limiter.record_action(caller_id, "save_studio_attack_draft")
 
     logger.info(f"Successfully saved draft with ID: {result['draft_id']}")
 
@@ -889,6 +896,10 @@ def sb_update_studio_attack_draft(
 
     logger.info(f"Updating draft attack {attack_id} '{name}' (type={attack_type}) for console: {console}")
 
+    # Rate limiting gate — check before mutating
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "update_studio_attack_draft")
+
     # Get authentication and base URL
     base_url = get_api_base_url(console, 'config')
     account_id = get_api_account_id(console)
@@ -953,6 +964,9 @@ def sb_update_studio_attack_draft(
         cache_key = f"studio_draft_{console}_{result['draft_id']}{get_cache_user_suffix()}"
         studio_draft_cache.set(cache_key, result)
         logger.debug(f"Updated cache with key: {cache_key}")
+
+    # Rate limiting gate — record after successful update
+    rate_limiter.record_action(caller_id, "update_studio_attack_draft")
 
     logger.info(f"Successfully updated draft with ID: {result['draft_id']}")
 
@@ -1098,6 +1112,10 @@ def sb_run_studio_attack(
                 f"targets={len(target_simulator_ids) if target_simulator_ids else 'N/A'}, "
                 f"attackers={len(attacker_simulator_ids) if attacker_simulator_ids else 'N/A'})")
 
+    # Rate limiting gate — check before mutating
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "run_studio_attack")
+
     # Get authentication and base URL
     base_url = get_api_base_url(console, 'orchestrator')
     account_id = get_api_account_id(console)
@@ -1186,6 +1204,9 @@ def sb_run_studio_attack(
         'attack_id': attack_id,
         'status': 'queued',
     }
+
+    # Rate limiting gate — record after successful queue
+    rate_limiter.record_action(caller_id, "run_studio_attack")
 
     logger.info(f"Successfully queued attack {attack_id} for execution "
                 f"(test_id: {result['test_id']}, step_run_id: {result['step_run_id']})")
@@ -1508,6 +1529,10 @@ def sb_set_studio_attack_status(
 
     old_status = current_status
 
+    # Rate limiting gate — check AFTER pre-check reads, before mutating PUT
+    caller_id = get_caller_identity()
+    rate_limiter.check_limit(caller_id, "set_studio_attack_status")
+
     # Fetch source code files needed for the PUT payload
     # Target file (always required)
     target_url = (
@@ -1616,6 +1641,9 @@ def sb_set_studio_attack_status(
     cache_key = f"studio_draft_{console}_{attack_id}{get_cache_user_suffix()}"
     if studio_draft_cache.delete(cache_key):
         logger.debug(f"Invalidated cache for key: {cache_key}")
+
+    # Rate limiting gate — record after successful status change
+    rate_limiter.record_action(caller_id, "set_studio_attack_status")
 
     # Build implications text
     if new_status == "published":

--- a/safebreach_mcp_studio/tests/test_rate_limiting.py
+++ b/safebreach_mcp_studio/tests/test_rate_limiting.py
@@ -1,9 +1,9 @@
-"""Gate integration tests — verify manage_test calls check_limit/record_action correctly."""
+"""Gate integration tests — verify rate limiting gates on write tools."""
 
 import pytest
 from unittest.mock import patch, MagicMock
 
-from safebreach_mcp_studio.studio_functions import sb_manage_test
+from safebreach_mcp_studio.studio_functions import sb_manage_test, sb_run_scenario
 from safebreach_mcp_core.token_context import _user_auth_artifacts
 
 
@@ -132,6 +132,193 @@ class TestManageTestRateLimitingGate:
         with pytest.raises(req.exceptions.RequestException):
             sb_manage_test(
                 test_id="1776488350786.15", action="cancel", console="test"
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures for run_scenario tests
+# ---------------------------------------------------------------------------
+MOCK_STATS = [
+    {"simulationCount": 100, "matchedTargetSimulators": 3,
+     "matchedAttackerSimulators": 2, "matchedAttacks": 5,
+     "totalTargetSimulators": 10, "totalAttackerSimulators": 5, "totalAttacks": 8},
+]
+
+MOCK_OOB_SCENARIO = {
+    "id": "3b8eade5-9285-43b8-b3e7-6350420983a5",
+    "name": "Test Scenario",
+    "steps": [{"name": "Step1", "uuid": "aaa", "attacksFilter": {},
+               "targetFilter": {"os": {"operator": "is", "values": ["WINDOWS"], "name": "os"}},
+               "attackerFilter": {"os": {"operator": "is", "values": ["LINUX"], "name": "os"}},
+               "systemFilter": {}}],
+    "actions": [], "edges": [], "systemTags": [],
+}
+
+MOCK_QUEUE_RESPONSE = {
+    "data": {
+        "planRunId": "1776488350786.15",
+        "name": "Test Scenario",
+        "steps": [{"stepRunId": "step-run-1"}],
+    }
+}
+
+
+class TestRunScenarioRateLimitingGate:
+    """Verify run_scenario gates: check_limit before queue POST, skip on dry_run."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions._get_scenario_statistics",
+           return_value=MOCK_STATS)
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_check_limit_before_queue_post(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, mock_post, _mock_stats, _mock_identity, mock_rate_limiter,
+    ):
+        """check_limit called before POST, record_action after success."""
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        # Mock GET (scenario fetch)
+        mock_get_resp = MagicMock()
+        mock_get_resp.json.return_value = [MOCK_OOB_SCENARIO]
+        mock_get_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_resp
+
+        # Mock POST (queue)
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 200
+        mock_post_resp.json.return_value = MOCK_QUEUE_RESPONSE
+        mock_post_resp.raise_for_status.return_value = None
+
+        def post_side_effect(*args, **kwargs):
+            call_order.append("queue_post")
+            return mock_post_resp
+
+        mock_post.side_effect = post_side_effect
+
+        result = sb_run_scenario(
+            scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
+            console="test",
+        )
+        assert result["status"] == "queued"
+        assert call_order == ["check_limit", "queue_post", "record_action"]
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "run_scenario"
+        )
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "run_scenario"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions._get_scenario_statistics",
+           return_value=MOCK_STATS)
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_dry_run_does_not_call_gates(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, _mock_stats, _mock_identity, mock_rate_limiter,
+    ):
+        """dry_run=True returns prediction without calling check_limit or record_action."""
+        mock_get_resp = MagicMock()
+        mock_get_resp.json.return_value = [MOCK_OOB_SCENARIO]
+        mock_get_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_resp
+
+        result = sb_run_scenario(
+            scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
+            console="test",
+            dry_run=True,
+        )
+        assert result["status"] == "dry_run"
+        mock_rate_limiter.check_limit.assert_not_called()
+        mock_rate_limiter.record_action.assert_not_called()
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_not_ready_does_not_call_gates(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, _mock_identity, mock_rate_limiter,
+    ):
+        """Not-ready diagnostic returns without calling gates."""
+        not_ready_scenario = {
+            **MOCK_OOB_SCENARIO,
+            "steps": [{
+                "name": "Incomplete",
+                "uuid": "bbb",
+                "attacksFilter": {},
+                "targetFilter": {},
+                "attackerFilter": {},
+                "systemFilter": {},
+            }],
+        }
+        mock_get_resp = MagicMock()
+        mock_get_resp.json.return_value = [not_ready_scenario]
+        mock_get_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_resp
+
+        result = sb_run_scenario(
+            scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
+            console="test",
+        )
+        assert result["status"] == "not_ready"
+        mock_rate_limiter.check_limit.assert_not_called()
+        mock_rate_limiter.record_action.assert_not_called()
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions._get_scenario_statistics",
+           return_value=MOCK_STATS)
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_record_action_not_called_on_queue_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, mock_post, _mock_stats, _mock_identity, mock_rate_limiter,
+    ):
+        """Queue POST failure: check_limit called, record_action NOT called."""
+        import requests as req
+
+        mock_get_resp = MagicMock()
+        mock_get_resp.json.return_value = [MOCK_OOB_SCENARIO]
+        mock_get_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_get_resp
+
+        mock_post.side_effect = req.exceptions.RequestException("Queue failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_run_scenario(
+                scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
+                console="test",
             )
 
         mock_rate_limiter.check_limit.assert_called_once()

--- a/safebreach_mcp_studio/tests/test_rate_limiting.py
+++ b/safebreach_mcp_studio/tests/test_rate_limiting.py
@@ -1,0 +1,138 @@
+"""Gate integration tests — verify manage_test calls check_limit/record_action correctly."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from safebreach_mcp_studio.studio_functions import sb_manage_test
+from safebreach_mcp_core.token_context import _user_auth_artifacts
+
+
+@pytest.fixture(autouse=True)
+def set_auth_context():
+    token = _user_auth_artifacts.set({"x-apitoken": "test-token"})
+    yield
+    _user_auth_artifacts.reset(token)
+
+
+class TestManageTestRateLimitingGate:
+    """Verify rate limiting gates are called in the correct order around the API call."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_caller_identity",
+        return_value="test-caller",
+    )
+    @patch("safebreach_mcp_studio.studio_functions.requests.delete")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_account_id",
+        return_value="1234567890",
+    )
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_base_url",
+        return_value="https://test.safebreach.com",
+    )
+    def test_check_limit_called_before_api_call(
+        self,
+        _mock_base_url,
+        _mock_account_id,
+        mock_delete,
+        _mock_get_identity,
+        mock_rate_limiter,
+    ):
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {}
+
+        def delete_side_effect(*args, **kwargs):
+            call_order.append("api_call")
+            return mock_response
+
+        mock_delete.side_effect = delete_side_effect
+
+        sb_manage_test(
+            test_id="1776488350786.15", action="cancel", console="test"
+        )
+
+        assert call_order == ["check_limit", "api_call", "record_action"]
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "manage_test"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_caller_identity",
+        return_value="test-caller",
+    )
+    @patch("safebreach_mcp_studio.studio_functions.requests.delete")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_account_id",
+        return_value="1234567890",
+    )
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_base_url",
+        return_value="https://test.safebreach.com",
+    )
+    def test_record_action_called_after_success(
+        self,
+        _mock_base_url,
+        _mock_account_id,
+        mock_delete,
+        _mock_get_identity,
+        mock_rate_limiter,
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        sb_manage_test(
+            test_id="1776488350786.15", action="cancel", console="test"
+        )
+
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "manage_test"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_caller_identity",
+        return_value="test-caller",
+    )
+    @patch("safebreach_mcp_studio.studio_functions.requests.delete")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_account_id",
+        return_value="1234567890",
+    )
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_base_url",
+        return_value="https://test.safebreach.com",
+    )
+    def test_record_action_not_called_on_api_failure(
+        self,
+        _mock_base_url,
+        _mock_account_id,
+        mock_delete,
+        _mock_get_identity,
+        mock_rate_limiter,
+    ):
+        import requests as req
+
+        mock_delete.side_effect = req.exceptions.RequestException("API error")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_manage_test(
+                test_id="1776488350786.15", action="cancel", console="test"
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()

--- a/safebreach_mcp_studio/tests/test_rate_limiting.py
+++ b/safebreach_mcp_studio/tests/test_rate_limiting.py
@@ -3,7 +3,14 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from safebreach_mcp_studio.studio_functions import sb_manage_test, sb_run_scenario
+from safebreach_mcp_studio.studio_functions import (
+    sb_manage_test,
+    sb_run_scenario,
+    sb_save_studio_attack_draft,
+    sb_update_studio_attack_draft,
+    sb_run_studio_attack,
+    sb_set_studio_attack_status,
+)
 from safebreach_mcp_core.token_context import _user_auth_artifacts
 
 
@@ -319,6 +326,389 @@ class TestRunScenarioRateLimitingGate:
             sb_run_scenario(
                 scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
                 console="test",
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Shared mock response helpers
+# ---------------------------------------------------------------------------
+MOCK_DRAFT_API_RESPONSE = {
+    "id": 10000001,
+    "name": "Test Attack",
+    "status": "draft",
+    "methodType": 5,
+    "class": "python",
+    "description": "test",
+    "timeout": 300,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+}
+
+MOCK_QUEUE_API_RESPONSE = {
+    "data": {
+        "planRunId": "1776488350786.15",
+        "name": "Studio Attack Test",
+        "steps": [{"stepRunId": "step-run-1"}],
+    }
+}
+
+
+def _mock_success_response(json_value=None, status_code=200):
+    """Create a mock HTTP response that looks successful."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = json_value if json_value is not None else {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# save_studio_attack_draft
+# ---------------------------------------------------------------------------
+class TestSaveStudioAttackDraftRateLimitingGate:
+    """Verify gates on save_studio_attack_draft: check before POST, record after cache."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_check_limit_before_post(
+        self, _mock_base_url, _mock_account_id,
+        mock_post, _mock_identity, mock_rate_limiter,
+    ):
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        def post_side_effect(*args, **kwargs):
+            call_order.append("api_call")
+            return _mock_success_response(MOCK_DRAFT_API_RESPONSE)
+
+        mock_post.side_effect = post_side_effect
+
+        sb_save_studio_attack_draft(
+            name="Test Attack", python_code="print('hello')", console="test",
+        )
+
+        assert call_order == ["check_limit", "api_call", "record_action"]
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "save_studio_attack_draft"
+        )
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "save_studio_attack_draft"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_record_action_not_called_on_api_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_post, _mock_identity, mock_rate_limiter,
+    ):
+        import requests as req
+        mock_post.side_effect = req.exceptions.RequestException("POST failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_save_studio_attack_draft(
+                name="Test Attack", python_code="print('hello')", console="test",
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_studio_attack_draft
+# ---------------------------------------------------------------------------
+class TestUpdateStudioAttackDraftRateLimitingGate:
+    """Verify gates on update_studio_attack_draft: check before PUT, record after cache."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.put")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_check_limit_before_put(
+        self, _mock_base_url, _mock_account_id,
+        mock_put, _mock_identity, mock_rate_limiter,
+    ):
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        def put_side_effect(*args, **kwargs):
+            call_order.append("api_call")
+            return _mock_success_response(MOCK_DRAFT_API_RESPONSE)
+
+        mock_put.side_effect = put_side_effect
+
+        sb_update_studio_attack_draft(
+            attack_id=10000001, name="Updated Attack",
+            python_code="print('updated')", console="test",
+        )
+
+        assert call_order == ["check_limit", "api_call", "record_action"]
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "update_studio_attack_draft"
+        )
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "update_studio_attack_draft"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.put")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_record_action_not_called_on_api_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_put, _mock_identity, mock_rate_limiter,
+    ):
+        import requests as req
+        mock_put.side_effect = req.exceptions.RequestException("PUT failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_update_studio_attack_draft(
+                attack_id=10000001, name="Updated Attack",
+                python_code="print('updated')", console="test",
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_studio_attack
+# ---------------------------------------------------------------------------
+class TestRunStudioAttackRateLimitingGate:
+    """Verify gates on run_studio_attack: check before queue POST, record after response."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_check_limit_before_queue_post(
+        self, _mock_base_url, _mock_account_id,
+        mock_post, _mock_identity, mock_rate_limiter,
+    ):
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        def post_side_effect(*args, **kwargs):
+            call_order.append("api_call")
+            return _mock_success_response(MOCK_QUEUE_API_RESPONSE)
+
+        mock_post.side_effect = post_side_effect
+
+        sb_run_studio_attack(
+            attack_id=10000001, console="test",
+            target_simulator_ids=["sim-uuid-1"],
+        )
+
+        assert call_order == ["check_limit", "api_call", "record_action"]
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "run_studio_attack"
+        )
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "run_studio_attack"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.post")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_record_action_not_called_on_api_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_post, _mock_identity, mock_rate_limiter,
+    ):
+        import requests as req
+        mock_post.side_effect = req.exceptions.RequestException("Queue failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_run_studio_attack(
+                attack_id=10000001, console="test",
+                target_simulator_ids=["sim-uuid-1"],
+            )
+
+        mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# set_studio_attack_status
+# ---------------------------------------------------------------------------
+MOCK_ALL_ATTACKS_RESPONSE = {
+    "data": [
+        {
+            "id": 10000001,
+            "name": "Test Attack",
+            "status": "draft",
+            "methodType": 5,
+            "timeout": 300,
+            "description": "test",
+            "parameters": [],
+            "tags": [],
+        }
+    ]
+}
+
+MOCK_TARGET_SOURCE_RESPONSE = {
+    "data": {"filename": "target.py", "content": "print('hello')"}
+}
+
+
+class TestSetStudioAttackStatusRateLimitingGate:
+    """Verify gates: check AFTER pre-check GET, before PUT. Record after cache invalidate."""
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.put")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_check_limit_after_precheck_before_put(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, mock_put, _mock_identity, mock_rate_limiter,
+    ):
+        call_order = []
+        mock_rate_limiter.check_limit.side_effect = (
+            lambda *a, **kw: call_order.append("check_limit")
+        )
+        mock_rate_limiter.record_action.side_effect = (
+            lambda *a, **kw: call_order.append("record_action")
+        )
+
+        # GET calls: first = list attacks (pre-check), second = target source
+        def get_side_effect(*args, **kwargs):
+            url = args[0] if args else kwargs.get("url", "")
+            if "customMethods?" in url:
+                call_order.append("precheck_get")
+                return _mock_success_response(MOCK_ALL_ATTACKS_RESPONSE)
+            elif "/files/target" in url:
+                call_order.append("source_get")
+                return _mock_success_response(MOCK_TARGET_SOURCE_RESPONSE)
+            return _mock_success_response()
+
+        mock_get.side_effect = get_side_effect
+
+        def put_side_effect(*args, **kwargs):
+            call_order.append("put_call")
+            return _mock_success_response()
+
+        mock_put.side_effect = put_side_effect
+
+        sb_set_studio_attack_status(
+            attack_id=10000001, new_status="published", console="test",
+        )
+
+        # Pre-check GETs happen BEFORE check_limit; PUT happens AFTER check_limit
+        assert call_order.index("precheck_get") < call_order.index("check_limit")
+        assert call_order.index("check_limit") < call_order.index("put_call")
+        assert call_order.index("put_call") < call_order.index("record_action")
+        mock_rate_limiter.check_limit.assert_called_once_with(
+            "test-caller", "set_studio_attack_status"
+        )
+        mock_rate_limiter.record_action.assert_called_once_with(
+            "test-caller", "set_studio_attack_status"
+        )
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_gates_not_called_on_precheck_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, _mock_identity, mock_rate_limiter,
+    ):
+        """Pre-check GET fails → neither check_limit nor record_action called."""
+        import requests as req
+        mock_get.side_effect = req.exceptions.RequestException("List failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_set_studio_attack_status(
+                attack_id=10000001, new_status="published", console="test",
+            )
+
+        mock_rate_limiter.check_limit.assert_not_called()
+        mock_rate_limiter.record_action.assert_not_called()
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
+           return_value="test-caller")
+    @patch("safebreach_mcp_studio.studio_functions.requests.put")
+    @patch("safebreach_mcp_studio.studio_functions.requests.get")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_account_id",
+           return_value="1234567890")
+    @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
+           return_value="https://test.safebreach.com")
+    def test_record_action_not_called_on_put_failure(
+        self, _mock_base_url, _mock_account_id,
+        mock_get, mock_put, _mock_identity, mock_rate_limiter,
+    ):
+        """PUT fails → check_limit was called, record_action NOT called."""
+        import requests as req
+
+        # GET calls succeed (pre-check + source fetch)
+        def get_side_effect(*args, **kwargs):
+            url = args[0] if args else kwargs.get("url", "")
+            if "customMethods?" in url:
+                return _mock_success_response(MOCK_ALL_ATTACKS_RESPONSE)
+            elif "/files/target" in url:
+                return _mock_success_response(MOCK_TARGET_SOURCE_RESPONSE)
+            return _mock_success_response()
+
+        mock_get.side_effect = get_side_effect
+        mock_put.side_effect = req.exceptions.RequestException("PUT failed")
+
+        with pytest.raises(req.exceptions.RequestException):
+            sb_set_studio_attack_status(
+                attack_id=10000001, new_status="published", console="test",
             )
 
         mock_rate_limiter.check_limit.assert_called_once()

--- a/tests/test_rate_limiting_e2e.py
+++ b/tests/test_rate_limiting_e2e.py
@@ -111,3 +111,46 @@ class TestRateLimitingE2E:
         finally:
             if test_id:
                 _cancel_test_best_effort(test_id, E2E_CONSOLE)
+
+    @patch("safebreach_mcp_core.rate_limiter._identical_action_limit", 1)
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 10)
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    def test_per_tool_name_limit_enforced(self):
+        """Call manage_test once OK, 2nd call hits per-tool limit of 1."""
+        scenario = _find_ready_scenario(E2E_CONSOLE)
+        test_id = None
+        try:
+            queue_result = sb_run_scenario(
+                scenario_id=str(scenario["id"]),
+                console=E2E_CONSOLE,
+                test_name="E2E: rate_limit_per_tool_test",
+            )
+            test_id = queue_result["test_id"]
+
+            # Action 1: pause (should succeed — hits per-tool limit of 1)
+            result = sb_manage_test(
+                test_id=test_id,
+                action="pause",
+                console=E2E_CONSOLE,
+                reason="E2E per-tool rate limit test",
+            )
+            assert result["status"] == "success"
+
+            time.sleep(1)
+
+            # Action 2: resume (same tool, should be rate-limited)
+            with pytest.raises(ToolError, match="manage_test") as exc_info:
+                sb_manage_test(
+                    test_id=test_id,
+                    action="resume",
+                    console=E2E_CONSOLE,
+                    reason="E2E per-tool rate limit - should fail",
+                )
+
+            error_msg = str(exc_info.value)
+            assert "1/1" in error_msg
+            assert any(c.isdigit() for c in error_msg)
+
+        finally:
+            if test_id:
+                _cancel_test_best_effort(test_id, E2E_CONSOLE)

--- a/tests/test_rate_limiting_e2e.py
+++ b/tests/test_rate_limiting_e2e.py
@@ -1,0 +1,113 @@
+"""E2E tests for rate limiting — requires real SafeBreach environment."""
+
+import os
+import time
+import logging
+
+import pytest
+from unittest.mock import patch
+
+from mcp.server.fastmcp.exceptions import ToolError
+from safebreach_mcp_studio.studio_functions import (
+    sb_run_scenario,
+    sb_manage_test,
+)
+from safebreach_mcp_core.rate_limiter import _rate_limit_store
+
+logger = logging.getLogger(__name__)
+
+E2E_CONSOLE = os.environ.get("E2E_CONSOLE", "pentest01")
+SKIP_E2E_TESTS = os.environ.get("SKIP_E2E_TESTS", "false").lower() == "true"
+
+skip_e2e = pytest.mark.skipif(
+    SKIP_E2E_TESTS,
+    reason="E2E tests skipped (set SKIP_E2E_TESTS=false to enable)",
+)
+
+
+def _cancel_test_best_effort(test_id: str, console: str) -> None:
+    """Best-effort cleanup — cancel a queued/running test."""
+    try:
+        sb_manage_test(test_id=test_id, action="cancel", console=console)
+    except Exception:
+        pass
+
+
+def _find_ready_scenario(console: str) -> dict:
+    """Find a ready-to-run scenario on the console."""
+    from safebreach_mcp_studio.studio_functions import (
+        _fetch_all_scenarios,
+        compute_scenario_readiness,
+    )
+
+    scenarios = _fetch_all_scenarios(console)
+    ready = next((s for s in scenarios if compute_scenario_readiness(s)), None)
+    assert ready is not None, f"No ready scenario found on {console}"
+    return ready
+
+
+@skip_e2e
+@pytest.mark.e2e
+class TestRateLimitingE2E:
+    """E2E: verify total action limit on manage_test against a real console."""
+
+    @pytest.fixture(autouse=True)
+    def clear_rate_limit_store(self):
+        _rate_limit_store.clear()
+        yield
+        _rate_limit_store.clear()
+
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 2)
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    def test_total_action_limit_enforced(self):
+        """Pause (1) -> resume (2) -> cancel (3, rate-limited)."""
+        scenario = _find_ready_scenario(E2E_CONSOLE)
+        test_id = None
+        try:
+            # Queue a real test
+            queue_result = sb_run_scenario(
+                scenario_id=str(scenario["id"]),
+                console=E2E_CONSOLE,
+                test_name="E2E: rate_limit_total_action_test",
+            )
+            test_id = queue_result["test_id"]
+            logger.info("Queued test %s for rate limit E2E", test_id)
+
+            # Action 1: pause (should succeed)
+            result = sb_manage_test(
+                test_id=test_id,
+                action="pause",
+                console=E2E_CONSOLE,
+                reason="E2E rate limit test - pause",
+            )
+            assert result["status"] == "success"
+
+            time.sleep(1)
+
+            # Action 2: resume (should succeed — hits limit of 2)
+            result = sb_manage_test(
+                test_id=test_id,
+                action="resume",
+                console=E2E_CONSOLE,
+                reason="E2E rate limit test - resume",
+            )
+            assert result["status"] == "success"
+
+            # Action 3: cancel (should be rate-limited)
+            with pytest.raises(ToolError, match="total actions") as exc_info:
+                sb_manage_test(
+                    test_id=test_id,
+                    action="cancel",
+                    console=E2E_CONSOLE,
+                    reason="E2E rate limit test - should fail",
+                )
+
+            error_msg = str(exc_info.value)
+            assert "2/2" in error_msg
+            # Verify retry-after seconds is present (a number)
+            assert any(c.isdigit() for c in error_msg)
+            logger.info("Rate limit correctly enforced: %s", error_msg)
+
+        finally:
+            if test_id:
+                _cancel_test_best_effort(test_id, E2E_CONSOLE)

--- a/tests/test_rate_limiting_e2e.py
+++ b/tests/test_rate_limiting_e2e.py
@@ -57,14 +57,14 @@ class TestRateLimitingE2E:
         yield
         _rate_limit_store.clear()
 
-    @patch("safebreach_mcp_core.rate_limiter._action_limit", 2)
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 3)
     @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
     def test_total_action_limit_enforced(self):
-        """Pause (1) -> resume (2) -> cancel (3, rate-limited)."""
+        """run_scenario (1) -> pause (2) -> resume (3, hits limit) -> cancel (rate-limited)."""
         scenario = _find_ready_scenario(E2E_CONSOLE)
         test_id = None
         try:
-            # Queue a real test
+            # Queue a real test — action 1 (run_scenario records an action)
             queue_result = sb_run_scenario(
                 scenario_id=str(scenario["id"]),
                 console=E2E_CONSOLE,
@@ -73,7 +73,7 @@ class TestRateLimitingE2E:
             test_id = queue_result["test_id"]
             logger.info("Queued test %s for rate limit E2E", test_id)
 
-            # Action 1: pause (should succeed)
+            # Action 2: pause (should succeed)
             result = sb_manage_test(
                 test_id=test_id,
                 action="pause",
@@ -84,7 +84,7 @@ class TestRateLimitingE2E:
 
             time.sleep(1)
 
-            # Action 2: resume (should succeed — hits limit of 2)
+            # Action 3: resume (should succeed — hits limit of 3)
             result = sb_manage_test(
                 test_id=test_id,
                 action="resume",
@@ -93,7 +93,7 @@ class TestRateLimitingE2E:
             )
             assert result["status"] == "success"
 
-            # Action 3: cancel (should be rate-limited)
+            # Action 4: cancel (should be rate-limited)
             with pytest.raises(ToolError, match="total actions") as exc_info:
                 sb_manage_test(
                     test_id=test_id,
@@ -103,7 +103,7 @@ class TestRateLimitingE2E:
                 )
 
             error_msg = str(exc_info.value)
-            assert "2/2" in error_msg
+            assert "3/3" in error_msg
             # Verify retry-after seconds is present (a number)
             assert any(c.isdigit() for c in error_msg)
             logger.info("Rate limit correctly enforced: %s", error_msg)
@@ -151,6 +151,69 @@ class TestRateLimitingE2E:
             assert "1/1" in error_msg
             assert any(c.isdigit() for c in error_msg)
 
+        finally:
+            if test_id:
+                _cancel_test_best_effort(test_id, E2E_CONSOLE)
+
+    @patch("safebreach_mcp_core.rate_limiter._identical_action_limit", 1)
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 10)
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    def test_run_scenario_per_tool_limit_enforced(self):
+        """run_scenario (1, hits per-tool limit of 1) -> 2nd run_scenario (rate-limited)."""
+        scenario = _find_ready_scenario(E2E_CONSOLE)
+        test_id = None
+        try:
+            # Action 1: run_scenario succeeds — hits per-tool limit of 1
+            queue_result = sb_run_scenario(
+                scenario_id=str(scenario["id"]),
+                console=E2E_CONSOLE,
+                test_name="E2E: run_scenario_rate_limit_test",
+            )
+            test_id = queue_result["test_id"]
+            assert queue_result["status"] == "queued"
+
+            # Action 2: run_scenario again — same tool, should be rate-limited
+            with pytest.raises(ToolError, match="run_scenario") as exc_info:
+                sb_run_scenario(
+                    scenario_id=str(scenario["id"]),
+                    console=E2E_CONSOLE,
+                    test_name="E2E: run_scenario_rate_limit_should_fail",
+                )
+
+            error_msg = str(exc_info.value)
+            assert "1/1" in error_msg
+            assert any(c.isdigit() for c in error_msg)
+            logger.info("run_scenario rate limit correctly enforced: %s", error_msg)
+
+        finally:
+            if test_id:
+                _cancel_test_best_effort(test_id, E2E_CONSOLE)
+
+    @patch("safebreach_mcp_core.rate_limiter._identical_action_limit", 5)
+    @patch("safebreach_mcp_core.rate_limiter._action_limit", 10)
+    @patch("safebreach_mcp_core.rate_limiter._window_seconds", 60)
+    def test_run_scenario_dry_run_bypasses_rate_limit(self):
+        """dry_run=True does not consume rate limit quota."""
+        scenario = _find_ready_scenario(E2E_CONSOLE)
+        # Multiple dry runs should all succeed — none count toward limit
+        for i in range(3):
+            result = sb_run_scenario(
+                scenario_id=str(scenario["id"]),
+                console=E2E_CONSOLE,
+                dry_run=True,
+            )
+            assert result["status"] == "dry_run", f"dry_run #{i+1} should succeed"
+
+        # Real run should still work (no quota consumed by dry runs)
+        test_id = None
+        try:
+            queue_result = sb_run_scenario(
+                scenario_id=str(scenario["id"]),
+                console=E2E_CONSOLE,
+                test_name="E2E: dry_run_bypass_test",
+            )
+            test_id = queue_result["test_id"]
+            assert queue_result["status"] == "queued"
         finally:
             if test_id:
                 _cancel_test_best_effort(test_id, E2E_CONSOLE)


### PR DESCRIPTION
## Summary

- Add per-caller sliding-window rate limiting to all 6 Studio write tools (`save_studio_attack_draft`, `update_studio_attack_draft`, `run_studio_attack`, `set_studio_attack_status`, `run_scenario`, `manage_test`)
- Two-phase gate pattern: `check_limit` before mutation, `record_action` after success only — dry-run, diagnostic, and failure paths don't consume quota
- Two independent limits: total actions (default 10) and per-tool-name (default 5) within configurable sliding window (default 30 min)
- Hybrid caller identity: auth token SHA256[:16] for external connections (survives reconnection), session ID fallback for localhost, `anonymous` if neither available
- Configurable via env vars: `SAFEBREACH_MCP_RATE_LIMIT_ENABLED`, `SAFEBREACH_MCP_ACTION_LIMIT`, `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT`, `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES`

## Test plan

- [x] 26 core unit tests (rate limiter engine, sliding window, error messages, config, hybrid identity)
- [x] 16 gate integration tests (call ordering, failure paths, dry-run exclusion for all 6 tools)
- [x] 4 E2E tests against real console (total limit, per-tool limit, run_scenario limit, dry-run bypass)
- [x] Manual E2E verification on pentest01 (no-op accounting, upstream error accounting, window decay, retry-after accuracy, concurrent burst serialization)
- [x] 372 total tests pass (non-E2E), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)