### PR TITLE
SAF-31111: Make manage_test idempotent with real-time orchestrator state check

### DIFF
--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/context.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/context.md
@@ -1,0 +1,95 @@
+# SAF-31111: manage_test tool is failing to cancel a test
+
+## Status
+Phase 5: Problem Analysis Complete
+
+## Ticket Info
+- **Type**: Bug
+- **Priority**: Medium
+- **Assignee**: Yossi Attas
+- **Sprint**: Saf sprint 89 (May 12-26, 2026)
+- **Branch**: SAF-31111-manage_test-failing-to-cancel-tests
+
+## Description
+The `manage_test` tool fails when attempting to cancel a test. The original ticket hypothesis was
+that the code uses `POST` instead of `DELETE` — this was disproven. The actual root cause is a
+**lack of idempotency**: `manage_test` doesn't check the test's current state before sending the
+API call.
+
+## Investigation Findings
+
+### Repository: safebreach-mcp
+
+#### Initial Hypothesis Disproven
+The code at `studio_functions.py:2627` has always used `requests.delete()` since the initial commit
+(`289efde`, SAF-29969). Verified at tag `1.1.0` and HEAD — identical. The E2E cancel test
+(`test_e2e_cancel_test`) passes against pentest01.
+
+#### Root Cause: Lack of Idempotency
+`_set_test_state()` sends the API call without checking the test's current status. The orchestrator
+API returns errors for invalid state transitions:
+
+| Test State | Cancel (DELETE) | Pause (PUT) | Resume (PUT) |
+|------------|----------------|-------------|--------------|
+| Running | 200 (success) | 200 (success) | N/A |
+| Paused | **500** `"no plan was stopped"` | N/A | 200 (success) |
+| Canceled | **404** `PLAN_NOT_EXISTS` | 200 (silent no-op) | **500** crash |
+| Completed | **404** `PLAN_NOT_EXISTS` | ? | ? |
+
+These errors propagate through `check_rbac_response()` → `raise_for_status()` → exception →
+tool returns `"Error managing test: ..."`.
+
+**Notably**: Canceling a **paused** test returns 500 — the orchestrator requires the test to be
+running for DELETE to work.
+
+#### Secondary Issue: Note Append Error Exposure
+`_append_test_note()` failures are caught but the error text (e.g., "500 Server Error") is
+included in the tool response. An LLM may interpret this as the entire cancel having failed.
+
+#### Code Flow (studio_functions.py)
+1. `sb_manage_test()` (line 2702) — validates input, calls `_set_test_state()`
+2. `_set_test_state()` (line 2604) — sends DELETE/PUT without state pre-check
+3. `_append_test_note()` (line 2648) — best-effort GET+PUT to add comment
+
+## Problem Analysis
+
+### What Needs to Change
+1. **Pre-check test state** via `GET testsummaries/{test_id}` before the action
+2. **Idempotent quick-return** if test is already in the desired terminal state
+   (cancel on canceled/completed → success, not error)
+3. **Informative error** for invalid transitions
+   (cancel on paused → "test is paused, resume first then cancel")
+4. **Silent note failures** — log only, don't expose error text in tool response
+
+### State Transition Matrix (proposed)
+| Current State | Cancel | Pause | Resume |
+|--------------|--------|-------|--------|
+| Running | Execute DELETE | Execute PUT | Already running |
+| Paused | Error: resume first | Already paused | Execute PUT |
+| Canceled | Quick-return: already canceled | Error: already canceled | Error: already canceled |
+| Completed | Quick-return: already completed | Error: already completed | Error: already completed |
+
+## Files of Interest
+| File | Lines | Purpose |
+|------|-------|---------|
+| `safebreach_mcp_studio/studio_functions.py` | 2604-2645 | `_set_test_state()` — HTTP call |
+| `safebreach_mcp_studio/studio_functions.py` | 2648-2699 | `_append_test_note()` — note append |
+| `safebreach_mcp_studio/studio_functions.py` | 2702-2756 | `sb_manage_test()` — orchestration |
+| `safebreach_mcp_studio/studio_server.py` | 1410-1474 | Tool registration + response formatting |
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | 7310-7341 | Cancel unit tests |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | 97-139 | Cancel E2E test |
+
+## E2E Reproduction Evidence
+```
+# Cancel already-canceled test (1778761910751.16) — returns 404
+DELETE /api/orch/v4/accounts/3471166703/queue/1778761910751.16
+→ 404: {"error":{"statusCode":404,"message":"no test with runId ... was found","type":"PLAN_NOT_EXISTS"}}
+
+# Cancel paused test (1778678311904.157) — returns 500
+DELETE /api/orch/v4/accounts/3471166703/queue/1778678311904.157
+→ 500: {"error":{"message":"no plan was stopped"}}
+
+# Cancel completed test (1778774475413.82) — returns 404
+DELETE /api/orch/v4/accounts/3471166703/queue/1778774475413.82
+→ 404: {"error":{"statusCode":404,"message":"no test with runId ... was found","type":"PLAN_NOT_EXISTS"}}
+```

--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/context.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/context.md
@@ -1,7 +1,7 @@
 # SAF-31111: manage_test tool is failing to cancel a test
 
 ## Status
-Phase 5: Problem Analysis Complete
+Phase 6: PRD Created
 
 ## Ticket Info
 - **Type**: Bug

--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
@@ -17,8 +17,8 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Approved |
-| **Last Updated** | 2026-05-14 22:30 |
+| **PRD Status** | In Progress |
+| **Last Updated** | 2026-05-14 23:00 |
 | **Owner** | Yossi Attas |
 | **Current Phase** | N/A |
 
@@ -119,7 +119,7 @@ error text in the tool response. Note failures should be logged but not shown to
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: State pre-check and idempotent handling | ⏳ Pending | - | - | |
+| Phase 1: State pre-check and idempotent handling | ✅ Complete | 2026-05-14 | - | 34 unit + 4 rate limiting tests |
 | Phase 2: Silent note append failures | ⏳ Pending | - | - | |
 
 ---

--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
@@ -17,7 +17,7 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | In Progress |
+| **PRD Status** | Complete |
 | **Last Updated** | 2026-05-14 23:00 |
 | **Owner** | Yossi Attas |
 | **Current Phase** | N/A |
@@ -120,7 +120,7 @@ error text in the tool response. Note failures should be logged but not shown to
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
 | Phase 1: State pre-check and idempotent handling | ✅ Complete | 2026-05-14 | - | 34 unit + 4 rate limiting tests |
-| Phase 2: Silent note append failures | ⏳ Pending | - | - | |
+| Phase 2: Silent note append failures | ✅ Complete | 2026-05-14 | - | Note Warning removed from response |
 
 ---
 

--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/prd.md
@@ -1,0 +1,248 @@
+# Make manage_test Idempotent with State Pre-Check — SAF-31111
+
+## 1. Overview
+
+- **Task Type**: Bug fix
+- **Purpose**: The `manage_test` MCP tool fails when attempting lifecycle actions (cancel, pause,
+  resume) on tests that are not in the expected state. The orchestrator API returns 404/500 errors
+  for invalid transitions, which propagate as tool failures to LLM agents.
+- **Target Consumer**: LLM agents using the SafeBreach MCP server
+- **Key Benefits**:
+  - Idempotent cancel: canceling an already-canceled/completed test returns success instead of error
+  - Clear error messages for invalid transitions (e.g., cancel while paused)
+  - Note append failures no longer confuse LLMs with embedded error text
+- **Originating Request**: SAF-31111
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Approved |
+| **Last Updated** | 2026-05-14 22:30 |
+| **Owner** | Yossi Attas |
+| **Current Phase** | N/A |
+
+## 2. Solution Description
+
+**Chosen Solution**: Add a state pre-check via `GET testsummaries/{test_id}` before executing any
+lifecycle action. Map the current state against a transition matrix and either proceed, quick-return
+(idempotent), or return an informative error.
+
+**Alternatives Considered**:
+- **Catch specific HTTP errors after the fact**: Parse 404/500 responses and translate them. Rejected
+  because the orchestrator API error messages are inconsistent (500 for both "no plan was stopped"
+  and server crashes) and this approach requires maintaining fragile error parsing.
+- **Let the LLM handle retries**: Do nothing and rely on the LLM to understand the error. Rejected
+  because LLMs interpret any error text as failure and enter retry loops.
+
+**Decision Rationale**: Pre-checking state is one extra GET per call but provides deterministic
+behavior. The data API `testsummaries` endpoint is reliable (verified via E2E testing) and returns
+the test status consistently.
+
+## 3. Core Feature Components
+
+### Component A: State Pre-Check and Transition Validation
+
+**Purpose**: Modify `sb_manage_test()` to fetch the test's current state before executing the
+lifecycle action. Handle idempotent quick-returns and invalid transitions.
+
+**Key Features**:
+- New `_get_test_state()` helper that calls `GET testsummaries/{test_id}` and returns the status
+- State transition validation matrix in `sb_manage_test()`:
+
+| Current State | Cancel | Pause | Resume |
+|--------------|--------|-------|--------|
+| RUNNING | Execute DELETE | Execute PUT | Quick-return: already running |
+| PAUSED | Error: resume first | Quick-return: already paused | Execute PUT |
+| CANCELED | Quick-return: already canceled | Error: terminal state | Error: terminal state |
+| COMPLETED | Quick-return: already completed | Error: terminal state | Error: terminal state |
+
+- Quick-returns set `status="already_<state>"` with `hint_to_agent` explaining the situation
+- Invalid transitions raise `ValueError` with actionable guidance
+
+### Component B: Silent Note Append Failures
+
+**Purpose**: Modify the tool response formatting in `studio_server.py` to not expose note append
+error text in the tool response. Note failures should be logged but not shown to the LLM.
+
+**Key Features**:
+- Remove the `**Note Warning:**` line from the tool response when note append fails
+- Keep logging the failure via `logger.warning()` for debugging
+- The `note_status` and `note_error` fields remain in the function result dict for internal use
+
+## 4. API Endpoints and Integration
+
+**Existing API Consumed (new usage)**:
+- **API Name**: Get Test Summary
+- **URL**: `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`
+- **Headers**: `x-apitoken`, `Content-Type: application/json`
+- **Response**: JSON with `status` field — values: `RUNNING`, `PAUSED`, `CANCELED`, `COMPLETED`
+- **Already used by**: `_append_test_note()` for comment read/write
+
+## 7. Definition of Done
+
+- [ ] `_get_test_state()` helper function fetches test status via GET testsummaries
+- [ ] `sb_manage_test()` calls `_get_test_state()` before `_set_test_state()`
+- [ ] Cancel on CANCELED/COMPLETED returns success with `status="already_canceled"` /
+  `"already_completed"`
+- [ ] Cancel on PAUSED raises ValueError with "resume first" guidance
+- [ ] Pause on PAUSED returns success with `status="already_paused"`
+- [ ] Resume on RUNNING returns success with `status="already_running"`
+- [ ] Actions on terminal states (CANCELED/COMPLETED) for pause/resume raise ValueError
+- [ ] Pre-check GET failure propagates as an error (don't silently skip)
+- [ ] Note append failures are logged but NOT shown in tool response
+- [ ] All existing tests pass
+- [ ] Unit tests cover all state transition scenarios
+- [ ] E2E test for cancel-on-canceled idempotency
+
+## 8. Testing Strategy
+
+**Unit Testing**:
+- **Framework**: pytest with unittest.mock
+- **Scope**: All state transition scenarios in `test_studio_functions.py`
+- **Key Scenarios**:
+  - Cancel on each state (RUNNING, PAUSED, CANCELED, COMPLETED)
+  - Pause on each state
+  - Resume on each state
+  - Pre-check GET failure handling
+  - Note append failure no longer in tool response
+- **Mocking**: Mock `requests.get` for the testsummaries pre-check, existing mocks for
+  `requests.delete`/`requests.put`
+
+**E2E Testing**:
+- Add idempotent cancel test: cancel an already-canceled test and verify success response
+- Use existing E2E framework in `test_e2e_manage_test.py`
+
+## 9. Implementation Phases
+
+### Phase Status Tracking
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: State pre-check and idempotent handling | ⏳ Pending | - | - | |
+| Phase 2: Silent note append failures | ⏳ Pending | - | - | |
+
+---
+
+### Phase 1: State Pre-Check and Idempotent Handling
+
+**Semantic Change**: Add state pre-check to `sb_manage_test()` so lifecycle actions are validated
+against the test's current state before execution.
+
+**Deliverables**:
+- `_get_test_state()` helper function
+- State transition validation in `sb_manage_test()`
+- Idempotent quick-returns and informative error messages
+- Unit tests for all state transition scenarios
+- E2E test for cancel-on-canceled idempotency
+
+**Implementation Details**:
+
+1. **New function `_get_test_state(test_id, console)`** in `studio_functions.py`:
+   - Call `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}` (same endpoint as
+     `_append_test_note` step 1)
+   - Extract and return the `status` field from the response JSON
+   - Use the same auth headers pattern as other functions (`get_auth_headers_for_console`)
+   - Timeout: 30 seconds
+   - On failure: let the exception propagate (caller handles it)
+   - Return type: string (e.g., "RUNNING", "PAUSED", "CANCELED", "COMPLETED")
+
+2. **Modify `sb_manage_test()`** — add state pre-check between input validation and
+   `_set_test_state()`:
+   - Call `_get_test_state(test_id, console)` to get current status
+   - Normalize the status to uppercase for comparison
+   - Define terminal states: `{"CANCELED", "COMPLETED"}`
+   - Define the state transition logic:
+     - **Cancel action**:
+       - If CANCELED or COMPLETED: return quick-return dict with
+         `status="already_canceled"` or `"already_completed"`, `was_already=True`,
+         and appropriate `hint_to_agent`
+       - If PAUSED: raise `ValueError` with message telling the agent to resume first
+       - If RUNNING: proceed to `_set_test_state()`
+     - **Pause action**:
+       - If PAUSED: return quick-return dict with `status="already_paused"`, `was_already=True`
+       - If CANCELED or COMPLETED: raise `ValueError` — cannot pause a terminal test
+       - If RUNNING: proceed to `_set_test_state()`
+     - **Resume action**:
+       - If RUNNING: return quick-return dict with `status="already_running"`, `was_already=True`
+       - If CANCELED or COMPLETED: raise `ValueError` — cannot resume a terminal test
+       - If PAUSED: proceed to `_set_test_state()`
+   - Quick-return dicts include: `test_id`, `action`, `status`, `was_already=True`,
+     `current_state`, and `hint_to_agent`
+   - Rate limiting: do NOT call `check_limit` or `record_action` for quick-returns
+     (no mutation occurred)
+
+3. **Update tool handler** in `studio_server.py` — handle the `was_already` flag:
+   - When `result.get('was_already')` is True, format the response to indicate the test was
+     already in the desired state (e.g., "Test is already canceled. No action needed.")
+   - Include the `hint_to_agent` in the response
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/studio_functions.py` | Add `_get_test_state()`, modify `sb_manage_test()` |
+| `safebreach_mcp_studio/studio_server.py` | Update `manage_test` tool handler for `was_already` |
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add state transition unit tests |
+| `safebreach_mcp_studio/tests/test_e2e_manage_test.py` | Add cancel-on-canceled E2E test |
+
+**Test Plan**:
+- Unit tests for `_get_test_state()`: success, API error
+- Unit tests for each cell in the state transition matrix (4 states x 3 actions = 12 tests)
+- Unit test that quick-returns do NOT trigger rate limiting
+- Unit test that the tool handler formats `was_already` responses correctly
+- E2E test: queue a test, cancel it, cancel it again — second cancel returns success
+
+**Git Commit**: `fix(studio): make manage_test idempotent with state pre-check (SAF-31111)`
+
+---
+
+### Phase 2: Silent Note Append Failures
+
+**Semantic Change**: Remove note append error text from the tool response so LLMs don't interpret
+it as an operation failure.
+
+**Deliverables**:
+- Modified tool response formatting — no `**Note Warning:**` line
+- Unit test verifying note failures are not in the tool response
+
+**Implementation Details**:
+
+1. **Modify tool handler** in `studio_server.py`:
+   - Remove the `elif result.get('note_status') == 'failed'` block that adds
+     `**Note Warning:** Failed to append note — ...` to the response
+   - The note failure is already logged via `logger.warning()` in `_append_test_note()`
+   - The `note_status` and `note_error` fields remain in the function result dict (internal use)
+
+2. **No changes to `_append_test_note()`** — it already handles errors correctly and logs them
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `safebreach_mcp_studio/studio_server.py` | Remove note failure line from tool response |
+| `safebreach_mcp_studio/tests/test_studio_functions.py` | Add test verifying note error not in response |
+
+**Test Plan**:
+- Unit test: call `manage_test` tool handler with a result containing
+  `note_status="failed"` — verify the response string does NOT contain "Note Warning"
+  or error text
+
+**Git Commit**: `fix(studio): suppress note append errors from manage_test tool response (SAF-31111)`
+
+## 12. Executive Summary
+
+- **Issue**: `manage_test` tool fails with HTTP errors (404/500) when attempting lifecycle actions
+  on tests that are not in the expected state (already canceled, completed, or paused)
+- **What Was Built**: State pre-check via data API before lifecycle actions, with idempotent
+  quick-returns for terminal states and informative errors for invalid transitions
+- **Key Technical Decisions**: Pre-check via GET testsummaries (one extra API call) rather than
+  post-hoc error parsing; note append errors suppressed from tool response
+- **Business Value**: LLM agents no longer enter retry loops on valid no-op scenarios; clearer
+  error guidance for invalid state transitions
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-05-14 22:30 | PRD created — initial draft |

--- a/prds/SAF-31111-manage_test-failing-to-cancel-tests/summary.md
+++ b/prds/SAF-31111-manage_test-failing-to-cancel-tests/summary.md
@@ -1,0 +1,158 @@
+# Ticket Summary: SAF-31111
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repository**: safebreach-mcp
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] manage_test tool is failing to cancel a test
+**Issues Identified**: Original hypothesis (POST vs DELETE) was incorrect. The actual root cause
+is lack of idempotency — `manage_test` doesn't check the test's current state before sending
+the API call.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- The cancel implementation has always used `requests.delete()` since the initial commit
+- E2E cancel test passes when the test is in a running state
+- Canceling non-running tests (paused, canceled, completed) returns HTTP errors (404/500)
+- The orchestrator API does not support idempotent cancel operations
+- Note append failures expose error text in the tool response, potentially confusing LLMs
+- Relevant files:
+  - `safebreach_mcp_studio/studio_functions.py` — `_set_test_state()`, `sb_manage_test()`,
+    `_append_test_note()`
+  - `safebreach_mcp_studio/studio_server.py` — tool registration and response formatting
+  - `safebreach_mcp_studio/tests/test_studio_functions.py` — unit tests
+  - `safebreach_mcp_studio/tests/test_e2e_manage_test.py` — E2E tests
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The `manage_test` tool sends lifecycle API calls (cancel/pause/resume) without first checking the
+test's current state. The SafeBreach orchestrator API returns errors for invalid state transitions:
+- Cancel on paused test: 500 "no plan was stopped"
+- Cancel on canceled/completed test: 404 "PLAN_NOT_EXISTS"
+- Resume on canceled test: 500 (server crash)
+
+These errors propagate through `raise_for_status()` and the tool returns an error message. An LLM
+agent calling `manage_test` to cancel a test that was already canceled, paused, or completed sees
+a failure — even though the desired outcome (test not running) is already achieved.
+
+### Impact Assessment
+- **LLM usability**: Agents retry failed operations, potentially sending unnecessary API calls
+- **User experience**: Error messages for valid no-op scenarios create confusion
+- **Paused test cancel**: Cannot cancel a paused test at all — must resume first, which is
+  unintuitive
+
+### Risks & Edge Cases
+- Pre-check GET adds one extra API call per `manage_test` invocation
+- Race condition: test state could change between pre-check and action (acceptable — the action
+  would then succeed or get a retriable error)
+- Note append on canceled/completed tests: data API GET works (200), PUT should also work
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Make manage_test idempotent with state pre-check
+
+### Description
+
+**Background**
+The `manage_test` MCP tool allows LLM agents to pause, resume, or cancel running tests. Currently,
+it sends lifecycle API calls without checking the test's current state, causing errors when the
+test is not in the expected state.
+
+**Important**: Canceling a test does NOT delete it from history. The test remains in test history
+(accessible via `get_tests` and `get_test_details`) with a "canceled" status. A dedicated tool for
+deleting tests from history will be created separately.
+
+**Technical Context**
+* The orchestrator queue API returns 404 for cancel on completed/canceled tests and 500 for cancel
+  on paused tests
+* `_set_test_state()` in `studio_functions.py` calls the API blindly without state pre-check
+* `_append_test_note()` catches errors but includes error text in the tool response, which can
+  confuse LLM agents
+
+**Problem Description**
+* Canceling a paused test returns 500 `"no plan was stopped"` — user must resume first then cancel
+* Canceling an already-canceled or completed test returns 404 `PLAN_NOT_EXISTS`
+* Resuming a canceled test causes a 500 server crash
+* These are all surfaced as tool errors to the LLM, causing retry loops and confusion
+
+**Affected Areas**
+* `safebreach_mcp_studio/studio_functions.py`: `_set_test_state()`, `sb_manage_test()`,
+  `_append_test_note()`
+* `safebreach_mcp_studio/studio_server.py`: tool response formatting
+* `safebreach_mcp_studio/tests/test_studio_functions.py`: unit tests
+* `safebreach_mcp_studio/tests/test_e2e_manage_test.py`: E2E tests
+
+### Acceptance Criteria
+
+- [ ] `manage_test` pre-checks test state via `GET testsummaries/{test_id}` before action
+- [ ] Cancel on canceled/completed test returns success (idempotent quick-return)
+- [ ] Cancel on paused test returns informative error: suggest resume first
+- [ ] Pause on already-paused test returns success (idempotent)
+- [ ] Resume on already-running test returns success (idempotent)
+- [ ] Actions on terminal states (canceled/completed) return informative messages, not errors
+- [ ] Note append failures are logged but NOT exposed in the tool response
+- [ ] Unit tests cover all state transition scenarios (running, paused, canceled, completed)
+- [ ] E2E test for cancel-on-canceled idempotency
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+The `manage_test` MCP tool allows LLM agents to pause, resume, or cancel running tests.
+Currently, it sends lifecycle API calls without checking the test's current state, causing
+errors when the test is not in the expected state.
+
+### Technical Context
+* The orchestrator queue API returns 404 for cancel on completed/canceled tests and 500 for
+  cancel on paused tests
+* `_set_test_state()` in `studio_functions.py` calls the API without state pre-check
+* `_append_test_note()` catches errors but includes error text in the tool response
+
+### Problem Description
+* Canceling a paused test returns 500 — user must resume first then cancel
+* Canceling already-canceled or completed test returns 404 PLAN_NOT_EXISTS
+* Resuming a canceled test causes a 500 server crash
+* These are surfaced as tool errors, causing LLM retry loops and confusion
+
+### Fix
+* Add state pre-check via GET testsummaries/{test_id} before action
+* Idempotent quick-return for terminal states (canceled/completed)
+* Informative error for invalid transitions (e.g., cancel while paused)
+* Silent note append failures (log only, don't expose in response)
+
+### Affected Areas
+* `safebreach_mcp_studio/studio_functions.py`
+* `safebreach_mcp_studio/studio_server.py`
+* `safebreach_mcp_studio/tests/`
+```
+
+**Acceptance Criteria:**
+```markdown
+* manage_test pre-checks test state via GET testsummaries before action
+* Cancel on canceled/completed test returns success (idempotent quick-return)
+* Cancel on paused test returns informative error: suggest resume first
+* Pause on already-paused test returns success (idempotent)
+* Resume on already-running test returns success (idempotent)
+* Actions on terminal states return informative messages, not errors
+* Note append failures are logged but NOT exposed in the tool response
+* Unit tests cover all state transition scenarios
+* E2E test for cancel-on-canceled idempotency
+```

--- a/safebreach_mcp_core/queue_state.py
+++ b/safebreach_mcp_core/queue_state.py
@@ -1,0 +1,63 @@
+"""
+Orchestrator queue state lookup.
+
+Provides real-time test state from the orchestrator ``GET /queue`` endpoint.
+The data API (``testsummaries``) has 10-15 seconds of eventual consistency lag
+after lifecycle changes; the orchestrator queue reflects state immediately.
+
+Usage::
+
+    from safebreach_mcp_core.queue_state import get_orchestrator_test_state
+
+    state = get_orchestrator_test_state("1778787545455.150", "pentest01")
+    # Returns "RUNNING", "PAUSED", or None (test not in queue)
+"""
+
+import logging
+
+import requests
+from safebreach_mcp_core.secret_utils import get_auth_headers_for_console, check_rbac_response
+from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
+
+logger = logging.getLogger(__name__)
+
+
+def get_orchestrator_test_state(test_id: str, console: str) -> str | None:
+    """
+    Check the orchestrator queue for a test's real-time state.
+
+    Calls ``GET /api/orch/v4/accounts/{account_id}/queue`` and searches
+    ``slotState`` for the given ``planRunId``.
+
+    Args:
+        test_id: Test execution ID (planRunId)
+        console: SafeBreach console identifier
+
+    Returns:
+        ``"RUNNING"`` or ``"PAUSED"`` if the test is in an active slot,
+        ``None`` if the test is not in the queue (terminal or unknown).
+        On API error, returns ``None`` (caller should fall back to data API).
+    """
+    try:
+        orch_base = get_api_base_url(console, 'orchestrator')
+        account_id = get_api_account_id(console)
+        queue_url = f"{orch_base}/api/orch/v4/accounts/{account_id}/queue"
+        headers = {"accept": "application/json", **get_auth_headers_for_console(console)}
+
+        response = requests.get(queue_url, headers=headers, timeout=30)
+        check_rbac_response(response)
+        queue_data = response.json().get('data', {})
+
+        for slot in queue_data.get('slotState', []):
+            if slot.get('planRunId') == test_id:
+                if slot.get('isPaused'):
+                    return "PAUSED"
+                return "RUNNING"
+
+        return None  # Test not in any slot
+
+    except Exception as e:
+        logger.warning(
+            "Orchestrator queue check failed for '%s': %s", test_id, e
+        )
+        return None

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -420,24 +420,35 @@ def sb_get_test_details(test_id: str, console: str = "default",
         # Try the list endpoint first (via cache) — it includes findingsCount/compromisedHosts
         return_details = _find_test_in_cached_list(test_id, console)
 
-        # If cached entry shows a non-terminal status, fetch fresh from single-test
-        # endpoint. The cached list can be up to 30 minutes stale, and transient
+        # If cached entry shows a non-terminal status, fetch fresh status.
+        # The cached list can be up to 30 minutes stale, and transient
         # statuses (RUNNING, QUEUED, etc.) may have changed since caching.
+        # SAF-31111: Check orchestrator queue first (real-time) before the
+        # data API, which has 10-15s eventual consistency lag.
         terminal_statuses = {'completed', 'canceled', 'failed'}
         cached_status = (return_details.get('status', '') or '').lower() if return_details else ''
         if return_details is not None and cached_status not in terminal_statuses:
             logger.info("Test '%s' shows non-terminal status '%s' in cache — fetching fresh", test_id, cached_status)
-            try:
-                fresh = _fetch_single_test(test_id, console)
-                # Merge: use fresh status/end_time but keep cached extras
-                # (findingsCount, compromisedHosts) that single-test omits
-                return_details['status'] = fresh.get('status', return_details['status'])
-                return_details['end_time'] = fresh.get('end_time', return_details['end_time'])
-                return_details['simulations_statistics'] = fresh.get(
-                    'simulations_statistics', return_details['simulations_statistics']
-                )
-            except Exception as e:
-                logger.warning("Failed to refresh RUNNING test '%s': %s — using cached data", test_id, e)
+
+            # Phase 1: orchestrator queue (real-time, no lag)
+            from safebreach_mcp_core.queue_state import get_orchestrator_test_state
+            orch_state = get_orchestrator_test_state(test_id, console)
+            if orch_state is not None:
+                return_details['status'] = orch_state
+                logger.info("Test '%s' status from orchestrator queue: %s", test_id, orch_state)
+            else:
+                # Phase 2: data API single-test endpoint (eventual consistency)
+                try:
+                    fresh = _fetch_single_test(test_id, console)
+                    # Merge: use fresh status/end_time but keep cached extras
+                    # (findingsCount, compromisedHosts) that single-test omits
+                    return_details['status'] = fresh.get('status', return_details['status'])
+                    return_details['end_time'] = fresh.get('end_time', return_details['end_time'])
+                    return_details['simulations_statistics'] = fresh.get(
+                        'simulations_statistics', return_details['simulations_statistics']
+                    )
+                except Exception as e:
+                    logger.warning("Failed to refresh RUNNING test '%s': %s — using cached data", test_id, e)
 
         if return_details is None:
             # Fallback: single-test endpoint (missing findingsCount/compromisedHosts)

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2601,6 +2601,30 @@ def sb_run_scenario(
 # ---------------------------------------------------------------------------
 
 
+def _get_test_state(test_id: str, console: str) -> str:
+    """
+    Fetch the current state of a test via the data API.
+
+    Args:
+        test_id: Test execution ID (planRunId)
+        console: SafeBreach console identifier
+
+    Returns:
+        Status string, e.g. "RUNNING", "PAUSED", "CANCELED", "COMPLETED"
+
+    Raises:
+        requests.exceptions.RequestException: On API error
+    """
+    base_url = get_api_base_url(console, 'data')
+    account_id = get_api_account_id(console)
+    url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
+    headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
+
+    response = requests.get(url, headers=headers, timeout=30)
+    check_rbac_response(response)
+    return response.json().get('status', 'UNKNOWN')
+
+
 def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
     """
     Change a running test's state via the orchestrator API.
@@ -2727,6 +2751,57 @@ def sb_manage_test(
         )
 
     logger.info(f"Managing test {test_id}: action={action}, console={console}")
+
+    # State pre-check — SAF-31111: validate transition before API call
+    current_state = _get_test_state(test_id, console).upper()
+    terminal_states = {"CANCELED", "COMPLETED"}
+
+    # Idempotent quick-returns and invalid transition checks
+    if action == "cancel":
+        if current_state in terminal_states:
+            status_key = f"already_{current_state.lower()}"
+            return {
+                "test_id": test_id, "action": action, "status": status_key,
+                "was_already": True, "current_state": current_state,
+                "hint_to_agent": (
+                    f"Test is already {current_state.lower()}. No action needed. "
+                    "Use get_test_details to view results."
+                ),
+            }
+        if current_state == "PAUSED":
+            raise ValueError(
+                "Cannot cancel a paused test. Use manage_test with "
+                "action='resume' first, then cancel."
+            )
+    elif action == "pause":
+        if current_state == "PAUSED":
+            return {
+                "test_id": test_id, "action": action, "status": "already_paused",
+                "was_already": True, "current_state": current_state,
+                "hint_to_agent": (
+                    "Test is already paused. Use manage_test with action='resume' "
+                    "to continue, or action='cancel' to abort."
+                ),
+            }
+        if current_state in terminal_states:
+            raise ValueError(
+                f"Cannot pause a {current_state.lower()} test. "
+                "The test has already finished."
+            )
+    elif action == "resume":
+        if current_state == "RUNNING":
+            return {
+                "test_id": test_id, "action": action, "status": "already_running",
+                "was_already": True, "current_state": current_state,
+                "hint_to_agent": (
+                    "Test is already running. Use get_test_details to monitor progress."
+                ),
+            }
+        if current_state in terminal_states:
+            raise ValueError(
+                f"Cannot resume a {current_state.lower()} test. "
+                "The test has already finished."
+            )
 
     # Rate limiting gate — check before mutating
     caller_id = get_caller_identity()

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2606,11 +2606,6 @@ def _get_test_state(test_id: str, console: str) -> str:
     Fetch the current state of a test by consulting the orchestrator queue
     first (real-time), falling back to the data API (eventually consistent).
 
-    The orchestrator ``GET /queue`` endpoint returns live slot state including
-    ``isPaused`` for each running test.  If the test appears in a slot it is
-    either RUNNING or PAUSED.  If it does not appear, the data API
-    ``/testsummaries/{test_id}`` provides the terminal status.
-
     Args:
         test_id: Test execution ID (planRunId)
         console: SafeBreach console identifier
@@ -2621,36 +2616,19 @@ def _get_test_state(test_id: str, console: str) -> str:
     Raises:
         requests.exceptions.RequestException: On API error
     """
-    # --- Phase 1: ask the orchestrator (authoritative for active tests) ---
-    try:
-        orch_base = get_api_base_url(console, 'orchestrator')
-        account_id = get_api_account_id(console)
-        queue_url = f"{orch_base}/api/orch/v4/accounts/{account_id}/queue"
-        headers = {"accept": "application/json", **get_auth_headers_for_console(console)}
+    from safebreach_mcp_core.queue_state import get_orchestrator_test_state
 
-        response = requests.get(queue_url, headers=headers, timeout=30)
-        check_rbac_response(response)
-        queue_data = response.json().get('data', {})
+    # Phase 1: orchestrator queue (real-time for active tests)
+    orch_state = get_orchestrator_test_state(test_id, console)
+    if orch_state is not None:
+        return orch_state
 
-        # Search slotState for this test
-        for slot in queue_data.get('slotState', []):
-            if slot.get('planRunId') == test_id:
-                if slot.get('isPaused'):
-                    return "PAUSED"
-                return "RUNNING"
+    logger.info(
+        "Test '%s' not found in orchestrator queue — "
+        "falling back to data API", test_id
+    )
 
-        # Test not in any slot — it's no longer active
-        logger.info(
-            "Test '%s' not found in orchestrator queue — "
-            "falling back to data API", test_id
-        )
-    except Exception as e:
-        logger.warning(
-            "Orchestrator queue check failed for '%s': %s — "
-            "falling back to data API", test_id, e
-        )
-
-    # --- Phase 2: fall back to data API (terminal / historical tests) ---
+    # Phase 2: data API (terminal / historical tests)
     data_base = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
     url = f"{data_base}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2603,21 +2603,57 @@ def sb_run_scenario(
 
 def _get_test_state(test_id: str, console: str) -> str:
     """
-    Fetch the current state of a test via the data API.
+    Fetch the current state of a test by consulting the orchestrator queue
+    first (real-time), falling back to the data API (eventually consistent).
+
+    The orchestrator ``GET /queue`` endpoint returns live slot state including
+    ``isPaused`` for each running test.  If the test appears in a slot it is
+    either RUNNING or PAUSED.  If it does not appear, the data API
+    ``/testsummaries/{test_id}`` provides the terminal status.
 
     Args:
         test_id: Test execution ID (planRunId)
         console: SafeBreach console identifier
 
     Returns:
-        Status string, e.g. "RUNNING", "PAUSED", "CANCELED", "COMPLETED"
+        Status string: "RUNNING", "PAUSED", "CANCELED", "COMPLETED", etc.
 
     Raises:
         requests.exceptions.RequestException: On API error
     """
-    base_url = get_api_base_url(console, 'data')
+    # --- Phase 1: ask the orchestrator (authoritative for active tests) ---
+    try:
+        orch_base = get_api_base_url(console, 'orchestrator')
+        account_id = get_api_account_id(console)
+        queue_url = f"{orch_base}/api/orch/v4/accounts/{account_id}/queue"
+        headers = {"accept": "application/json", **get_auth_headers_for_console(console)}
+
+        response = requests.get(queue_url, headers=headers, timeout=30)
+        check_rbac_response(response)
+        queue_data = response.json().get('data', {})
+
+        # Search slotState for this test
+        for slot in queue_data.get('slotState', []):
+            if slot.get('planRunId') == test_id:
+                if slot.get('isPaused'):
+                    return "PAUSED"
+                return "RUNNING"
+
+        # Test not in any slot — it's no longer active
+        logger.info(
+            "Test '%s' not found in orchestrator queue — "
+            "falling back to data API", test_id
+        )
+    except Exception as e:
+        logger.warning(
+            "Orchestrator queue check failed for '%s': %s — "
+            "falling back to data API", test_id, e
+        )
+
+    # --- Phase 2: fall back to data API (terminal / historical tests) ---
+    data_base = get_api_base_url(console, 'data')
     account_id = get_api_account_id(console)
-    url = f"{base_url}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
+    url = f"{data_base}/api/data/v1/accounts/{account_id}/testsummaries/{test_id}"
     headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
 
     response = requests.get(url, headers=headers, timeout=30)
@@ -2631,7 +2667,7 @@ def _set_test_state(test_id: str, action: str, console: str) -> Dict[str, Any]:
 
     Args:
         test_id: Test execution ID (planRunId), e.g. "1776488350786.15"
-        action: Lifecycle action — currently "cancel" (pause/resume added later)
+        action: Lifecycle action — "cancel", "pause", or "resume"
         console: SafeBreach console identifier
 
     Returns:
@@ -2752,7 +2788,8 @@ def sb_manage_test(
 
     logger.info(f"Managing test {test_id}: action={action}, console={console}")
 
-    # State pre-check — SAF-31111: validate transition before API call
+    # State pre-check — SAF-31111: validate transition before API call.
+    # Uses orchestrator GET /queue (real-time) with data API fallback.
     current_state = _get_test_state(test_id, console).upper()
     terminal_states = {"CANCELED", "COMPLETED"}
 

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -1443,6 +1443,19 @@ manage_test(test_id="1776488350786.15", action="pause", console="demo",
             try:
                 result = sb_manage_test(test_id, action, console, reason)
 
+                # Idempotent quick-return — SAF-31111
+                if result.get('was_already'):
+                    response_parts = [
+                        f"## Test {action.capitalize()} — No Action Needed",
+                        "",
+                        f"**Test ID:** {result['test_id']}",
+                        f"**Status:** Test is already {result['current_state'].lower()}.",
+                    ]
+                    if result.get('hint_to_agent'):
+                        response_parts.append("")
+                        response_parts.append(f"**Hint:** {result['hint_to_agent']}")
+                    return "\n".join(response_parts)
+
                 action_display = action.capitalize()
                 response_parts = [
                     f"## Test {action_display}",
@@ -1454,11 +1467,6 @@ manage_test(test_id="1776488350786.15", action="pause", console="demo",
 
                 if result.get('note_status') == 'success':
                     response_parts.append(f"**Note:** {result['note']}")
-                elif result.get('note_status') == 'failed':
-                    response_parts.append(
-                        f"**Note Warning:** Failed to append note — "
-                        f"{result.get('note_error', 'unknown error')}"
-                    )
 
                 if result.get('hint_to_agent'):
                     response_parts.append("")

--- a/safebreach_mcp_studio/tests/test_e2e_manage_test.py
+++ b/safebreach_mcp_studio/tests/test_e2e_manage_test.py
@@ -250,8 +250,8 @@ class TestManageTestE2E:
             assert cancel_result_1['status'] == "success"
             assert cancel_result_1['action'] == "cancel"
 
-            # Wait for state propagation
-            time.sleep(COMMENT_PROPAGATION_DELAY)
+            # Wait for data API to reflect canceled state (longer than comment propagation)
+            time.sleep(10)
 
             # Second cancel — should return idempotent success (not error)
             cancel_result_2 = sb_manage_test(

--- a/safebreach_mcp_studio/tests/test_e2e_manage_test.py
+++ b/safebreach_mcp_studio/tests/test_e2e_manage_test.py
@@ -221,3 +221,46 @@ class TestManageTestE2E:
         finally:
             if test_id:
                 _cancel_test(test_id, E2E_CONSOLE)
+
+    def test_e2e_cancel_already_canceled_test(self):
+        """Queue, cancel, cancel again — second cancel returns idempotent success."""
+        scenarios = _fetch_all_scenarios(E2E_CONSOLE)
+        ready = next(
+            (s for s in scenarios if compute_scenario_readiness(s)), None
+        )
+        assert ready is not None, f"No ready OOB scenario on {E2E_CONSOLE}"
+
+        test_id = None
+        try:
+            queue_result = sb_run_scenario(
+                scenario_id=str(ready['id']),
+                console=E2E_CONSOLE,
+                test_name="E2E: test_e2e_cancel_already_canceled_test",
+            )
+            test_id = queue_result['test_id']
+            assert test_id, "No test_id returned from run_scenario"
+
+            # First cancel — should succeed normally
+            cancel_result_1 = sb_manage_test(
+                test_id=test_id,
+                action="cancel",
+                console=E2E_CONSOLE,
+                reason="E2E first cancel",
+            )
+            assert cancel_result_1['status'] == "success"
+            assert cancel_result_1['action'] == "cancel"
+
+            # Wait for state propagation
+            time.sleep(COMMENT_PROPAGATION_DELAY)
+
+            # Second cancel — should return idempotent success (not error)
+            cancel_result_2 = sb_manage_test(
+                test_id=test_id,
+                action="cancel",
+                console=E2E_CONSOLE,
+            )
+            assert cancel_result_2.get('was_already') is True
+            assert "already" in cancel_result_2['status']
+            assert cancel_result_2['test_id'] == test_id
+        finally:
+            pass  # Test is already canceled, no cleanup needed

--- a/safebreach_mcp_studio/tests/test_rate_limiting.py
+++ b/safebreach_mcp_studio/tests/test_rate_limiting.py
@@ -29,6 +29,7 @@ class TestManageTestRateLimitingGate:
         "safebreach_mcp_studio.studio_functions.get_caller_identity",
         return_value="test-caller",
     )
+    @patch("safebreach_mcp_studio.studio_functions._get_test_state", return_value="RUNNING")
     @patch("safebreach_mcp_studio.studio_functions.requests.delete")
     @patch(
         "safebreach_mcp_studio.studio_functions.get_api_account_id",
@@ -43,6 +44,7 @@ class TestManageTestRateLimitingGate:
         _mock_base_url,
         _mock_account_id,
         mock_delete,
+        _mock_state,
         _mock_get_identity,
         mock_rate_limiter,
     ):
@@ -79,6 +81,7 @@ class TestManageTestRateLimitingGate:
         "safebreach_mcp_studio.studio_functions.get_caller_identity",
         return_value="test-caller",
     )
+    @patch("safebreach_mcp_studio.studio_functions._get_test_state", return_value="RUNNING")
     @patch("safebreach_mcp_studio.studio_functions.requests.delete")
     @patch(
         "safebreach_mcp_studio.studio_functions.get_api_account_id",
@@ -93,6 +96,7 @@ class TestManageTestRateLimitingGate:
         _mock_base_url,
         _mock_account_id,
         mock_delete,
+        _mock_state,
         _mock_get_identity,
         mock_rate_limiter,
     ):
@@ -115,6 +119,7 @@ class TestManageTestRateLimitingGate:
         "safebreach_mcp_studio.studio_functions.get_caller_identity",
         return_value="test-caller",
     )
+    @patch("safebreach_mcp_studio.studio_functions._get_test_state", return_value="RUNNING")
     @patch("safebreach_mcp_studio.studio_functions.requests.delete")
     @patch(
         "safebreach_mcp_studio.studio_functions.get_api_account_id",
@@ -129,6 +134,7 @@ class TestManageTestRateLimitingGate:
         _mock_base_url,
         _mock_account_id,
         mock_delete,
+        _mock_state,
         _mock_get_identity,
         mock_rate_limiter,
     ):
@@ -142,6 +148,39 @@ class TestManageTestRateLimitingGate:
             )
 
         mock_rate_limiter.check_limit.assert_called_once()
+        mock_rate_limiter.record_action.assert_not_called()
+
+    # --- SAF-31111: Quick-returns skip rate limiting ---
+
+    @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_caller_identity",
+        return_value="test-caller",
+    )
+    @patch("safebreach_mcp_studio.studio_functions._get_test_state", return_value="CANCELED")
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_account_id",
+        return_value="1234567890",
+    )
+    @patch(
+        "safebreach_mcp_studio.studio_functions.get_api_base_url",
+        return_value="https://test.safebreach.com",
+    )
+    def test_quick_return_does_not_trigger_rate_limiting(
+        self,
+        _mock_base_url,
+        _mock_account_id,
+        _mock_state,
+        _mock_get_identity,
+        mock_rate_limiter,
+    ):
+        """Quick-return for already-canceled test does NOT call rate limiter."""
+        result = sb_manage_test(
+            test_id="test123", action="cancel", console="test"
+        )
+
+        assert result.get('was_already') is True
+        mock_rate_limiter.check_limit.assert_not_called()
         mock_rate_limiter.record_action.assert_not_called()
 
 

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7759,55 +7759,20 @@ class TestManageTest:
 
     # --- Phase 8: State pre-check (_get_test_state) — SAF-31111 ---
 
-    @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
-    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_get_test_state_from_orchestrator_running(
-        self, mock_base_url, mock_account_id, mock_get
-    ):
-        """_get_test_state returns RUNNING from orchestrator queue slot."""
-        mock_base_url.return_value = "https://test.safebreach.com"
-        mock_account_id.return_value = "1234567890"
-
-        # Orchestrator queue response — test found in a slot, not paused
-        mock_orch_response = MagicMock()
-        mock_orch_response.json.return_value = {
-            "data": {
-                "slotState": [
-                    {"planRunId": "test123", "isPaused": False,
-                     "slotStatus": "Running Step"},
-                ]
-            }
-        }
-        mock_orch_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_orch_response
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state')
+    def test_get_test_state_from_orchestrator_running(self, mock_orch):
+        """_get_test_state returns RUNNING from orchestrator queue."""
+        mock_orch.return_value = "RUNNING"
 
         result = _get_test_state("test123", "test")
 
         assert result == "RUNNING"
-        mock_get.assert_called_once()  # Only orchestrator called, no data API fallback
+        mock_orch.assert_called_once_with("test123", "test")
 
-    @patch('safebreach_mcp_studio.studio_functions.requests.get')
-    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
-    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_get_test_state_from_orchestrator_paused(
-        self, mock_base_url, mock_account_id, mock_get
-    ):
-        """_get_test_state returns PAUSED from orchestrator queue slot."""
-        mock_base_url.return_value = "https://test.safebreach.com"
-        mock_account_id.return_value = "1234567890"
-
-        mock_orch_response = MagicMock()
-        mock_orch_response.json.return_value = {
-            "data": {
-                "slotState": [
-                    {"planRunId": "test123", "isPaused": True,
-                     "slotStatus": "Running Step"},
-                ]
-            }
-        }
-        mock_orch_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_orch_response
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state')
+    def test_get_test_state_from_orchestrator_paused(self, mock_orch):
+        """_get_test_state returns PAUSED from orchestrator queue."""
+        mock_orch.return_value = "PAUSED"
 
         result = _get_test_state("test123", "test")
 
@@ -7816,58 +7781,46 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state')
     def test_get_test_state_falls_back_to_data_api(
-        self, mock_base_url, mock_account_id, mock_get
+        self, mock_orch, mock_base_url, mock_account_id, mock_get
     ):
         """_get_test_state falls back to data API when test not in queue."""
+        mock_orch.return_value = None  # Not in orchestrator queue
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
-        # First call: orchestrator — test not in any slot
-        mock_orch_response = MagicMock()
-        mock_orch_response.json.return_value = {
-            "data": {"slotState": [{"planRunId": "other-test", "isPaused": False}]}
-        }
-        mock_orch_response.raise_for_status.return_value = None
-
-        # Second call: data API — returns terminal status
         mock_data_response = MagicMock()
         mock_data_response.json.return_value = {"status": "CANCELED"}
         mock_data_response.raise_for_status.return_value = None
-
-        mock_get.side_effect = [mock_orch_response, mock_data_response]
+        mock_get.return_value = mock_data_response
 
         result = _get_test_state("test123", "test")
 
         assert result == "CANCELED"
-        assert mock_get.call_count == 2  # Orchestrator + data API
+        mock_orch.assert_called_once()
+        mock_get.assert_called_once()
 
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state')
     def test_get_test_state_orch_failure_falls_back(
-        self, mock_base_url, mock_account_id, mock_get
+        self, mock_orch, mock_base_url, mock_account_id, mock_get
     ):
-        """_get_test_state falls back to data API when orchestrator fails."""
-        import requests as req
+        """_get_test_state falls back to data API when orchestrator returns None."""
+        mock_orch.return_value = None
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
-        # First call: orchestrator fails
-        # Second call: data API succeeds
         mock_data_response = MagicMock()
         mock_data_response.json.return_value = {"status": "COMPLETED"}
         mock_data_response.raise_for_status.return_value = None
-
-        mock_get.side_effect = [
-            req.exceptions.ConnectionError("orchestrator down"),
-            mock_data_response,
-        ]
+        mock_get.return_value = mock_data_response
 
         result = _get_test_state("test123", "test")
 
         assert result == "COMPLETED"
-        assert mock_get.call_count == 2
 
     # --- Phase 9: State transition matrix — Cancel — SAF-31111 ---
 

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -7762,42 +7762,112 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_get_test_state_success(self, mock_base_url, mock_account_id, mock_get):
-        """_get_test_state returns status string from testsummaries API."""
+    def test_get_test_state_from_orchestrator_running(
+        self, mock_base_url, mock_account_id, mock_get
+    ):
+        """_get_test_state returns RUNNING from orchestrator queue slot."""
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"status": "RUNNING"}
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        # Orchestrator queue response — test found in a slot, not paused
+        mock_orch_response = MagicMock()
+        mock_orch_response.json.return_value = {
+            "data": {
+                "slotState": [
+                    {"planRunId": "test123", "isPaused": False,
+                     "slotStatus": "Running Step"},
+                ]
+            }
+        }
+        mock_orch_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_orch_response
 
         result = _get_test_state("test123", "test")
 
         assert result == "RUNNING"
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args
-        expected_url = (
-            "https://test.safebreach.com/api/data/v1/accounts/"
-            "1234567890/testsummaries/test123"
-        )
-        assert call_args[0][0] == expected_url
-        assert call_args[1]['headers']['x-apitoken'] == "test-token"
-        assert call_args[1]['timeout'] == 30
+        mock_get.assert_called_once()  # Only orchestrator called, no data API fallback
 
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_get_test_state_api_error(self, mock_base_url, mock_account_id, mock_get):
-        """_get_test_state propagates API errors (does not catch)."""
+    def test_get_test_state_from_orchestrator_paused(
+        self, mock_base_url, mock_account_id, mock_get
+    ):
+        """_get_test_state returns PAUSED from orchestrator queue slot."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_orch_response = MagicMock()
+        mock_orch_response.json.return_value = {
+            "data": {
+                "slotState": [
+                    {"planRunId": "test123", "isPaused": True,
+                     "slotStatus": "Running Step"},
+                ]
+            }
+        }
+        mock_orch_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_orch_response
+
+        result = _get_test_state("test123", "test")
+
+        assert result == "PAUSED"
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_test_state_falls_back_to_data_api(
+        self, mock_base_url, mock_account_id, mock_get
+    ):
+        """_get_test_state falls back to data API when test not in queue."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        # First call: orchestrator — test not in any slot
+        mock_orch_response = MagicMock()
+        mock_orch_response.json.return_value = {
+            "data": {"slotState": [{"planRunId": "other-test", "isPaused": False}]}
+        }
+        mock_orch_response.raise_for_status.return_value = None
+
+        # Second call: data API — returns terminal status
+        mock_data_response = MagicMock()
+        mock_data_response.json.return_value = {"status": "CANCELED"}
+        mock_data_response.raise_for_status.return_value = None
+
+        mock_get.side_effect = [mock_orch_response, mock_data_response]
+
+        result = _get_test_state("test123", "test")
+
+        assert result == "CANCELED"
+        assert mock_get.call_count == 2  # Orchestrator + data API
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_test_state_orch_failure_falls_back(
+        self, mock_base_url, mock_account_id, mock_get
+    ):
+        """_get_test_state falls back to data API when orchestrator fails."""
         import requests as req
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
-        mock_get.side_effect = req.exceptions.RequestException("API error")
+        # First call: orchestrator fails
+        # Second call: data API succeeds
+        mock_data_response = MagicMock()
+        mock_data_response.json.return_value = {"status": "COMPLETED"}
+        mock_data_response.raise_for_status.return_value = None
 
-        with pytest.raises(req.exceptions.RequestException, match="API error"):
-            _get_test_state("test123", "test")
+        mock_get.side_effect = [
+            req.exceptions.ConnectionError("orchestrator down"),
+            mock_data_response,
+        ]
+
+        result = _get_test_state("test123", "test")
+
+        assert result == "COMPLETED"
+        assert mock_get.call_count == 2
 
     # --- Phase 9: State transition matrix — Cancel — SAF-31111 ---
 

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -26,6 +26,7 @@ from safebreach_mcp_studio.studio_functions import (
     _get_scenario_statistics,
     sb_run_scenario,
     sb_manage_test,
+    _get_test_state,
     studio_draft_cache,
     MAIN_FUNCTION_PATTERN,
     _validate_and_build_parameters,
@@ -7306,11 +7307,13 @@ class TestManageTest:
         yield
         _user_auth_artifacts.reset(token)
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_cancel_success(self, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_success(self, mock_base_url, mock_account_id, mock_delete, mock_state):
         """Cancel a running test via DELETE — happy path."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7340,11 +7343,13 @@ class TestManageTest:
         assert call_args[1]['headers']['x-apitoken'] == "test-token"
         assert call_args[1]['timeout'] == 30
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_cancel_api_error(self, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_api_error(self, mock_base_url, mock_account_id, mock_delete, mock_state):
         """API error during cancel propagates as RequestException."""
+        mock_state.return_value = "RUNNING"
         import requests as req
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
@@ -7358,11 +7363,13 @@ class TestManageTest:
 
     # --- Phase 2: Pause ---
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_pause_success(self, mock_base_url, mock_account_id, mock_put):
+    def test_pause_success(self, mock_base_url, mock_account_id, mock_put, mock_state):
         """Pause a running test via PUT /state — happy path."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7394,11 +7401,13 @@ class TestManageTest:
 
     # --- Phase 3: Resume ---
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_resume_success(self, mock_base_url, mock_account_id, mock_put):
+    def test_resume_success(self, mock_base_url, mock_account_id, mock_put, mock_state):
         """Resume a paused test via PUT /state — happy path."""
+        mock_state.return_value = "PAUSED"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7437,11 +7446,13 @@ class TestManageTest:
         with pytest.raises(ValueError, match="test_id"):
             sb_manage_test(test_id=None, action="cancel")
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_not_found_404(self, mock_base_url, mock_account_id, mock_delete):
+    def test_not_found_404(self, mock_base_url, mock_account_id, mock_delete, mock_state):
         """404 from API propagates as HTTPError."""
+        mock_state.return_value = "RUNNING"
         import requests as req
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
@@ -7549,6 +7560,7 @@ class TestManageTest:
         put_body = mock_put.call_args[1]['json']
         assert not put_body['comment'].startswith("\n")
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
@@ -7556,9 +7568,10 @@ class TestManageTest:
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
     def test_manage_test_with_reason(
         self, mock_base_url, mock_account_id,
-        mock_get, mock_put, mock_delete
+        mock_get, mock_put, mock_delete, mock_state
     ):
         """sb_manage_test with reason calls _append_test_note."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7587,13 +7600,15 @@ class TestManageTest:
         assert result['note_status'] == "success"
         assert "Test cancel: no longer needed" in result['note']
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
     def test_manage_test_without_reason(
-        self, mock_base_url, mock_account_id, mock_delete
+        self, mock_base_url, mock_account_id, mock_delete, mock_state
     ):
         """sb_manage_test without reason does NOT call _append_test_note."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7652,13 +7667,15 @@ class TestManageTest:
         assert result['note_status'] == "failed"
         assert 'note_error' in result
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
     def test_note_failure_doesnt_block_lifecycle(
-        self, mock_base_url, mock_account_id, mock_delete
+        self, mock_base_url, mock_account_id, mock_delete, mock_state
     ):
         """Lifecycle succeeds even when note append fails."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7680,11 +7697,13 @@ class TestManageTest:
 
     # --- Phase 7: hint_to_agent ---
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_pause_hint(self, mock_base_url, mock_account_id, mock_put):
+    def test_pause_hint(self, mock_base_url, mock_account_id, mock_put, mock_state):
         """Pause result includes hint_to_agent mentioning resume and cancel."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7699,11 +7718,13 @@ class TestManageTest:
         assert "cancel" in result['hint_to_agent']
         assert "get_test_details" in result['hint_to_agent']
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.put')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_resume_hint(self, mock_base_url, mock_account_id, mock_put):
+    def test_resume_hint(self, mock_base_url, mock_account_id, mock_put, mock_state):
         """Resume result includes hint_to_agent mentioning monitoring."""
+        mock_state.return_value = "PAUSED"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7716,11 +7737,13 @@ class TestManageTest:
         assert 'hint_to_agent' in result
         assert "get_test_details" in result['hint_to_agent']
 
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
     @patch('safebreach_mcp_studio.studio_functions.requests.delete')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_cancel_hint(self, mock_base_url, mock_account_id, mock_delete):
+    def test_cancel_hint(self, mock_base_url, mock_account_id, mock_delete, mock_state):
         """Cancel result includes hint_to_agent mentioning partial results."""
+        mock_state.return_value = "RUNNING"
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7733,3 +7756,276 @@ class TestManageTest:
         assert 'hint_to_agent' in result
         assert "get_test_details" in result['hint_to_agent']
         assert "partial" in result['hint_to_agent'].lower()
+
+    # --- Phase 8: State pre-check (_get_test_state) — SAF-31111 ---
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_test_state_success(self, mock_base_url, mock_account_id, mock_get):
+        """_get_test_state returns status string from testsummaries API."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "RUNNING"}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = _get_test_state("test123", "test")
+
+        assert result == "RUNNING"
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        expected_url = (
+            "https://test.safebreach.com/api/data/v1/accounts/"
+            "1234567890/testsummaries/test123"
+        )
+        assert call_args[0][0] == expected_url
+        assert call_args[1]['headers']['x-apitoken'] == "test-token"
+        assert call_args[1]['timeout'] == 30
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_test_state_api_error(self, mock_base_url, mock_account_id, mock_get):
+        """_get_test_state propagates API errors (does not catch)."""
+        import requests as req
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+
+        mock_get.side_effect = req.exceptions.RequestException("API error")
+
+        with pytest.raises(req.exceptions.RequestException, match="API error"):
+            _get_test_state("test123", "test")
+
+    # --- Phase 9: State transition matrix — Cancel — SAF-31111 ---
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.requests.delete')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_cancel_on_running_proceeds(
+        self, mock_base_url, mock_account_id, mock_delete, mock_state
+    ):
+        """Cancel on RUNNING test proceeds to DELETE API call."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "RUNNING"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_delete.return_value = mock_response
+
+        result = sb_manage_test(test_id="test123", action="cancel", console="test")
+
+        assert result['status'] == "success"
+        assert result['action'] == "cancel"
+        mock_delete.assert_called_once()
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_cancel_on_canceled_returns_idempotent(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Cancel on CANCELED test returns idempotent quick-return."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "CANCELED"
+
+        result = sb_manage_test(test_id="test123", action="cancel", console="test")
+
+        assert result['status'] == "already_canceled"
+        assert result['was_already'] is True
+        assert result['current_state'] == "CANCELED"
+        assert result['test_id'] == "test123"
+        assert result['action'] == "cancel"
+        assert 'hint_to_agent' in result
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_cancel_on_completed_returns_idempotent(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Cancel on COMPLETED test returns idempotent quick-return."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "COMPLETED"
+
+        result = sb_manage_test(test_id="test123", action="cancel", console="test")
+
+        assert result['status'] == "already_completed"
+        assert result['was_already'] is True
+        assert result['current_state'] == "COMPLETED"
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_cancel_on_paused_raises_error(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Cancel on PAUSED test raises ValueError with resume guidance."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "PAUSED"
+
+        with pytest.raises(ValueError, match="resume"):
+            sb_manage_test(test_id="test123", action="cancel", console="test")
+
+    # --- Phase 10: State transition matrix — Pause — SAF-31111 ---
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_pause_on_running_proceeds(
+        self, mock_base_url, mock_account_id, mock_put, mock_state
+    ):
+        """Pause on RUNNING test proceeds to PUT API call."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "RUNNING"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(test_id="test123", action="pause", console="test")
+
+        assert result['status'] == "success"
+        assert result['action'] == "pause"
+        mock_put.assert_called_once()
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_pause_on_paused_returns_idempotent(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Pause on PAUSED test returns idempotent quick-return."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "PAUSED"
+
+        result = sb_manage_test(test_id="test123", action="pause", console="test")
+
+        assert result['status'] == "already_paused"
+        assert result['was_already'] is True
+        assert result['current_state'] == "PAUSED"
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_pause_on_canceled_raises_error(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Pause on CANCELED test raises ValueError — terminal state."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "CANCELED"
+
+        with pytest.raises(ValueError):
+            sb_manage_test(test_id="test123", action="pause", console="test")
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_pause_on_completed_raises_error(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Pause on COMPLETED test raises ValueError — terminal state."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "COMPLETED"
+
+        with pytest.raises(ValueError):
+            sb_manage_test(test_id="test123", action="pause", console="test")
+
+    # --- Phase 11: State transition matrix — Resume — SAF-31111 ---
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.requests.put')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_resume_on_paused_proceeds(
+        self, mock_base_url, mock_account_id, mock_put, mock_state
+    ):
+        """Resume on PAUSED test proceeds to PUT API call."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "PAUSED"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_response
+
+        result = sb_manage_test(test_id="test123", action="resume", console="test")
+
+        assert result['status'] == "success"
+        assert result['action'] == "resume"
+        mock_put.assert_called_once()
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_resume_on_running_returns_idempotent(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Resume on RUNNING test returns idempotent quick-return."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "RUNNING"
+
+        result = sb_manage_test(test_id="test123", action="resume", console="test")
+
+        assert result['status'] == "already_running"
+        assert result['was_already'] is True
+        assert result['current_state'] == "RUNNING"
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_resume_on_canceled_raises_error(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Resume on CANCELED test raises ValueError — terminal state."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "CANCELED"
+
+        with pytest.raises(ValueError):
+            sb_manage_test(test_id="test123", action="resume", console="test")
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_resume_on_completed_raises_error(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """Resume on COMPLETED test raises ValueError — terminal state."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "COMPLETED"
+
+        with pytest.raises(ValueError):
+            sb_manage_test(test_id="test123", action="resume", console="test")
+
+    # --- Phase 12: State normalization — SAF-31111 ---
+
+    @patch('safebreach_mcp_studio.studio_functions._get_test_state')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_state_precheck_normalizes_lowercase_status(
+        self, mock_base_url, mock_account_id, mock_state
+    ):
+        """State pre-check normalizes lowercase status to uppercase."""
+        mock_base_url.return_value = "https://test.safebreach.com"
+        mock_account_id.return_value = "1234567890"
+        mock_state.return_value = "canceled"  # lowercase
+
+        result = sb_manage_test(test_id="test123", action="cancel", console="test")
+
+        assert result['was_already'] is True
+        assert result['status'] == "already_canceled"


### PR DESCRIPTION
## Problem
The `manage_test` tool failed with HTTP 404/500 errors when attempting lifecycle actions (cancel/pause/resume) on tests not in the expected state — e.g., canceling an already-canceled test returned a cryptic `PLAN_NOT_EXISTS` error instead of a graceful "already canceled" response. Additionally, both `manage_test` and `get_test_details` relied on the data API (`testsummaries`) for test state, which has 10-15 seconds of eventual consistency lag after lifecycle changes. This caused incorrect state reads immediately after pause/resume, leading to skipped actions and inconsistent responses between tools.

## Summary
- `manage_test` now validates test state before lifecycle actions (cancel/pause/resume), returning idempotent responses for terminal states and informative errors for invalid transitions
- Both `manage_test` (studio) and `get_test_details` (data) now consult the orchestrator `GET /queue` endpoint for real-time active test state, eliminating the 10-15s eventual consistency lag from the data API
- Note append failures are logged but no longer exposed in the tool response

## Changes
- **`safebreach_mcp_core/queue_state.py`** — New shared module: real-time test state lookup from orchestrator queue slots (`isPaused` / running)
- **`safebreach_mcp_studio/studio_functions.py`** — `_get_test_state()` uses orchestrator queue first, data API fallback for terminal states. `sb_manage_test()` pre-checks state for idempotent handling
- **`safebreach_mcp_studio/studio_server.py`** — Handle `was_already` quick-return formatting, remove note error exposure
- **`safebreach_mcp_data/data_functions.py`** — `get_test_details` uses orchestrator queue for non-terminal status refresh instead of the lagging data API

## Test plan
- [x] 370 studio unit tests pass (36 manage_test specific, including 17 new state transition tests)
- [x] 775 studio + data unit tests pass
- [x] 4 manage_test E2E tests pass (including new cancel-on-canceled idempotency test)
- [x] 26 studio E2E tests pass
- [x] Verified real-time state correctness against 2 live running tests on pentest01 — pause/resume state reflected immediately with zero lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)