### PR TITLE
SAF-31054: Disable actions rate limiter by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Caller identity (`get_caller_identity()`): auth token SHA256[:16] for external c
 | `manage_test` | After input validation | After state change | Note append is best-effort |
 
 Rate limiting environment variables:
-- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` — enable/disable (default: `true`)
+- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` — enable/disable (default: `false`)
 - `SAFEBREACH_MCP_ACTION_LIMIT` — total actions per caller per window (default: `10`)
 - `SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT` — per-tool-name limit per caller per window (default: `5`)
 - `SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES` — sliding window duration in minutes (default: `30`)
@@ -536,7 +536,7 @@ export SAFEBREACH_MCP_TRANSPORT=sse            # Server-Sent Events (default) �
 export SAFEBREACH_MCP_TRANSPORT=streamable-http # Streamable HTTP — single endpoint: /mcp (or $SAFEBREACH_MCP_BASE_URL)
 
 # Rate limiting (applies to all write tools)
-export SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true              # Enable/disable (default: true)
+export SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true              # Enable/disable (default: false)
 export SAFEBREACH_MCP_ACTION_LIMIT=10                      # Total actions per caller per window (default: 10)
 export SAFEBREACH_MCP_IDENTICAL_ACTION_LIMIT=5             # Per-tool limit per caller per window (default: 5)
 export SAFEBREACH_MCP_RATE_LIMIT_WINDOW_MINUTES=30         # Sliding window in minutes (default: 30)

--- a/prds/SAF-31054-disable-actions-rate-limit-by-default/context.md
+++ b/prds/SAF-31054-disable-actions-rate-limit-by-default/context.md
@@ -20,7 +20,7 @@
 
 ## Status
 
-Phase 5: Problem Analysis Complete
+Phase 6: PRD Created
 
 ---
 

--- a/prds/SAF-31054-disable-actions-rate-limit-by-default/context.md
+++ b/prds/SAF-31054-disable-actions-rate-limit-by-default/context.md
@@ -1,0 +1,95 @@
+# SAF-31054 — Context File
+
+## Ticket Info
+
+| Field    | Value                                                              |
+|----------|--------------------------------------------------------------------|
+| ID       | SAF-31054                                                          |
+| Title    | [safebreach-mcp] make the actions rate limiter disabled by default |
+| Status   | To Do                                                              |
+| Assignee | Yossi Attas                                                        |
+| Type     | Task                                                               |
+| Created  | May 13, 2026                                                       |
+
+**Branch**: `SAF-31054-disable-actions-rate-limit-by-default`
+
+## Ticket Description (verbatim)
+
+> In the scope of SAF-29871 we introduced a rate limiting mechanism for non readOnly actions and it is enabled by default.
+> We want to have the rate limiter disabled by default until it would be possible to configure it using content (a separate work item to be opened by Tal).
+
+## Status
+
+Phase 5: Problem Analysis Complete
+
+---
+
+## Investigation Findings
+
+### Repository: safebreach-mcp
+
+**Rate limiter configuration** (`safebreach_mcp_core/rate_limiter.py` lines 32–34):
+
+```python
+_rate_limit_enabled: bool = os.environ.get(
+    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "true"
+).strip().lower() in ("true", "1", "yes")
+```
+
+The default is `"true"`. The fix is to change `"true"` → `"false"` in the default argument to `os.environ.get()`.
+
+**Environment variable surface** (`CLAUDE.md`):
+```
+- `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` — enable/disable (default: `true`)
+```
+Must be updated to `default: false`.
+
+**Test impact** (`safebreach_mcp_core/tests/test_rate_limiter.py`):
+- `record_action()` has `if not _rate_limit_enabled: return` → with `False` default, no timestamps are stored.
+- `check_limit()` also short-circuits with `if not _rate_limit_enabled: return`.
+- Tests in `TestCheckLimitBasic`, `TestRecordAction`, `TestSlidingWindow`, `TestErrorMessage`,
+  `TestMultipleCallers`, `TestPerToolNameLimit`, and `get_caller_identity` tests
+  that call `record_action()` and then expect `check_limit()` to raise would all fail silently
+  (no-op instead of working).
+- Fix: add an `autouse` fixture `enable_rate_limiter` that patches `_rate_limit_enabled` to `True`.
+  Tests in `TestConfiguration` that explicitly patch to `False` still work because the `@patch`
+  decorator applies after the fixture.
+- `safebreach_mcp_studio/tests/test_rate_limiting.py`: unaffected — mocks `rate_limiter` directly.
+
+**No other files reference `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` default**.
+
+---
+
+## Problem Analysis
+
+### What is the problem?
+
+The rate limiter was introduced as a safety guardrail (SAF-29871) and shipped **enabled by default**
+(`SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true`). However, the limit thresholds and window sizes are
+currently hardcoded via environment variables and are not configurable from within the SafeBreach
+platform (content-side). This means customers and operators cannot tune or disable the rate limiter
+without accessing the server's environment. Until content-based configuration is available
+(separate future work item), having rate limiting **on by default** is premature and may
+unexpectedly block legitimate AI agent workflows.
+
+### Affected areas
+
+| Area | File | Change |
+|------|------|--------|
+| Core rate limiter config | `safebreach_mcp_core/rate_limiter.py` | `"true"` → `"false"` default |
+| Documentation | `CLAUDE.md` | Update `default: true` → `default: false` |
+| Unit tests | `safebreach_mcp_core/tests/test_rate_limiter.py` | Add `enable_rate_limiter` autouse fixture |
+
+### Risks
+
+- **No behavioral regression risk**: the mechanism itself is unchanged; only the opt-in direction flips.
+- **Test risk**: tests that rely on `_rate_limit_enabled` being `True` by default will fail unless
+  an autouse fixture explicitly enables it. Well-understood and easy to fix.
+- **Documentation clarity**: after this change, rate limiting must be explicitly opt-in via
+  `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true`. CLAUDE.md must reflect this.
+
+### Edge cases
+
+- Tests that patch `_rate_limit_enabled` to `False` (i.e., `TestConfiguration.test_disabled_*`)
+  will continue to work correctly because `@patch` decorators apply after autouse fixtures.
+- No E2E impact — E2E tests already set explicit env var overrides.

--- a/prds/SAF-31054-disable-actions-rate-limit-by-default/prd.md
+++ b/prds/SAF-31054-disable-actions-rate-limit-by-default/prd.md
@@ -1,0 +1,232 @@
+# Disable Actions Rate Limiter by Default — SAF-31054
+
+## 1. Overview
+
+- **Task Type**: Configuration change
+- **Purpose**: Make the per-caller rate limiting mechanism opt-in rather than on-by-default, until
+  content-based configuration is available
+- **Target Consumer**: Internal — MCP server operators and AI agent consumers
+- **Key Benefits**:
+  - Prevents unexpected blocking of legitimate AI agent workflows
+  - Rate limiting remains available for operators who explicitly enable it
+  - Prepares for future content-based configuration (separate work item)
+- **Business Alignment**: Follow-up to SAF-29871 rate limiting feature; aligns with incremental
+  rollout approach
+- **Originating Request**: [SAF-31054](https://safebreach.atlassian.net/browse/SAF-31054)
+
+---
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Draft |
+| **Last Updated** | 2026-05-14 15:50 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+---
+
+## 2. Solution Description
+
+### Chosen Solution: Flip Default to Disabled
+
+Change the default value of `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` from `"true"` to `"false"` in the
+`os.environ.get()` call in `rate_limiter.py`. This is a single-character change that makes rate
+limiting opt-in. All rate limiting logic, gate placement, and configuration env vars remain
+unchanged.
+
+### Alternatives Considered
+
+**Approach A — Remove rate limiting entirely**:
+- Pros: Simplest, no dead code paths
+- Cons: Loses the safety guardrail; would need to re-implement when content config is ready
+
+**Approach B — Feature flag with server-side content config**:
+- Pros: Content-managed, no env var needed
+- Cons: Out of scope for this ticket; requires separate design and implementation
+
+### Decision Rationale
+
+Flipping the default preserves the entire rate limiting infrastructure for future use while
+removing the risk of unexpected blocking. Operators who want rate limiting today can enable it
+via environment variable. When content-based configuration is ready, the default can be revisited.
+
+---
+
+## 3. Core Feature Components
+
+### Component A: Rate Limiter Default Change (`safebreach_mcp_core/rate_limiter.py`)
+
+**Purpose**: Modify the existing rate limiter configuration to default to disabled.
+
+**Key Features**:
+- Change `os.environ.get("SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "true")` default arg to `"false"`
+- All other rate limiter logic, data structures, and gate placements remain unchanged
+- Explicit `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true` still enables rate limiting
+
+### Component B: Documentation Update (`CLAUDE.md`)
+
+**Purpose**: Update env var documentation to reflect the new default.
+
+**Key Features**:
+- Change `default: true` to `default: false` for `SAFEBREACH_MCP_RATE_LIMIT_ENABLED`
+- All other rate limiting documentation remains accurate
+
+### Component C: Test Fixture Update (`safebreach_mcp_core/tests/test_rate_limiter.py`)
+
+**Purpose**: Ensure unit tests continue to exercise rate limiting logic with an explicit enable.
+
+**Key Features**:
+- Add `enable_rate_limiter` autouse fixture that patches `_rate_limit_enabled` to `True`
+- Existing `TestConfiguration.test_disabled_*` tests still work (their `@patch(False)` overrides
+  the fixture)
+- No changes to test logic, assertions, or test coverage
+
+---
+
+## 6. Non-Functional Requirements
+
+### Technical Constraints
+
+- **Backward Compatibility**: Deployments that already set `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true`
+  are unaffected. Deployments that relied on the default being `true` will now have rate limiting
+  disabled — this is the intended behavior change.
+- **No migration needed**: Pure configuration default change with no data migration or deployment
+  coordination required.
+
+---
+
+## 7. Definition of Done
+
+- [ ] `_rate_limit_enabled` defaults to `False` when `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` is unset
+- [ ] Setting `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true` explicitly enables rate limiting
+- [ ] All unit tests in `test_rate_limiter.py` pass with the `enable_rate_limiter` autouse fixture
+- [ ] All gate integration tests in `test_rate_limiting.py` pass (unaffected)
+- [ ] Full cross-server test suite passes (`uv run pytest ... -m "not e2e"`)
+- [ ] `CLAUDE.md` documents `default: false` for `SAFEBREACH_MCP_RATE_LIMIT_ENABLED`
+
+---
+
+## 8. Testing Strategy
+
+### Unit Testing
+
+**Scope**: `safebreach_mcp_core/tests/test_rate_limiter.py`
+
+**Key Scenarios**:
+- All existing tests pass under the `enable_rate_limiter` autouse fixture (no logic changes)
+- `TestConfiguration.test_disabled_*` tests still verify disabled behavior via explicit `@patch`
+- No new test scenarios needed — the change is purely a default value flip
+
+**Framework**: pytest with unittest.mock
+
+### Integration Testing
+
+**Scope**: `safebreach_mcp_studio/tests/test_rate_limiting.py`
+
+**Key Scenarios**:
+- Gate integration tests are unaffected (they mock `rate_limiter` directly, not `_rate_limit_enabled`)
+- No changes required
+
+### Verification
+
+- Run: `uv run pytest safebreach_mcp_core/tests/test_rate_limiter.py -v`
+- Run: `uv run pytest safebreach_mcp_studio/tests/test_rate_limiting.py -v`
+- Run full suite: `uv run pytest safebreach_mcp_config/tests/ safebreach_mcp_data/tests/
+  safebreach_mcp_utilities/tests/ safebreach_mcp_playbook/tests/ safebreach_mcp_studio/tests/
+  -v -m "not e2e"`
+
+---
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Flip default + test fixture + docs | ⏳ Pending | - | - | Single phase — all 3 changes |
+
+---
+
+### Phase 1: Flip Default, Update Tests, Update Docs
+
+**Semantic Change**: Change rate limiter default from enabled to disabled, update test fixtures
+and documentation to match.
+
+**Deliverables**: Rate limiting disabled by default; tests pass; documentation accurate.
+
+**Implementation Details**:
+
+1. **`safebreach_mcp_core/rate_limiter.py`** (line 33):
+   Change the second argument of `os.environ.get("SAFEBREACH_MCP_RATE_LIMIT_ENABLED", ...)` from
+   `"true"` to `"false"`. This makes `_rate_limit_enabled` evaluate to `False` when the env var
+   is not set.
+
+2. **`safebreach_mcp_core/tests/test_rate_limiter.py`**:
+   Add a new `autouse` fixture named `enable_rate_limiter` that patches
+   `safebreach_mcp_core.rate_limiter._rate_limit_enabled` to `True` using `unittest.mock.patch`
+   as a context manager. Place it at module level alongside the existing `reset_rate_limiter`
+   fixture. Tests in `TestConfiguration` that explicitly patch `_rate_limit_enabled` to `False`
+   will override this fixture because `@patch` decorators apply inside the fixture's context.
+
+3. **`CLAUDE.md`**:
+   Find all occurrences of `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` documentation that say
+   `default: true` or `default: \`true\`` and change them to `default: false` or
+   `default: \`false\``.
+
+**Changes**:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `safebreach_mcp_core/rate_limiter.py` | Modify | `"true"` → `"false"` default arg |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Modify | Add `enable_rate_limiter` autouse fixture |
+| `CLAUDE.md` | Modify | Update default to `false` in rate limiting docs |
+
+**Git Commit**: `feat: disable actions rate limiter by default (SAF-31054)`
+
+---
+
+## 10. Risks and Assumptions
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Deployments relying on default-enabled rate limiting lose protection | Low — rate limiting
+was recently introduced in SAF-29871 and not yet content-configurable | Document the change;
+operators who want rate limiting can set `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true` |
+
+### Assumptions
+
+- No production deployments currently depend on the default-enabled rate limiting behavior
+  (the feature was just shipped in SAF-29871)
+- Content-based configuration will be implemented separately, at which point the default may
+  be revisited
+
+---
+
+## 11. Future Enhancements
+
+- **Content-based rate limit configuration**: A separate work item (to be opened by Tal) will
+  allow configuring rate limiting thresholds and enable/disable state from within the SafeBreach
+  platform. Once available, the default may be flipped back to enabled.
+
+---
+
+## 12. Executive Summary
+
+- **Issue/Feature Description**: The rate limiter introduced in SAF-29871 defaults to enabled,
+  which is premature until content-based configuration is available.
+- **What Will Be Built**: A one-line default change, test fixture update, and documentation update.
+- **Key Technical Decisions**: Flip default rather than removing rate limiting entirely, preserving
+  the infrastructure for future content-based configuration.
+- **Scope**: 3 files changed; no logic modifications, no gate placement changes, no API changes.
+- **Business Value**: Prevents unexpected blocking of legitimate AI agent workflows while retaining
+  the rate limiting guardrail for explicit opt-in use.
+
+---
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-05-14 15:50 | PRD created — initial draft |

--- a/prds/SAF-31054-disable-actions-rate-limit-by-default/summary.md
+++ b/prds/SAF-31054-disable-actions-rate-limit-by-default/summary.md
@@ -1,0 +1,75 @@
+# SAF-31054 — Ticket Summary
+
+## Proposed Title
+
+[safebreach-mcp] Make the actions rate limiter disabled by default
+
+## Problem Statement
+
+The rate limiting mechanism introduced in SAF-29871 is **enabled by default**. Because rate limit
+thresholds and windows are not yet configurable from within the SafeBreach platform (content-side
+configuration is a separate future work item), enabling rate limiting by default is premature and
+may unexpectedly block legitimate AI agent workflows. The limiter should be **opt-in** until
+content-based configuration is available.
+
+## Proposed Description
+
+In SAF-29871 we introduced a per-caller sliding-window rate limiting mechanism for all non-readOnly
+MCP tools. It is currently enabled by default.
+
+We want to change the default to **disabled** (`SAFEBREACH_MCP_RATE_LIMIT_ENABLED=false`) so rate
+limiting is opt-in until it can be configured via the SafeBreach platform content
+(separate work item tracked by Tal).
+
+**Operators who want rate limiting** can enable it explicitly:
+```bash
+export SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true
+```
+
+## Implementation
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_core/rate_limiter.py` | Line 33: `"true"` → `"false"` in `os.environ.get()` default |
+| `CLAUDE.md` | Update rate limiting env var doc: `default: true` → `default: false` |
+| `safebreach_mcp_core/tests/test_rate_limiter.py` | Add `enable_rate_limiter` autouse fixture |
+
+### Code Change Detail
+
+**`safebreach_mcp_core/rate_limiter.py` (line 32–34):**
+```python
+# Before
+_rate_limit_enabled: bool = os.environ.get(
+    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "true"
+).strip().lower() in ("true", "1", "yes")
+
+# After
+_rate_limit_enabled: bool = os.environ.get(
+    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "false"
+).strip().lower() in ("true", "1", "yes")
+```
+
+**`safebreach_mcp_core/tests/test_rate_limiter.py` — add fixture:**
+```python
+@pytest.fixture(autouse=True)
+def enable_rate_limiter():
+    """Enable rate limiting for unit tests (overrides the disabled-by-default config)."""
+    with patch("safebreach_mcp_core.rate_limiter._rate_limit_enabled", True):
+        yield
+```
+
+## Acceptance Criteria
+
+- [ ] `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` defaults to `false` (rate limiting disabled by default)
+- [ ] Rate limiting can be explicitly enabled via `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true`
+- [ ] All existing unit tests pass (with `enable_rate_limiter` autouse fixture)
+- [ ] `CLAUDE.md` documents the new default as `false`
+- [ ] No changes to the rate limiting logic or gate placement
+
+## Out of Scope
+
+- Changing rate limiting thresholds, windows, or gate placement (no logic changes)
+- Content-based configuration (separate future work item)
+- E2E test changes (tests use explicit env var overrides already)

--- a/safebreach_mcp_core/rate_limiter.py
+++ b/safebreach_mcp_core/rate_limiter.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # Configuration (read at module load, patchable in tests)
 # ---------------------------------------------------------------------------
 _rate_limit_enabled: bool = os.environ.get(
-    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "true"
+    "SAFEBREACH_MCP_RATE_LIMIT_ENABLED", "false"
 ).strip().lower() in ("true", "1", "yes")
 
 _action_limit: int = int(os.environ.get("SAFEBREACH_MCP_ACTION_LIMIT", "10"))

--- a/safebreach_mcp_core/tests/test_rate_limiter.py
+++ b/safebreach_mcp_core/tests/test_rate_limiter.py
@@ -19,6 +19,13 @@ def reset_rate_limiter():
     _rate_limit_store.clear()
 
 
+@pytest.fixture(autouse=True)
+def enable_rate_limiter():
+    """Enable rate limiting for unit tests (overrides the disabled-by-default config)."""
+    with patch("safebreach_mcp_core.rate_limiter._rate_limit_enabled", True):
+        yield
+
+
 @pytest.fixture
 def limiter():
     return RateLimiter()


### PR DESCRIPTION
## Summary

- Changes `SAFEBREACH_MCP_RATE_LIMIT_ENABLED` default from `true` to `false`, making rate limiting opt-in
- Adds `enable_rate_limiter` autouse fixture to unit tests so they continue exercising rate limiting logic
- Updates `CLAUDE.md` documentation to reflect the new default

**Why**: Rate limiting (introduced in SAF-29871) is not yet configurable from the SafeBreach platform. Until content-based configuration is available, having it enabled by default may unexpectedly block legitimate AI agent workflows.

**Operators who want rate limiting** can still enable it: `SAFEBREACH_MCP_RATE_LIMIT_ENABLED=true`

## Changes

| File | Change |
|------|--------|
| `safebreach_mcp_core/rate_limiter.py` | `"true"` → `"false"` default arg |
| `safebreach_mcp_core/tests/test_rate_limiter.py` | Add `enable_rate_limiter` autouse fixture |
| `CLAUDE.md` | Update default to `false` in rate limiting docs |

## Test plan

- [x] 26/26 rate limiter unit tests pass
- [x] 16/16 gate integration tests pass  
- [x] 1021/1021 cross-server tests pass (excluding e2e)
- [x] `TestConfiguration.test_disabled_*` still correctly test disabled behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)