### PR TITLE
SAF-27570 feat(auth): OAuth-aware bundle + cache scoping

### DIFF
--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -101,18 +101,22 @@ def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """
     bundle = _user_auth_artifacts.get()
 
+    def _has_user_creds(b):
+        # Any credential is enough: legacy (x-token/cookie/x-apitoken) or OAuth Bearer.
+        return bool(b) and any(k in b for k in ('x-token', 'cookie', 'x-apitoken', 'authorization'))
+
     # SSE transport fallback (SAF-29974 Slice 6): the ContextVar set on the
     # /messages/ POST doesn't propagate to the tool handler (SSE GET's create_task
     # uses a different async context).  Read the POST's headers directly from the
     # MCP SDK's request_ctx, which IS set on the tool handler's task.
-    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
+    if not _has_user_creds(bundle):
         from .token_context import _get_auth_from_mcp_request_ctx
         mcp_bundle = _get_auth_from_mcp_request_ctx()
         if mcp_bundle:
             bundle = mcp_bundle
 
     # Tertiary fallback: session store lookup via session_id from request_ctx
-    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
+    if not _has_user_creds(bundle):
         from .token_context import _get_session_id_from_mcp_ctx, _session_auth_artifacts
         session_id = _get_session_id_from_mcp_ctx()
         if session_id:

--- a/safebreach_mcp_core/token_context.py
+++ b/safebreach_mcp_core/token_context.py
@@ -30,9 +30,16 @@ AUTH_COOKIE_NAME = os.environ.get('SAFEBREACH_MCP_AUTH_COOKIE_NAME', 'X-Token')
 
 
 def extract_auth_bundle(scope: dict) -> Optional[Dict[str, str]]:
-    """Extract x-apitoken/x-token/cookie(filtered) from ASGI scope headers.
+    """Extract auth artifacts from ASGI scope headers.
 
     Returns a dict with only the non-empty auth artifacts, or None if none present.
+
+    Credentials (any one is sufficient for outbound auth):
+      x-apitoken, x-token, cookie(filtered), authorization (OAuth Bearer)
+
+    Hint headers stamped by ui-server's mcpProxyHandler (SAF-27570):
+      x-sb-auth-type, x-sb-client-id — used only for cache scoping, not for
+      authenticating to ui-server (the credential headers above do that).
     """
     raw_headers = dict(scope.get('headers', []))
     bundle: Dict[str, str] = {}
@@ -49,6 +56,18 @@ def extract_auth_bundle(scope: dict) -> Optional[Dict[str, str]]:
     scrubbed = _keep_only_cookie(raw_cookie, AUTH_COOKIE_NAME)
     if scrubbed:
         bundle['cookie'] = scrubbed
+
+    authorization = raw_headers.get(b'authorization', b'').decode('utf-8', errors='ignore')
+    if authorization:
+        bundle['authorization'] = authorization
+
+    auth_type = raw_headers.get(b'x-sb-auth-type', b'').decode('utf-8', errors='ignore')
+    if auth_type:
+        bundle['x-sb-auth-type'] = auth_type
+
+    client_id = raw_headers.get(b'x-sb-client-id', b'').decode('utf-8', errors='ignore')
+    if client_id:
+        bundle['x-sb-client-id'] = client_id
 
     return bundle or None
 
@@ -88,6 +107,15 @@ def _get_auth_from_mcp_request_ctx() -> Optional[Dict[str, str]]:
     scrubbed = _keep_only_cookie(raw_cookie, AUTH_COOKIE_NAME)
     if scrubbed:
         bundle['cookie'] = scrubbed
+    authorization = headers.get('authorization', '')
+    if authorization:
+        bundle['authorization'] = authorization
+    auth_type = headers.get('x-sb-auth-type', '')
+    if auth_type:
+        bundle['x-sb-auth-type'] = auth_type
+    client_id = headers.get('x-sb-client-id', '')
+    if client_id:
+        bundle['x-sb-client-id'] = client_id
     return bundle or None
 
 
@@ -158,10 +186,14 @@ def mask_artifacts(bundle: Optional[Dict[str, str]]) -> Dict[str, str]:
 
 
 def get_cache_user_suffix() -> str:
-    """Return a user-scoped cache key suffix based on the current auth artifacts.
+    """Return a principal-scoped cache key suffix based on the current auth artifacts.
 
     Returns '_' + first 8 chars of SHA-256 hex digest of the most stable
     artifact present, or '' when no user bundle is set.
+
+    For OAuth callers (SAF-27570) we scope by x-sb-client-id when available — it's
+    stable across token refreshes, unlike the Bearer JWT itself. Falls back to
+    hashing the Authorization header value if the hint isn't present.
     """
     bundle = _user_auth_artifacts.get()
     if not bundle:
@@ -170,14 +202,22 @@ def get_cache_user_suffix() -> str:
         logger.debug("get_cache_user_suffix() → '' (no user bundle)")
         return ''
 
-    # Priority: x-apitoken (most stable) > x-token > cookie value
-    value = bundle.get('x-apitoken')
-    if not value:
-        value = bundle.get('x-token')
-    if not value:
-        cookie = bundle.get('cookie', '')
-        if '=' in cookie:
-            value = cookie.split('=', 1)[1]
+    # OAuth callers: prefer the stable client_id over the Bearer JWT (which
+    # rotates on token refresh and would invalidate the cache unnecessarily).
+    if bundle.get('x-sb-auth-type') == 'oauth':
+        value = bundle.get('x-sb-client-id') or bundle.get('authorization')
+    else:
+        # User callers: x-apitoken (most stable) > x-token > cookie value > authorization
+        value = bundle.get('x-apitoken')
+        if not value:
+            value = bundle.get('x-token')
+        if not value:
+            cookie = bundle.get('cookie', '')
+            if '=' in cookie:
+                value = cookie.split('=', 1)[1]
+        if not value:
+            value = bundle.get('authorization')
+
     if not value:
         logger.debug("get_cache_user_suffix() → '' (bundle present but no usable value)")
         return ''

--- a/tests/test_auth_concurrency.py
+++ b/tests/test_auth_concurrency.py
@@ -255,6 +255,64 @@ class TestGetCacheUserSuffix:
         suffix = get_cache_user_suffix()
         assert suffix == expected
 
+    def test_oauth_caller_scoped_by_client_id(self):
+        """OAuth callers (x-sb-auth-type=oauth) use x-sb-client-id for cache scope.
+
+        client_id is stable across token refreshes, unlike the Bearer JWT itself
+        (which would otherwise invalidate the cache on every refresh).
+        """
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer rotating-jwt-1',
+            'x-sb-auth-type': 'oauth',
+            'x-sb-client-id': 'oauth_abc123',
+        })
+
+        import hashlib
+        expected = '_' + hashlib.sha256('oauth_abc123'.encode()).hexdigest()[:8]
+        suffix_1 = get_cache_user_suffix()
+
+        # Simulate a token refresh: same client_id, different Bearer.
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer rotating-jwt-2',
+            'x-sb-auth-type': 'oauth',
+            'x-sb-client-id': 'oauth_abc123',
+        })
+        suffix_2 = get_cache_user_suffix()
+
+        assert suffix_1 == expected
+        assert suffix_1 == suffix_2
+
+    def test_two_oauth_clients_get_different_suffixes(self):
+        """Different OAuth clients on the same account must not collide."""
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer jwt-A',
+            'x-sb-auth-type': 'oauth',
+            'x-sb-client-id': 'oauth_client_A',
+        })
+        suffix_a = get_cache_user_suffix()
+
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer jwt-B',
+            'x-sb-auth-type': 'oauth',
+            'x-sb-client-id': 'oauth_client_B',
+        })
+        suffix_b = get_cache_user_suffix()
+
+        assert suffix_a != suffix_b
+
+    def test_oauth_without_client_id_falls_back_to_bearer(self):
+        """If the hint is missing client_id, hash the Authorization value
+        (best available stability)."""
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer fallback-jwt',
+            'x-sb-auth-type': 'oauth',
+        })
+
+        import hashlib
+        expected = '_' + hashlib.sha256('Bearer fallback-jwt'.encode()).hexdigest()[:8]
+        suffix = get_cache_user_suffix()
+        assert suffix == expected
+
 
 class TestLastUserAuthBundleRemoved:
 
@@ -297,3 +355,16 @@ class TestGetAuthHeadersForConsole:
         result = get_auth_headers_for_console('default')
         result['x-token'] = 'mutated'
         assert _user_auth_artifacts.get()['x-token'] == 'jwt1'
+
+    def test_oauth_bearer_alone_passes_user_creds_check(self):
+        """OAuth Bearer in the bundle is enough — _has_user_creds must accept it
+        even without x-token / cookie / x-apitoken (SAF-27570)."""
+        _user_auth_artifacts.set({
+            'authorization': 'Bearer oauth-jwt',
+            'x-sb-auth-type': 'oauth',
+            'x-sb-client-id': 'oauth_abc',
+        })
+        result = get_auth_headers_for_console('default')
+        assert result['authorization'] == 'Bearer oauth-jwt'
+        assert result['x-sb-auth-type'] == 'oauth'
+        assert result['x-sb-client-id'] == 'oauth_abc'


### PR DESCRIPTION
Closes Gap 4 from the SAF-27570 audit. Previously, OAuth callers were invisible to the auth bundle (extract_auth_bundle / _get_auth_from_mcp_request_ctx only looked at x-apitoken, x-token, cookie). That meant:

1. get_auth_headers_for_console returned no bundle for OAuth callers → outbound HTTP to ui-server had no auth → 401.
2. get_cache_user_suffix returned '' for OAuth callers → all OAuth callers shared an unscoped cache key, colliding with each other and with anonymous-fallback paths.

Changes:

- extract_auth_bundle + _get_auth_from_mcp_request_ctx now also capture 'authorization' (OAuth Bearer) and the SAF-27570 hint headers 'x-sb-auth-type' / 'x-sb-client-id'.
- get_cache_user_suffix prefers x-sb-client-id for OAuth callers — it's stable across token refreshes (the Bearer JWT rotates). Falls back to hashing the Authorization value if the hint is absent. Non-OAuth path is unchanged.
- get_auth_headers_for_console's "do we have credentials?" gate accepts the OAuth Bearer alongside x-token/cookie/x-apitoken.

Pairs with mcp-proxy PR #43 (forwards 'authorization' + hint headers) and ui PR #1555 (stamps the hint headers and binds credential role).