### PR TITLE
SAF-30717: Enrich get_studio_attack_latest_result with test-level context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,13 @@ Rate limiting environment variables:
   Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`. Note append is
   best-effort — failure does not block the lifecycle operation. Response includes
   `hint_to_agent` with contextual next-step guidance per action.
+22. `get_studio_attack_latest_result` ✨ **Enhanced** - Retrieves latest execution results for a Studio
+  attack by playbook ID. Now includes **Test Overview** section with test-level context fetched from
+  `GET /testsummaries/{test_id}`: test status (running/completed/canceled/failed), test-level
+  start/end times and duration, simulation status breakdown (missed/stopped/prevented/detected/
+  logged/no-result/inconsistent) with total count. When test is non-terminal, includes `hint_to_agent`
+  with polling guidance. Test ID resolved from parameter or extracted from first simulation's planRunId.
+  Graceful degradation: if test summary API fails, response is returned without test overview.
 
 
 ## Filtering and Search Capabilities

--- a/prds/SAF-30717-Improve-get_studio_attack_latest_result/context.md
+++ b/prds/SAF-30717-Improve-get_studio_attack_latest_result/context.md
@@ -1,0 +1,95 @@
+# SAF-30717 Investigation Context
+
+## Status: Phase 6 — PRD Created
+
+## Ticket Information
+- **ID**: SAF-30717
+- **Title**: get_studio_attack_latest_result returns simulation-scoped timing and count instead of test-level aggregates
+- **Type**: Bug
+- **Status**: To Do
+- **Assignee**: Yossi Attas
+- **Priority**: Medium
+
+## Task Scope
+Enrich `get_studio_attack_latest_result` response with test-level metadata so calling agents can correctly determine whether a test is still running, how long the overall test took, and how many simulations exist in total.
+
+## Investigation Findings
+
+### 1. Current Response Structure (studio_server.py:627-814)
+
+The tool queries the execution history API (`POST executionsHistoryResults`) and returns individual simulation results. Response includes:
+- `Total Executions Found`: from API's `total` field (actual count of matching simulations)
+- `Showing`: number of results returned (capped by `max_results`, default=1)
+- Per-simulation: timing, status, simulators, drift, logs
+
+**Key observation**: `total_found` does correctly reflect the API total (not `max_results`). However, if a test is still running and only 1 simulation has completed, the API truthfully returns `total: 1`. The problem is there's no context telling the agent the test expects 22 simulations and is still running.
+
+### 2. Business Logic (studio_functions.py:1217-1365)
+
+- Calls `POST /api/data/v1/accounts/{account_id}/executionsHistoryResults`
+- Query: `Playbook_id:("{attack_id}")` with optional `AND runId:{test_id}`
+- Sorts by `startTime` descending, pages with `pageSize: min(page_size, max_results)`
+- Returns: `executions`, `returned_count`, `total_found`, `has_more`
+
+**Missing**: No call to the test summary API. The function only knows about simulations, not the parent test.
+
+### 3. Data Transformations (studio_types.py:219-343)
+
+`get_execution_result_mapping()` transforms raw simulation data. Each simulation already has `test_id` (planRunId) which is the key to fetch test-level data.
+
+### 4. How Data Server Gets Test-Level Data (data_functions.py:397-469)
+
+`sb_get_test_details()` fetches from `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`. The response includes:
+- `status`: running, completed, canceled, failed
+- `startTime`, `endTime`, `duration`
+- `finalStatus`: dict with simulation counts (missed, stopped, prevented, detected, logged, no-result, inconsistent)
+- `planName`: test name
+
+This is the same API endpoint the studio server can call to enrich its response.
+
+### 5. Test File (test_studio_functions.py:1732-1941)
+
+7 existing test cases covering success, multiple results, empty, validation, and errors. Mock data has 2 executions with `total: 2`.
+
+## Problem Analysis
+
+### Problem Scope
+The `get_studio_attack_latest_result` tool returns accurate simulation-level data but lacks test-level context. This creates two information gaps for calling agents:
+
+1. **No test status**: The agent cannot tell if a test is still running or completed. When a test with 22 expected simulations has only 1 completed, the tool returns that 1 simulation with no indication more are coming.
+
+2. **No test-level timing**: The timing shown (`start_time`/`end_time`) belongs to the individual simulation, not the overall test. An agent sees "7 seconds" for a single simulation and assumes the test took 7 seconds, when the full test actually took 3+ minutes.
+
+3. **No total simulation expectation**: `total_found` is the count of completed simulations matching the query at query time, not the expected total for the test. There's no way to know "1 of 22" without additional context.
+
+### Affected Areas
+- `studio_functions.py`: `sb_get_studio_attack_latest_result()` — needs to fetch test summary
+- `studio_server.py`: `get_studio_attack_latest_result` tool — needs to format and display test-level section
+- `studio_types.py`: May need a helper to transform test summary data
+- `test_studio_functions.py`: Tests need updating for new response fields
+
+### Risks
+- **Extra API call**: Fetching test summary adds one GET request per invocation. Low risk since the endpoint is lightweight.
+- **test_id availability**: The `planRunId` is already present in each simulation result, so we always have the key needed to fetch the test summary. When `test_id` parameter is provided, we can use it directly. When not provided, we can extract it from the first (latest) simulation result.
+
+### Edge Cases
+- No simulations found (total_found=0): No test_id available to fetch summary — skip enrichment
+- Multiple test_ids in results (when `test_id` param not provided and `max_results > 1`): Simulations from different test runs may appear. Should fetch test summary for each unique test_id, or just the first one.
+- Test summary API failure: Should not break the tool — gracefully degrade to current behavior
+
+### Dependencies
+- Data server's `testsummaries` API endpoint (already used extensively by `data_functions.py`)
+- Auth infrastructure (`get_auth_headers_for_console`, `get_api_base_url`) — already available in studio_functions.py
+
+## Brainstorming Results (Phase 5)
+
+### Chosen Approach
+All decisions agreed upon:
+
+| Decision | Choice |
+|----------|--------|
+| When to fetch test summary | Always — use `test_id` param or extract `planRunId` from first simulation |
+| Status breakdown format | Status + count with total line (no explanations) |
+| hint_to_agent target | Suggest both: poll this tool OR use `get_test_details` from Data Server |
+| Multiple test runs | Overview for first (latest) test only |
+| Extra API call latency | Always fetch, graceful degradation on failure (try/except, log warning) |

--- a/prds/SAF-30717-Improve-get_studio_attack_latest_result/prd.md
+++ b/prds/SAF-30717-Improve-get_studio_attack_latest_result/prd.md
@@ -1,0 +1,345 @@
+# Enrich get_studio_attack_latest_result with Test-Level Context — SAF-30717
+
+## 1. Overview
+
+- **Task Type**: Bug fix
+- **Purpose**: `get_studio_attack_latest_result` returns accurate simulation-level data but lacks test-level
+  context, causing calling agents to misinterpret results — falsely concluding a test is complete after its
+  first simulation finishes, reporting wrong timing (7 seconds vs 3+ minutes), and showing "1 execution found"
+  when 22 exist.
+- **Target Consumer**: AI agents (Helm agent, Claude) consuming SafeBreach MCP tools
+- **Key Benefits**:
+  1. Agents can correctly determine whether a test is still running or completed
+  2. Agents see test-level timing alongside simulation-level timing, preventing false "done" conclusions
+  3. Simulation status breakdown (missed/stopped/prevented/etc.) gives agents immediate posture awareness
+- **Business Alignment**: Improves agent reliability and trust in MCP-driven breach simulation workflows
+- **Originating Request**: [SAF-30717](https://safebreach.atlassian.net/browse/SAF-30717) — reported by
+  Yossi Attas after observing the Helm agent misinterpret results on staging
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-05-13 12:00 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+## 2. Solution Description
+
+### Chosen Solution
+
+Enrich the existing `get_studio_attack_latest_result` response with a **Test Overview** section by making one
+additional `GET /testsummaries/{test_id}` call after fetching simulation results. The `test_id` (planRunId) is
+already present in each simulation result, so no new user input is required.
+
+Changes are purely **additive** — no existing response fields are modified or removed.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| When to fetch test summary | Always — use `test_id` param or extract from first simulation | Covers the common workflow; agent always gets full context |
+| Status breakdown format | Status + count with total line | Compact; agents needing explanations can use `get_test_details` |
+| hint_to_agent target | Suggest both: poll this tool OR `get_test_details` | Flexible; doesn't force cross-server knowledge |
+| Multiple test runs | Overview for first (latest) test only | `max_results` defaults to 1; covers 99% of usage |
+| API call failure | Graceful degradation (try/except, log warning) | Tool still works; test overview is best-effort |
+
+### Alternatives Considered
+
+1. **Add `include_test_overview` parameter** — Rejected: unlikely anyone would opt out; adds unnecessary
+   complexity to the tool interface.
+2. **Redirect agents to `get_test_details`** — Rejected: forces cross-server dependency; agents shouldn't need
+   two tools to understand a single result.
+3. **Cache test summaries in studio server** — Rejected: adds cache management complexity for a lightweight
+   endpoint that returns quickly; not worth the overhead for this use case.
+
+## 3. Core Feature Components
+
+### Component A: Test Summary Fetch (studio_functions.py)
+
+- **Purpose**: Extend `sb_get_studio_attack_latest_result()` to fetch test summary data after retrieving
+  simulation results
+- **Key Features**:
+  - Determine `test_id`: use the parameter if provided, otherwise extract `planRunId` from the first simulation
+  - Call `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+  - Extract: status, startTime, endTime, duration, finalStatus (simulation counts)
+  - Compute total simulation count by summing all finalStatus values
+  - Add `test_overview` dict to the return value
+  - Wrap in try/except: on failure, log warning and set `test_overview` to None
+  - Skip entirely when `total_found == 0` (no simulations → no test_id available)
+
+### Component B: Response Formatting (studio_server.py)
+
+- **Purpose**: Add a "Test Overview" section to the formatted markdown response
+- **Key Features**:
+  - Insert Test Overview section between the header metadata and the first execution result
+  - Display: test status, test start/end times, duration, simulation status breakdown with total
+  - When test is not in a terminal state (running/queued), add `hint_to_agent` suggesting polling
+  - When `test_overview` is None (fetch failed or no simulations), omit the section silently
+
+## 4. API Endpoints and Integration
+
+### Existing API to Consume
+
+- **API Name**: Test Summary (single test)
+- **URL**: `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+- **Headers**: `Content-Type: application/json`, `x-apitoken: {token}`
+- **Response Example**:
+  ```json
+  {
+    "planRunId": "1764570357286.4",
+    "planName": "test registry shuit",
+    "status": "completed",
+    "startTime": "2025-11-02T07:58:00.000Z",
+    "endTime": "2025-11-02T08:01:11.000Z",
+    "duration": 191000,
+    "finalStatus": {
+      "missed": 5,
+      "stopped": 3,
+      "prevented": 10,
+      "detected": 2,
+      "logged": 1,
+      "no-result": 0,
+      "inconsistent": 1
+    }
+  }
+  ```
+- **Source**: Already used by `safebreach_mcp_data/data_functions.py:_fetch_single_test()`
+
+## 6. Non-Functional Requirements
+
+### Performance Requirements
+- The `GET /testsummaries/{test_id}` endpoint is lightweight (single record lookup).
+  Expected additional latency: ~100-200ms per invocation.
+- No caching needed — the endpoint returns quickly and test status changes frequently
+  during running tests (caching would return stale status).
+
+### Technical Constraints
+- **Backward Compatibility**: Fully backward compatible — additive changes only.
+  No existing response fields are modified or removed.
+- **No cross-server dependency**: The studio server calls the data API directly
+  (same pattern as its existing `executionsHistoryResults` call). It does not depend on
+  the data MCP server.
+
+## 7. Definition of Done
+
+- [ ] `sb_get_studio_attack_latest_result()` fetches test summary via `GET /testsummaries/{test_id}`
+- [ ] Response includes `test_overview` with: status, start_time, end_time, duration, simulation_status_counts,
+  total_simulations
+- [ ] `test_id` is resolved from parameter or extracted from first simulation's `planRunId`
+- [ ] When `total_found == 0`, test overview is skipped (no crash, no error)
+- [ ] When test summary API fails, tool returns existing response without test overview (graceful degradation)
+- [ ] When test status is non-terminal, `hint_to_agent` is included with polling guidance
+- [ ] Formatted markdown response includes "Test Overview" section before execution details
+- [ ] Simulation status breakdown shows status + count pairs with a total line
+- [ ] All existing unit tests pass without modification (additive change)
+- [ ] New unit tests cover: successful enrichment, graceful degradation, no-simulations skip,
+  non-terminal status hint
+- [ ] CLAUDE.md updated with new response fields documentation
+
+## 8. Testing Strategy
+
+### Unit Testing
+- **Scope**: `sb_get_studio_attack_latest_result()` in `studio_functions.py`
+- **Key Scenarios**:
+  1. Successful test summary fetch — verify `test_overview` fields
+  2. Test summary API failure — verify graceful degradation (result still returned, `test_overview` is None)
+  3. No simulations found (`total_found=0`) — verify test summary fetch is skipped
+  4. Non-terminal test status (running) — verify `hint_to_agent` is present
+  5. Terminal test status (completed) — verify no `hint_to_agent`
+  6. `test_id` parameter provided — verify it's used directly
+  7. `test_id` not provided — verify `planRunId` extracted from first simulation
+- **Framework**: pytest (existing)
+- **Coverage Target**: Maintain existing coverage; all new code paths tested
+
+### Integration Testing
+- Existing cross-server integration tests should continue passing (no behavioral changes to existing fields)
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Test summary fetch logic | ⏳ Pending | - | - | |
+| Phase 2: Response formatting | ⏳ Pending | - | - | |
+| Phase 3: Unit tests | ⏳ Pending | - | - | |
+| Phase 4: Documentation | ⏳ Pending | - | - | |
+
+### Phase 1: Test Summary Fetch Logic
+
+**Semantic Change**: Add test summary fetching to `sb_get_studio_attack_latest_result()`
+
+**Deliverables**: The function returns a `test_overview` dict alongside existing fields
+
+**Implementation Details**:
+
+1. In `studio_functions.py`, after the existing simulation fetch and transformation block (after line 1346),
+   add a test summary fetch:
+   - Determine `resolved_test_id`: if `test_id` parameter is provided, use it. Otherwise, extract
+     `planRunId` from the first element of `transformed_executions` (key: `test_id`).
+   - If `total_found == 0` (no simulations), skip test summary fetch entirely — set `test_overview` to None.
+   - Call `GET {base_url}/api/data/v1/accounts/{account_id}/testsummaries/{resolved_test_id}` with the same
+     `headers` and `timeout=120` already configured in the function.
+   - Call `check_rbac_response(response)` on the response.
+   - Parse the JSON response and extract: `status`, `startTime`, `endTime`, `duration`, `finalStatus` dict.
+   - Build `simulation_status_counts`: iterate over the `finalStatus` dict, creating a list of
+     `{"status": key, "count": value}` pairs for each status type.
+   - Compute `total_simulations` by summing all values in the `finalStatus` dict.
+   - Determine terminal status: `terminal_statuses = {'completed', 'canceled', 'failed'}`.
+   - Build `test_overview` dict with keys: `status`, `start_time`, `end_time`, `duration`,
+     `simulation_status_counts`, `total_simulations`.
+   - If test status is not in `terminal_statuses`, add `hint_to_agent` to `test_overview` with message:
+     `"Test is still {status} ({total_found} of {total_simulations} simulations completed so far).
+     Poll this tool again in 30 seconds, or use get_test_details(test_id='{resolved_test_id}',
+     console='{console}') from the Data Server for detailed status."`
+   - Wrap the entire test summary fetch in a try/except block. On any exception, log a warning
+     and set `test_overview` to None.
+
+2. Add `test_overview` to the result dict (alongside `executions`, `returned_count`, etc.).
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/studio_functions.py` | Add test summary fetch block after simulation processing |
+
+**Git Commit**: `feat(studio): fetch test summary in get_studio_attack_latest_result (SAF-30717)`
+
+### Phase 2: Response Formatting
+
+**Semantic Change**: Format and display the test overview section in the tool's markdown response
+
+**Deliverables**: The formatted response includes a "Test Overview" section between header metadata and
+execution details
+
+**Implementation Details**:
+
+1. In `studio_server.py`, in the `get_studio_attack_latest_result` tool function, after building the
+   header metadata lines (after line 696, the empty string after "Showing"), insert the test overview
+   formatting block:
+   - Check if `result['test_overview']` is not None.
+   - If present, append a "### Test Overview" section with:
+     - `**Test Status:** {status}`
+     - `**Test Start Time:** {start_time}`
+     - `**Test End Time:** {end_time}` (show "In progress" if empty/None)
+     - `**Test Duration:** {duration}` (show "In progress" if empty/None)
+     - A blank line, then "**Simulation Status Breakdown:**"
+     - For each entry in `simulation_status_counts`: `- {status}: {count}`
+     - `- **Total: {total_simulations}**`
+   - If `hint_to_agent` is present in `test_overview`, append it as a highlighted line:
+     `> **hint_to_agent:** {hint_text}`
+   - Append a separator line (`---`) after the test overview section.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/studio_server.py` | Add test overview formatting block in response builder |
+
+**Git Commit**: `feat(studio): format test overview section in latest result response (SAF-30717)`
+
+### Phase 3: Unit Tests
+
+**Semantic Change**: Add unit tests covering all test summary enrichment paths
+
+**Deliverables**: New test cases in `test_studio_functions.py`
+
+**Implementation Details**:
+
+1. Add a mock response fixture for the test summary API that matches the `testsummaries/{test_id}` response
+   structure (status, startTime, endTime, duration, finalStatus dict with all 7 status types).
+
+2. Add test cases:
+   - **test_get_latest_result_with_test_overview**: Mock both the execution history API and the test summary
+     API. Verify the result contains `test_overview` with correct status, timing, simulation_status_counts,
+     and total_simulations. Verify the test summary API was called with the correct test_id (extracted from
+     first simulation's planRunId).
+   - **test_get_latest_result_test_overview_with_test_id_param**: Provide `test_id` parameter explicitly.
+     Verify the test summary API is called with the provided test_id, not the simulation's planRunId.
+   - **test_get_latest_result_test_overview_running**: Mock test summary with status "running". Verify
+     `hint_to_agent` is present in `test_overview` and contains polling guidance.
+   - **test_get_latest_result_test_overview_completed**: Mock test summary with status "completed". Verify
+     `hint_to_agent` is NOT present in `test_overview`.
+   - **test_get_latest_result_test_overview_api_failure**: Mock test summary API to raise an exception.
+     Verify `test_overview` is None and the rest of the result is intact (graceful degradation).
+   - **test_get_latest_result_no_results_skips_test_overview**: Use the existing no-results test scenario.
+     Verify test summary API is NOT called and `test_overview` is None.
+
+3. Update existing test assertions if needed — existing tests should still pass since `test_overview` is a
+   new additive field. Existing tests may need to mock the test summary API call to avoid unexpected
+   HTTP requests.
+
+4. **E2E test updates** — piggyback on existing E2E tests in `test_e2e.py`:
+   - **test_get_studio_attack_latest_result_e2e** (line 424): Inside the `if result['total_found'] > 0:`
+     block, add assertions for the new `test_overview` field: verify it is present, and when not None,
+     verify it contains `status`, `start_time`, `total_simulations`, and `simulation_status_counts`.
+   - **test_debug_flow_e2e** (line 488): After fetching results with a known `test_id`, verify
+     `test_overview` is present and its status is a valid value (running, completed, canceled, failed).
+     Print test overview fields for diagnostic output.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add test summary mock fixture + 6 new test cases; update existing tests to mock test summary endpoint |
+| `safebreach_mcp_studio/tests/test_e2e.py` | Add `test_overview` assertions to 2 existing E2E tests |
+
+**Git Commit**: `test(studio): add unit tests and E2E assertions for test overview enrichment (SAF-30717)`
+
+### Phase 4: Documentation
+
+**Semantic Change**: Update CLAUDE.md with new response fields
+
+**Deliverables**: CLAUDE.md documents the test overview section in `get_studio_attack_latest_result`
+
+**Implementation Details**:
+
+1. In CLAUDE.md, find the Studio Server tools section and update the `get_studio_attack_latest_result`
+   description to mention the test overview enrichment: test status, test-level timing, simulation status
+   breakdown with total, and hint_to_agent for running tests.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | Update Studio Server tool description with test overview fields |
+
+**Git Commit**: `docs: document test overview enrichment in get_studio_attack_latest_result (SAF-30717)`
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Test summary API unavailable | Low — tool degrades gracefully | try/except wrapping; log warning; return response without test overview |
+| Stale `planRunId` in simulation | Low — planRunId is an immutable identifier | No mitigation needed; planRunId never changes after creation |
+| Extra latency per call | Low — ~100-200ms for lightweight GET | Acceptable tradeoff for the value provided |
+
+### Assumptions
+
+- The `GET /testsummaries/{test_id}` endpoint is available on all SafeBreach consoles with the same
+  response schema as used by the data server.
+- The `finalStatus` dict in the test summary response always contains all 7 status keys
+  (missed, stopped, prevented, detected, logged, no-result, inconsistent). If a key is missing,
+  it defaults to 0 via `.get()`.
+- The `planRunId` field is always present in simulation results from the `executionsHistoryResults` API.
+
+## 12. Executive Summary
+
+- **Issue**: `get_studio_attack_latest_result` returns simulation-level data without test-level context,
+  causing agents to misinterpret test completion status, timing, and simulation counts.
+- **What Was Built**: Additive enrichment of the tool's response with a Test Overview section containing
+  test status, test-level timing, simulation status breakdown, and polling hints for running tests.
+- **Key Technical Decisions**: Always fetch test summary (no opt-out parameter); graceful degradation
+  on API failure; compact status+count format without explanations; single test overview even for
+  multi-test results.
+- **Business Value Delivered**: Agents correctly understand test lifecycle, preventing false "done"
+  conclusions and enabling accurate status reporting to users.
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-05-13 12:00 | PRD created — initial draft |
+| 2026-05-13 12:30 | Added E2E test assertions to Phase 3 (piggyback on existing test_e2e.py tests) |

--- a/prds/SAF-30717-Improve-get_studio_attack_latest_result/prd.md
+++ b/prds/SAF-30717-Improve-get_studio_attack_latest_result/prd.md
@@ -20,10 +20,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Draft |
-| **Last Updated** | 2026-05-13 12:00 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-05-13 17:00 |
 | **Owner** | Yossi Attas |
-| **Current Phase** | N/A |
+| **Current Phase** | Complete |
 
 ## 2. Solution Description
 
@@ -124,19 +124,19 @@ Changes are purely **additive** — no existing response fields are modified or 
 
 ## 7. Definition of Done
 
-- [ ] `sb_get_studio_attack_latest_result()` fetches test summary via `GET /testsummaries/{test_id}`
-- [ ] Response includes `test_overview` with: status, start_time, end_time, duration, simulation_status_counts,
+- [x] `sb_get_studio_attack_latest_result()` fetches test summary via `GET /testsummaries/{test_id}`
+- [x] Response includes `test_overview` with: status, start_time, end_time, duration, simulation_status_counts,
   total_simulations
-- [ ] `test_id` is resolved from parameter or extracted from first simulation's `planRunId`
-- [ ] When `total_found == 0`, test overview is skipped (no crash, no error)
-- [ ] When test summary API fails, tool returns existing response without test overview (graceful degradation)
-- [ ] When test status is non-terminal, `hint_to_agent` is included with polling guidance
-- [ ] Formatted markdown response includes "Test Overview" section before execution details
-- [ ] Simulation status breakdown shows status + count pairs with a total line
-- [ ] All existing unit tests pass without modification (additive change)
-- [ ] New unit tests cover: successful enrichment, graceful degradation, no-simulations skip,
+- [x] `test_id` is resolved from parameter or extracted from first simulation's `planRunId`
+- [x] When `total_found == 0`, test overview is skipped (no crash, no error)
+- [x] When test summary API fails, tool returns existing response without test overview (graceful degradation)
+- [x] When test status is non-terminal, `hint_to_agent` is included with polling guidance
+- [x] Formatted markdown response includes "Test Overview" section before execution details
+- [x] Simulation status breakdown shows status + count pairs with a total line
+- [x] All existing unit tests pass without modification (additive change)
+- [x] New unit tests cover: successful enrichment, graceful degradation, no-simulations skip,
   non-terminal status hint
-- [ ] CLAUDE.md updated with new response fields documentation
+- [x] CLAUDE.md updated with new response fields documentation
 
 ## 8. Testing Strategy
 
@@ -160,10 +160,10 @@ Changes are purely **additive** — no existing response fields are modified or 
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: Test summary fetch logic | ⏳ Pending | - | - | |
-| Phase 2: Response formatting | ⏳ Pending | - | - | |
-| Phase 3: Unit tests | ⏳ Pending | - | - | |
-| Phase 4: Documentation | ⏳ Pending | - | - | |
+| Phase 1: Test summary fetch logic | ✅ Complete | 2026-05-13 | 2c83fed | TDD: 6 new tests + implementation |
+| Phase 2: Response formatting | ✅ Complete | 2026-05-13 | 639c0ce | Test overview section in markdown |
+| Phase 3: Unit tests + E2E | ✅ Complete | 2026-05-13 | 70f4a16 | E2E assertions added |
+| Phase 4: Documentation | ✅ Complete | 2026-05-13 | 6533060 | CLAUDE.md updated |
 
 ### Phase 1: Test Summary Fetch Logic
 
@@ -343,3 +343,4 @@ execution details
 |------|-------------------|
 | 2026-05-13 12:00 | PRD created — initial draft |
 | 2026-05-13 12:30 | Added E2E test assertions to Phase 3 (piggyback on existing test_e2e.py tests) |
+| 2026-05-13 17:00 | All 4 phases implemented via TDD — PRD complete |

--- a/prds/SAF-30717-Improve-get_studio_attack_latest_result/summary.md
+++ b/prds/SAF-30717-Improve-get_studio_attack_latest_result/summary.md
@@ -1,0 +1,42 @@
+# SAF-30717: Enrich get_studio_attack_latest_result with Test-Level Context
+
+## Problem Statement
+
+`get_studio_attack_latest_result` returns accurate simulation-level data but lacks test-level context, causing calling agents to misinterpret results. Specifically:
+- Agents cannot determine if a test is still running or completed
+- Timing reflects individual simulations, not the overall test duration
+- `total_found` shows completed simulations at query time, not the expected total
+
+## Proposed Fix
+
+Enrich the tool's response with a **Test Overview** section by fetching test summary data from the existing `GET /testsummaries/{test_id}` API endpoint. This is additive — no changes to existing response fields.
+
+## New Response Fields
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| Test Status | `testsummaries.status` | Running/completed/canceled/failed |
+| Test Start Time | `testsummaries.startTime` | When the overall test began |
+| Test End Time | `testsummaries.endTime` | When the overall test finished (null if running) |
+| Test Duration | `testsummaries.duration` | Total test duration |
+| Simulation Status Breakdown | `testsummaries.finalStatus` | Counts by status (missed, stopped, prevented, etc.) with total |
+| hint_to_agent | Computed | Polling guidance when test is still running |
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `studio_functions.py` | Add test summary fetch after simulation query |
+| `studio_server.py` | Add "Test Overview" section to formatted response |
+| `test_studio_functions.py` | Update tests for new response fields |
+
+## Acceptance Criteria
+
+- [ ] Response includes test-level status (running/completed/canceled/failed)
+- [ ] Response includes test-level start/end times and duration
+- [ ] Response includes simulation status breakdown with total count
+- [ ] When test is still running, response includes `hint_to_agent` with polling guidance
+- [ ] When no simulations found (total_found=0), test overview is gracefully skipped
+- [ ] Test summary API failure degrades gracefully (existing response preserved)
+- [ ] Existing unit tests continue to pass
+- [ ] New unit tests cover the enrichment logic

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -1336,13 +1336,56 @@ def sb_get_studio_attack_latest_result(
                 exec_result.pop('logs', None)
                 exec_result.pop('output', None)
 
+        # Fetch test-level overview (SAF-30717)
+        test_overview = None
+        if total_found > 0:
+            resolved_test_id = test_id if test_id else transformed_executions[0].get('test_id')
+            if resolved_test_id:
+                try:
+                    summary_url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{resolved_test_id}"
+                    summary_response = requests.get(summary_url, headers=headers, timeout=120)
+                    check_rbac_response(summary_response)
+                    summary_data = summary_response.json()
+
+                    final_status = summary_data.get('finalStatus', {})
+                    simulation_status_counts = [
+                        {"status": status, "count": final_status.get(status, 0)}
+                        for status in ['missed', 'stopped', 'prevented', 'detected',
+                                       'logged', 'no-result', 'inconsistent']
+                    ]
+                    total_simulations = sum(entry['count'] for entry in simulation_status_counts)
+
+                    test_overview = {
+                        'status': summary_data.get('status', ''),
+                        'start_time': summary_data.get('startTime'),
+                        'end_time': summary_data.get('endTime'),
+                        'duration': summary_data.get('duration'),
+                        'simulation_status_counts': simulation_status_counts,
+                        'total_simulations': total_simulations,
+                    }
+
+                    terminal_statuses = {'completed', 'canceled', 'failed'}
+                    test_status = (test_overview['status'] or '').lower()
+                    if test_status not in terminal_statuses:
+                        test_overview['hint_to_agent'] = (
+                            f"Test is still {test_overview['status']} "
+                            f"({total_found} of {total_simulations} simulations completed so far). "
+                            f"Poll this tool again in 30 seconds, or use "
+                            f"get_test_details(test_id='{resolved_test_id}', console='{console}') "
+                            f"from the Data Server for detailed status."
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to fetch test summary for test_id '{resolved_test_id}': {e}")
+                    test_overview = None
+
         result = {
             'executions': transformed_executions,
             'returned_count': len(transformed_executions),
             'total_found': total_found,
             'attack_id': attack_id,
             'console': console,
-            'has_more': total_found > len(transformed_executions)
+            'has_more': total_found > len(transformed_executions),
+            'test_overview': test_overview,
         }
 
         logger.info(f"Successfully retrieved {len(transformed_executions)} execution results for attack {attack_id}")

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -695,6 +695,33 @@ get_studio_attack_latest_result(attack_id=10000291, console="demo", include_logs
                     ""
                 ]
 
+                # Add test overview section (SAF-30717)
+                test_overview = result.get('test_overview')
+                if test_overview is not None:
+                    end_time_display = test_overview['end_time'] or "In progress"
+                    duration_display = test_overview['duration'] if test_overview['duration'] is not None else "In progress"
+                    response_parts.extend([
+                        "### Test Overview",
+                        "",
+                        f"**Test Status:** {test_overview['status']}",
+                        f"**Test Start Time:** {test_overview['start_time']}",
+                        f"**Test End Time:** {end_time_display}",
+                        f"**Test Duration:** {duration_display}",
+                        "",
+                        "**Simulation Status Breakdown:**",
+                    ])
+                    for entry in test_overview['simulation_status_counts']:
+                        response_parts.append(f"- {entry['status']}: {entry['count']}")
+                    response_parts.append(f"- **Total: {test_overview['total_simulations']}**")
+
+                    if 'hint_to_agent' in test_overview:
+                        response_parts.extend([
+                            "",
+                            f"> **hint_to_agent:** {test_overview['hint_to_agent']}",
+                        ])
+
+                    response_parts.extend(["", "---", ""])
+
                 # Add each execution result
                 for idx, execution in enumerate(result['executions'], 1):
                     response_parts.extend([

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -639,14 +639,16 @@ Parameters:
 - include_logs (optional): Include simulation_steps, logs, and output fields (default: True)
 - test_id (optional): Filter results to a specific test run (planRunId). Use the test_id returned by run_studio_attack.
 
-Returns detailed execution information including:
-- Execution status and status (missed, stopped, prevented, etc.)
-- Test/plan information and timing details
-- Attacker and target simulator details
-- Parameters used in the execution
-- Result codes and security actions
-- Simulation steps, logs, and output (when include_logs=True)
-- Drift tracking (is_drifted, drift_tracking_code)
+Returns:
+- **Test Overview** (from test summary API): test status (running/completed/canceled/failed),
+  test-level start/end times and duration, simulation status breakdown
+  (missed/stopped/prevented/detected/logged/no-result/inconsistent) with total count.
+  When the test is still running, includes hint_to_agent with polling guidance.
+- **Per-simulation details**: execution status, timing, attacker/target simulators,
+  result codes, security actions, drift tracking, simulation steps/logs/output (when include_logs=True).
+
+Note: "Executions Matched" shows how many simulations matched the query (may be less than
+the total in the test if the test is still running). See Test Overview for the full count.
 
 Typical workflow:
 1. result = run_studio_attack(attack_id=10000298, all_connected=True, console="demo")
@@ -690,7 +692,7 @@ get_studio_attack_latest_result(attack_id=10000291, console="demo", include_logs
                     "",
                     f"**Attack ID:** {result['attack_id']}",
                     f"**Console:** {result['console']}",
-                    f"**Total Executions Found:** {result['total_found']}",
+                    f"**Executions Matched:** {result['total_found']}",
                     f"**Showing:** {result['returned_count']} result(s)",
                     ""
                 ]

--- a/safebreach_mcp_studio/tests/test_e2e.py
+++ b/safebreach_mcp_studio/tests/test_e2e.py
@@ -456,6 +456,15 @@ class TestStudioExecutionE2E:
                 assert 'logs' in execution
                 assert 'output' in execution
 
+                # Verify test overview enrichment (SAF-30717)
+                assert 'test_overview' in result
+                if result['test_overview'] is not None:
+                    overview = result['test_overview']
+                    assert 'status' in overview
+                    assert 'start_time' in overview
+                    assert 'total_simulations' in overview
+                    assert 'simulation_status_counts' in overview
+
                 print(f"\n=== Latest Result E2E ===")
                 print(f"  Attack ID: {attack_id}")
                 print(f"  Total found: {result['total_found']}")
@@ -465,6 +474,9 @@ class TestStudioExecutionE2E:
                 print(f"  Simulation Steps: {len(execution['simulation_steps'])} step(s)")
                 print(f"  Has Logs: {bool(execution['logs'])}")
                 print(f"  Has Output: {bool(execution['output'])}")
+                if result['test_overview'] is not None:
+                    print(f"  Test Status: {result['test_overview']['status']}")
+                    print(f"  Total Simulations: {result['test_overview']['total_simulations']}")
             else:
                 print(f"\n=== Latest Result E2E ===")
                 print(f"  No execution results found for attack {attack_id}")
@@ -515,6 +527,14 @@ class TestStudioDebugFlowE2E:
             )
 
             assert 'executions' in result
+
+            # Verify test overview enrichment (SAF-30717)
+            assert 'test_overview' in result
+            if result['test_overview'] is not None:
+                overview = result['test_overview']
+                assert overview['status'] in ('running', 'completed', 'canceled', 'failed', 'queued')
+                print(f"  Test Overview: status={overview['status']}, "
+                      f"total_simulations={overview['total_simulations']}")
 
             if result['total_found'] > 0:
                 # Verify the result structure supports debug use case

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -1729,6 +1729,50 @@ def mock_execution_result_empty_response():
     }
 
 
+@pytest.fixture
+def mock_test_summary_response():
+    """Mock test summary API response (completed test)."""
+    return {
+        "planRunId": "1764570357286.4",
+        "planName": "test registry shuit",
+        "status": "completed",
+        "startTime": "2025-11-02T07:58:00.000Z",
+        "endTime": "2025-11-02T08:01:11.000Z",
+        "duration": 191000,
+        "finalStatus": {
+            "missed": 5,
+            "stopped": 3,
+            "prevented": 10,
+            "detected": 2,
+            "logged": 1,
+            "no-result": 0,
+            "inconsistent": 1
+        }
+    }
+
+
+@pytest.fixture
+def mock_test_summary_running_response():
+    """Mock test summary API response (running test)."""
+    return {
+        "planRunId": "1764570357286.4",
+        "planName": "test registry shuit",
+        "status": "running",
+        "startTime": "2025-11-02T07:58:00.000Z",
+        "endTime": None,
+        "duration": None,
+        "finalStatus": {
+            "missed": 1,
+            "stopped": 0,
+            "prevented": 0,
+            "detected": 0,
+            "logged": 0,
+            "no-result": 0,
+            "inconsistent": 0
+        }
+    }
+
+
 class TestGetStudioAttackLatestResult:
     """Test suite for sb_get_studio_attack_latest_result function."""
 
@@ -1939,6 +1983,232 @@ class TestGetStudioAttackLatestResult:
             sb_get_studio_attack_latest_result(attack_id=10000291, console="demo")
 
         assert "API Error" in str(exc_info.value)
+
+    # --- Test Overview Enrichment Tests (SAF-30717) ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_with_test_overview(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response,
+        mock_test_summary_response
+    ):
+        """Test that test overview is populated from test summary API."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        # Mock POST (execution history)
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        # Mock GET (test summary)
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = mock_test_summary_response
+        mock_get_response.status_code = 200
+        mock_get.return_value = mock_get_response
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo"
+        )
+
+        # Verify test_overview is populated
+        assert result['test_overview'] is not None
+        overview = result['test_overview']
+        assert overview['status'] == "completed"
+        assert overview['start_time'] == "2025-11-02T07:58:00.000Z"
+        assert overview['end_time'] == "2025-11-02T08:01:11.000Z"
+        assert overview['duration'] == 191000
+        assert overview['total_simulations'] == 22  # 5+3+10+2+1+0+1
+        assert isinstance(overview['simulation_status_counts'], list)
+        assert 'hint_to_agent' not in overview  # completed = terminal
+
+        # Verify GET called with correct test_id (from first simulation's planRunId)
+        mock_get.assert_called_once()
+        get_url = mock_get.call_args[0][0]
+        assert '/testsummaries/1764570357286.4' in get_url
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_test_overview_with_test_id_param(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response,
+        mock_test_summary_response
+    ):
+        """Test that explicit test_id param is used for test summary fetch."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = mock_test_summary_response
+        mock_get_response.status_code = 200
+        mock_get.return_value = mock_get_response
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo", test_id="explicit-test-id-999"
+        )
+
+        # Verify GET used the explicit test_id, not planRunId from simulation
+        mock_get.assert_called_once()
+        get_url = mock_get.call_args[0][0]
+        assert '/testsummaries/explicit-test-id-999' in get_url
+        assert result['test_overview'] is not None
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_test_overview_running(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response,
+        mock_test_summary_running_response
+    ):
+        """Test that hint_to_agent is present when test is still running."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = mock_test_summary_running_response
+        mock_get_response.status_code = 200
+        mock_get.return_value = mock_get_response
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo"
+        )
+
+        overview = result['test_overview']
+        assert overview is not None
+        assert overview['status'] == "running"
+        assert overview['end_time'] is None
+        assert 'hint_to_agent' in overview
+        assert 'still running' in overview['hint_to_agent']
+        assert 'Poll' in overview['hint_to_agent']
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_test_overview_completed(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response,
+        mock_test_summary_response
+    ):
+        """Test that hint_to_agent is NOT present when test is completed."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = mock_test_summary_response
+        mock_get_response.status_code = 200
+        mock_get.return_value = mock_get_response
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo"
+        )
+
+        overview = result['test_overview']
+        assert overview is not None
+        assert overview['status'] == "completed"
+        assert 'hint_to_agent' not in overview
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_test_overview_api_failure(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response
+    ):
+        """Test graceful degradation when test summary API fails."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        # Mock GET to raise exception
+        mock_get.side_effect = Exception("Connection timeout")
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo"
+        )
+
+        # Result should still be returned without test_overview
+        assert result['test_overview'] is None
+        assert len(result['executions']) > 0
+        assert result['total_found'] == 2
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_no_results_skips_test_overview(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_empty_response
+    ):
+        """Test that test summary fetch is skipped when no simulations found."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_empty_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        result = sb_get_studio_attack_latest_result(
+            attack_id=10000291, console="demo"
+        )
+
+        assert result['test_overview'] is None
+        assert result['total_found'] == 0
+        # Test summary API should NOT have been called
+        mock_get.assert_not_called()
 
 
 class TestParameterValidationAndBuilding:


### PR DESCRIPTION
## What

Enrich `get_studio_attack_latest_result` response with a Test Overview section containing test-level status, timing, simulation status breakdown, and polling hints for running tests.

## Why

[SAF-30717](https://safebreach.atlassian.net/browse/SAF-30717) — The tool returned only simulation-level data, causing AI agents to misinterpret results: falsely concluding tests were complete after the first simulation, reporting wrong timing (~7s vs ~3min), and showing "1 execution found" when 22 existed.

## Changes

- **feat**: Fetch test summary via `GET /testsummaries/{test_id}` after simulation query (`studio_functions.py`)
- **feat**: Format Test Overview section in markdown response with status, timing, simulation breakdown (`studio_server.py`)
- **fix**: Rename misleading `Total Executions Found` → `Executions Matched`
- **fix**: Update tool description to document Test Overview, hint_to_agent, and field semantics
- **test**: 6 new unit tests covering enrichment, graceful degradation, running status hint, no-results skip
- **test**: E2E assertions added to `test_get_studio_attack_latest_result_e2e` and `test_debug_flow_e2e`
- **docs**: CLAUDE.md updated with new tool capabilities
- **docs**: PRD with context, summary, and implementation plan

## Testing

- 6 new unit tests (TDD) — all pass
- 336 studio unit tests pass
- 1021 cross-server tests pass
- E2E test `test_get_studio_attack_latest_result_e2e` passes against live pentest01 console
- Graceful degradation verified: tool works when test summary API fails

## JIRA

[SAF-30717](https://safebreach.atlassian.net/browse/SAF-30717)