### PR TITLE
SAF-31243: Add /mcp-create-release skill for automated release preparation

### DIFF
--- a/.claude/commands/mcp-create-release.md
+++ b/.claude/commands/mcp-create-release.md
@@ -1,0 +1,216 @@
+# Create MCP Release
+
+Prepare a release candidate for the SafeBreach MCP servers.
+Bumps version in `pyproject.toml`, generates changelog from git history, and creates a GitHub PR.
+
+## Step 1: Validate Environment
+
+1. Read `pyproject.toml` in the repo root — confirm it contains `name = "safebreach-mcp-server"`.
+   If not found, halt: "This command must be run from the safebreach-mcp repository root."
+2. Check working tree is clean:
+   ```bash
+   git status --porcelain
+   ```
+   If dirty, present options via AskUserQuestion:
+   - "Stash changes" — run `git stash push --include-untracked -m "pre-release stash"` then continue
+     (the `--include-untracked` flag is required to capture new/untracked files, not just modified ones)
+   - "Abort" — stop the workflow
+
+## Step 2: Ask Version Bump Type
+
+Present the choice via AskUserQuestion:
+
+- **Minor** — increment minor version, reset patch (e.g., 1.1.0 → 1.2.0)
+- **Major** — increment major version, reset minor and patch (e.g., 1.1.0 → 2.0.0)
+
+## Step 3: Determine Current Version and Calculate Next
+
+1. Read `pyproject.toml` and extract the `version` field from line 3
+   (format: `version = "X.Y.Z"`)
+2. Parse into major, minor, patch integers
+3. Apply the bump:
+   - Minor: increment minor, set patch to 0
+   - Major: increment major, set minor and patch to 0
+4. Display: `Version: {current} → {next}`
+
+## Step 4: Create Release Branch
+
+1. Ensure on main with latest:
+   ```bash
+   git checkout main && git pull origin main
+   ```
+2. Construct branch name: `release_{next_version}` (e.g., `release_1.2.0`)
+3. Check if branch already exists:
+   ```bash
+   git branch -a --list "*release_{next_version}*"
+   ```
+4. If it exists, ask the user via AskUserQuestion:
+   - "Use existing branch" — checkout the existing branch
+   - "Create with suffix" — use `release_{next_version}-v2`
+   - "Abort" — stop the workflow
+5. Create and checkout: `git checkout -b {branch_name}`
+
+## Step 5: Bump Version
+
+Use the Edit tool to update `pyproject.toml` line 3, changing the old version string to the new one:
+```
+version = "{current}" → version = "{next}"
+```
+
+Read back `pyproject.toml` to verify the change took effect.
+
+## Step 6: Generate Changelog Entries
+
+1. Find the most recent tag:
+   ```bash
+   git describe --tags --abbrev=0
+   ```
+   If no tags exist, use the initial commit:
+   ```bash
+   git rev-list --max-parents=0 HEAD
+   ```
+2. List commits since that tag:
+   ```bash
+   git log {last_tag}..HEAD --oneline --no-merges
+   ```
+3. If no commits found, halt: "No changes since last release tag. Nothing to release."
+4. Categorize each commit into changelog sections:
+   - **Added** — new features, new tools, new capabilities
+   - **Changed** — modifications to existing behavior, renames, config changes
+   - **Fixed** — bug fixes, corrections
+   Use the commit message prefix and content to decide the category.
+   Strip SAF ticket prefixes and PR numbers from the entry text — keep just the
+   meaningful description. Write each entry as a concise, user-facing summary
+   (not a raw commit message).
+5. Format the new changelog section. The date separator MUST be an em-dash character (`—`,
+   Unicode U+2014), not a double hyphen (`--`). This is critical — the existing CHANGELOG.md
+   uses em-dash and the format must be consistent. Here is the exact template:
+   ```
+   ## {next_version} — {YYYY-MM-DD}
+
+   ### Added
+
+   - Entry one
+   - Entry two
+
+   ### Changed
+
+   - Entry three
+
+   ### Fixed
+
+   - Entry four
+   ```
+   Only include sections that have entries. Use today's date.
+   
+   **Example of CORRECT format**: `## 1.2.0 — 2026-05-18` (with em-dash `—`)
+   **Example of WRONG format**: `## 1.2.0 -- 2026-05-18` (with double hyphen `--`)
+
+## Step 7: Present Changelog Draft
+
+Show the user the generated changelog section and ask via AskUserQuestion:
+
+- "Approve" — proceed as-is
+- "Edit" — let user provide corrections (apply them and re-present)
+- "Abort" — clean up branch and stop
+
+This is the most important review gate — the changelog is what appears in the
+GitHub Release and is the public-facing record of what changed.
+
+## Step 8: Update CHANGELOG.md
+
+Use the Edit tool to insert the new version section into `CHANGELOG.md`, immediately
+after the header block (after the line starting with `and this project adheres to`)
+and before the first existing `## ` version entry.
+
+The insertion point is between the header paragraph and the first `## X.Y.Z` line.
+Add a blank line before and after the new section.
+
+**Critical**: When writing the Edit, copy the changelog section exactly as formatted in
+Step 6 — including the em-dash (`—`) character. Do NOT substitute `--` for `—`.
+The existing entry reads `## 1.1.0 — 2026-05-07` and the new one must match that style.
+
+## Step 9: Present Batch Summary
+
+Display a summary of everything that will be committed:
+
+- Version bump: `{current}` → `{next}`
+- Branch: `{branch_name}`
+- Files modified: `pyproject.toml`, `CHANGELOG.md`
+- Changelog entries: (list them)
+
+Ask for final approval via AskUserQuestion:
+- "Approve and commit" — proceed to commit
+- "Abort" — clean up (checkout main, delete branch)
+
+## Step 10: Commit and Push
+
+1. Stage the two modified files:
+   ```bash
+   git add pyproject.toml CHANGELOG.md
+   ```
+2. Commit with HEREDOC:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   chore: bump version to {next_version} and update changelog
+
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+3. Push with upstream:
+   ```bash
+   git push -u origin {branch_name}
+   ```
+
+## Step 11: Create GitHub PR
+
+1. Create PR via `gh` CLI:
+   ```bash
+   gh pr create \
+     --title "Release {next_version}" \
+     --body "$(cat <<'EOF'
+   ## Release {next_version}
+
+   {changelog section from Step 6}
+
+   ---
+   Once this PR is merged to main, GitHub Actions will automatically:
+   1. Validate the CHANGELOG entry
+   2. Create git tag `{next_version}`
+   3. Create a GitHub Release with the changelog notes
+   EOF
+   )" \
+     --base main \
+     --head {branch_name}
+   ```
+2. Report the PR URL to the user
+3. Remind: "Once the PR is approved and merged, GitHub Actions will automatically
+   create the tag and GitHub Release."
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Not safebreach-mcp repo | Halt with clear message |
+| Dirty working tree | Offer stash or abort |
+| Branch already exists | Offer use existing, suffix, or abort |
+| No tags found | Fall back to initial commit for changelog range |
+| No commits since last tag | Halt — nothing to release |
+| Version parse fails | Halt with error details |
+| `gh` CLI not available | Halt: "Install GitHub CLI: `brew install gh`" |
+| PR creation fails | Display error, suggest manual `gh pr create` |
+| Git push fails | Display error, do not force push |
+
+## Limitations
+
+**Will:**
+- Bump version in `pyproject.toml`
+- Generate changelog from git commit history
+- Create release branch, commit, push, and open PR
+
+**Will Not:**
+- Merge the PR (user must review and approve)
+- Create git tags or GitHub Releases (GitHub Actions handles this automatically)
+- Handle pre-release or patch versions
+- Modify files beyond `pyproject.toml` and `CHANGELOG.md`

--- a/.claude/skills/mcp-create-release/SKILL.md
+++ b/.claude/skills/mcp-create-release/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: mcp-create-release
+description: >-
+  Prepare a release candidate for the SafeBreach MCP servers.
+  Bumps version in pyproject.toml, generates changelog from git history, and creates a GitHub PR.
+  Use when "create release", "prepare release", "version bump", or "new MCP release".
+---
+
 # Create MCP Release
 
 Prepare a release candidate for the SafeBreach MCP servers.

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,9 @@ known_hosts
 *.db
 *.sqlite
 *.sqlite3
+
+# Skill testing workspace
+mcp-create-release-workspace/
+
+# Claude local settings
+.claude/settings.local.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -29,6 +29,7 @@ paths = [
     '''safebreach_mcp_server\.egg-info/.*''',  # Allow package info
     '''\.vscode/set_env\.sh''',  # Allow private development file (git-ignored)
     '''\.env''',  # Allow .env files (should be git-ignored)
+    '''mcp-create-release-workspace/.*''',  # Skill testing artifacts (git-ignored)
 ]
 regexes = [
     '''your-secure-token-here''',

--- a/prds/SAF-31243-create-skills-for-releasing/context.md
+++ b/prds/SAF-31243-create-skills-for-releasing/context.md
@@ -1,7 +1,7 @@
 # Ticket Context: SAF-31243
 
 ## Status
-Phase 5: Problem Analysis Complete
+Phase 9: Implementation Complete
 
 ## Mode
 Improving

--- a/prds/SAF-31243-create-skills-for-releasing/context.md
+++ b/prds/SAF-31243-create-skills-for-releasing/context.md
@@ -1,0 +1,108 @@
+# Ticket Context: SAF-31243
+
+## Status
+Phase 5: Problem Analysis Complete
+
+## Mode
+Improving
+
+## Original Ticket (if improving)
+- **Summary**: [safebreach-mcp] Create a repo-specific claude skills to automate the releases of the SafeBreach MCP
+- **Description**: Create a `/mcp-create-release` skill that bumps version, generates changelog, creates branch/PR. Inspired by VS Code extension release skills.
+- **Acceptance Criteria**: None specified
+- **Status**: To Do
+
+## Task Scope
+Investigate the current release process, versioning, changelog format, GitHub Actions, and the reference VS Code extension skills to prepare a detailed ticket for building the `/mcp-create-release` skill.
+
+## Repositories Under Investigation
+- /Users/yossiattas/Public/safebreach-mcp
+- /Users/yossiattas/projects/rules/plugins/sb-vsextension/skills
+
+## Investigation Findings
+
+### safebreach-mcp (target repo)
+
+**Version Management:**
+- Version declared in `pyproject.toml` line 3: `version = "1.1.0"`
+- Single source of truth, no dynamic versioning
+- Semantic versioning (MAJOR.MINOR.PATCH)
+- No `__version__.py` or other version files
+
+**CHANGELOG.md Format:**
+- "Keep a Changelog" standard
+- Entry format: `## X.Y.Z — YYYY-MM-DD` (em-dash separator, no brackets)
+- Sections: Added, Changed, Fixed (only include non-empty sections)
+- Entry style: descriptive bullet points with feature names
+
+**GitHub Actions (release.yml):**
+- Triggers on push to `main` when `pyproject.toml` changes
+- Extracts version from pyproject.toml
+- Validates CHANGELOG entry exists for that version
+- Creates annotated git tag (format: `X.Y.Z`, no "v" prefix)
+- Creates GitHub Release with notes extracted from CHANGELOG
+- Fully automated — no manual publish step needed
+
+**Git Tags:**
+- Current tag: `1.1.0`
+- 6 commits since last tag on main
+- Tag format: bare semantic version (no "v" prefix)
+
+**Branch Conventions:**
+- Feature: `SAF-XXXXX-description`
+- Release: `release_X.Y.Z` (underscore separator)
+- Existing release branch: `release_1.2.0`
+
+**Change Identification:**
+- No PRDs directory convention for changelog — changes identified from git commit history
+- Commit format: `SAF-XXXXX: Description (#PR)` or plain descriptions
+- 6 commits since 1.1.0 tag covering features and CI fixes
+
+**PR Workflow:**
+- GitHub-hosted (not Bitbucket)
+- No PR template defined
+- PRs use `gh` CLI for creation
+
+### sb-vsextension reference skills
+
+**Two-Skill Pattern:**
+1. `vse-create-release` — prepare release (bump, changelog, branch, PR)
+2. `vse-complete-release` — merge PR, package, publish to marketplace
+
+**Key Patterns Identified:**
+- 11-step workflow with validation gates and user confirmations
+- Environment validation first (check config file, git status)
+- Version bump type choice (minor/major) via AskUserQuestion
+- Last version marker found via `git log --grep="chore: bump version to"`
+- PRD-based changelog generation (scans `prds/` directory)
+- Batch summary + approval before commit
+- Branch collision handling (use existing, suffix, abort)
+- HEREDOC commit messages with Co-Authored-By trailer
+- Comprehensive error handling table
+- Clear limitations section (will/won't)
+
+**Differences from MCP repo:**
+| Aspect | VS Code Extension | SafeBreach MCP |
+|--------|------------------|----------------|
+| Version file | package.json | pyproject.toml |
+| Bump tool | `npm version` | Manual edit |
+| Source control | Bitbucket | GitHub |
+| PR tool | Bitbucket MCP | `gh` CLI |
+| Changelog source | PRD files | Git commit history |
+| Changelog format | `## [X.Y.Z] - YYYY-MM-DD` | `## X.Y.Z — YYYY-MM-DD` |
+| Release branch | `marketplace-release-version-X.Y.Z` | `release_X.Y.Z` |
+| Publish step | Manual (vsce publish) | Automated (GitHub Actions) |
+| Skills needed | 2 (create + complete) | 1 (create only) |
+
+## Problem Analysis
+
+**Core Problem**: The SafeBreach MCP release process is manual — version bumping, changelog writing, branch creation, and PR creation are all done by hand. This is error-prone and slow.
+
+**Solution**: A single `/mcp-create-release` skill that automates the entire preparation flow. Only one skill is needed because GitHub Actions handles tagging and release creation automatically when pyproject.toml changes land on main.
+
+**Key Design Decisions:**
+1. Use `Edit` tool for pyproject.toml version bump (no npm equivalent)
+2. Use `gh pr create` via Bash for GitHub PR creation
+3. Generate changelog from git commit history since last tag (not PRDs)
+4. Follow VS Code extension skill structure for consistency
+5. Single skill — no "complete release" needed

--- a/prds/SAF-31243-create-skills-for-releasing/prd.md
+++ b/prds/SAF-31243-create-skills-for-releasing/prd.md
@@ -1,0 +1,119 @@
+# PRD: /mcp-create-release Skill
+
+**Ticket**: [SAF-31243](https://safebreach.atlassian.net/browse/SAF-31243)
+**Status**: Complete
+**Author**: Yossi Attas
+
+## Problem Statement
+
+The SafeBreach MCP release process is fully manual: version bumping in `pyproject.toml`,
+changelog authoring, release branch creation, and PR submission are all done by hand. This
+introduces risk of inconsistent changelogs, incorrect formatting, wrong branch naming, and
+wasted developer time (~15-20 min per release).
+
+## Solution
+
+A repo-local Claude Code skill at `.claude/commands/mcp-create-release.md` that automates
+the entire release preparation workflow. Only one skill is needed because GitHub Actions
+(`release.yml`) automatically handles tagging and release creation after the PR merges to main.
+
+## Technical Design
+
+### Skill Location
+
+`.claude/commands/mcp-create-release.md` — local to the safebreach-mcp repo. Activates as
+`/mcp-create-release` when Claude Code runs in this repository.
+
+### Workflow (11 Steps)
+
+| Step | Action | Tool |
+|------|--------|------|
+| 1 | Validate environment (`pyproject.toml` exists, clean tree) | Read, Bash |
+| 2 | Ask version bump type (minor/major) | AskUserQuestion |
+| 3 | Parse current version, calculate next | Read |
+| 4 | Create `release_{version}` branch from main | Bash |
+| 5 | Bump version in `pyproject.toml` | Edit |
+| 6 | Generate changelog from `git log` since last tag | Bash |
+| 7 | Present changelog draft for user review | AskUserQuestion |
+| 8 | Insert new section into `CHANGELOG.md` | Edit |
+| 9 | Present batch summary for final approval | AskUserQuestion |
+| 10 | Commit and push | Bash |
+| 11 | Create GitHub PR via `gh pr create` | Bash |
+
+### Key Design Decisions
+
+1. **Single skill, no "complete release"** — GitHub Actions handles post-merge automatically
+   (validates CHANGELOG, creates tag, creates GitHub Release).
+
+2. **Git commit history for changelog** (not PRDs) — commits since last tag are categorized
+   into Added/Changed/Fixed sections. SAF ticket prefixes and PR numbers are stripped for
+   user-facing readability.
+
+3. **Em-dash format** (`## X.Y.Z — YYYY-MM-DD`) — matches existing `CHANGELOG.md` convention.
+   The skill includes explicit correct/wrong examples and reinforcement at the Edit step to
+   prevent double-hyphen substitution.
+
+4. **`git stash --include-untracked`** for dirty tree handling — plain `git stash` doesn't
+   capture untracked files, which was caught during testing.
+
+5. **Scope-constrained** — only modifies `pyproject.toml` and `CHANGELOG.md`. Does NOT touch
+   `README.md`, `CLAUDE.md`, or any other files (unlike unconstrained baseline which modified
+   4+ files).
+
+6. **Branch naming**: `release_{version}` (underscore) per existing convention, with collision
+   handling (reuse existing, suffix with `-v2`, or abort).
+
+### Reference Implementation
+
+Modeled after the VS Code extension release skills at
+`/Users/yossiattas/projects/rules/plugins/sb-vsextension/skills`:
+- `vse-create-release` — 11-step workflow with validation gates
+- `vse-complete-release` — merge + publish workflow (not needed for MCP)
+
+Key adaptations:
+- `pyproject.toml` + Edit tool instead of `package.json` + `npm version`
+- GitHub `gh` CLI instead of Bitbucket MCP tools
+- Git commit history instead of PRD-based changelog generation
+
+### Integration with Existing Infrastructure
+
+- **GitHub Actions** (`release.yml`): Triggers on `pyproject.toml` changes to main.
+  Validates CHANGELOG entry with `grep -q "^## $VERSION" CHANGELOG.md`, extracts
+  release notes, creates annotated tag, creates GitHub Release.
+- **Pre-commit hooks**: Gitleaks scan runs on commit. Workspace artifacts excluded
+  via `.gitleaks.toml` allowlist.
+- **Git tags**: Bare semantic version (e.g., `1.1.0`, no "v" prefix).
+
+## Testing
+
+Tested using the skill-creator evaluation framework across 2 iterations:
+
+### Iteration 1 (80% pass rate)
+- Found 2 bugs: em-dash rendered as double-hyphen in actual file, stash missing `--include-untracked`
+
+### Iteration 2 (100% pass rate)
+- Both bugs fixed and verified
+- 21/21 assertions passed across 3 test cases (minor release, major release, dirty tree)
+
+### Skill vs Baseline Comparison
+
+| Metric | With Skill | Without Skill |
+|--------|-----------|---------------|
+| Pass rate | 100% | 43% |
+| Mean tokens | 51k | 57k |
+| Mean duration | 127s | 170s |
+
+Baseline failures: wrong branch naming (`release/` vs `release_`), no `chore:` commit prefix,
+SAF ticket refs in changelog, modified extra files (README, CLAUDE.md), non-standard changelog
+sections ("Enhanced").
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.claude/commands/mcp-create-release.md` | New skill file (216 lines) |
+| `.gitignore` | Exclude workspace + `.claude/settings.local.json` |
+| `.gitleaks.toml` | Allowlist workspace path for false positive suppression |
+| `prds/SAF-31243-create-skills-for-releasing/context.md` | Investigation context |
+| `prds/SAF-31243-create-skills-for-releasing/summary.md` | Ticket summary |
+| `prds/SAF-31243-create-skills-for-releasing/prd.md` | This document |

--- a/prds/SAF-31243-create-skills-for-releasing/summary.md
+++ b/prds/SAF-31243-create-skills-for-releasing/summary.md
@@ -1,0 +1,171 @@
+# Ticket Summary: SAF-31243
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: safebreach-mcp, sb-vsextension (reference)
+
+---
+
+## Current State
+**Summary**: [safebreach-mcp] Create a repo-specific claude skills to automate the releases of the SafeBreach MCP
+**Issues Identified**: Ticket lacks acceptance criteria, detailed workflow steps, and adaptation specifics for the MCP repo (vs the VS Code extension reference).
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- Version in `pyproject.toml` (line 3), semantic versioning, single source of truth
+- CHANGELOG.md uses "Keep a Changelog" format: `## X.Y.Z — YYYY-MM-DD` (em-dash, no brackets)
+- GitHub Actions (`release.yml`) auto-creates tag + GitHub Release when `pyproject.toml` changes on main — validates CHANGELOG entry first
+- Git tags use bare semantic version (no "v" prefix), current: `1.1.0`
+- Release branch convention: `release_X.Y.Z`
+- Changes tracked via git commit history (not PRDs)
+- PRs created via `gh` CLI on GitHub
+
+### sb-vsextension (reference)
+- Two skills: `vse-create-release` (11-step workflow) and `vse-complete-release` (8-step)
+- Well-structured: validation gates, user confirmations, error handling tables, limitations
+- Uses Bitbucket MCP, `npm version`, PRD-based changelog generation
+- Pattern is proven and can be adapted for the MCP repo
+
+---
+
+## Problem Analysis
+
+### Problem Description
+The SafeBreach MCP release process is fully manual: version bumping, changelog authoring, branch creation, and PR submission are all done by hand. This introduces risk of inconsistent changelogs, forgotten version bumps, and wasted developer time.
+
+### Impact Assessment
+- **Developer productivity**: Each release requires ~15-20 min of manual steps
+- **Quality**: Manual changelog writing risks missing changes or inconsistent formatting
+- **Reliability**: Automated GitHub Actions depend on correct pyproject.toml + CHANGELOG.md format
+
+### Risks & Edge Cases
+- No commits since last tag — skill must detect and abort
+- Dirty working tree — must offer stash/abort
+- Release branch collision — must handle (reuse, suffix, abort)
+- Existing changelog entry for target version — must detect
+- Mixed commit message formats — changelog generation must handle with/without SAF tickets
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+[safebreach-mcp] Create `/mcp-create-release` skill to automate release preparation
+
+### Description
+
+**Background**
+The SafeBreach MCP repo currently requires manual release preparation: bumping the version in `pyproject.toml`, writing changelog entries from commit history, creating a release branch, and opening a PR. Once the PR is merged to main, GitHub Actions automatically validates the changelog, creates a git tag, and publishes a GitHub Release. A Claude Code skill should automate the preparation steps.
+
+**Technical Context**
+* Version source of truth: `pyproject.toml` line 3 (`version = "X.Y.Z"`)
+* Changelog format: "Keep a Changelog" — `## X.Y.Z — YYYY-MM-DD` with Added/Changed/Fixed sections
+* GitHub Actions `release.yml` triggers on pyproject.toml changes to main, validates changelog, creates tag + release
+* Git tag format: bare semantic version (e.g., `1.1.0`, no "v" prefix)
+* Release branch convention: `release_{version}` (e.g., `release_1.2.0`)
+* Changes are identified from git commit history since the last tag (not PRDs)
+* PRs are created via `gh pr create` on GitHub
+
+**Skill Workflow** (`/mcp-create-release`)
+1. Validate environment — read `pyproject.toml`, check git status is clean
+2. Ask version bump type — minor or major (via AskUserQuestion)
+3. Read current version from `pyproject.toml` and calculate next version
+4. Create release branch: `release_{next_version}` from main
+5. Bump version in `pyproject.toml` using Edit tool
+6. Generate changelog entries from `git log {last_tag}..HEAD --oneline`
+7. Present changelog draft to user for review/editing
+8. Update `CHANGELOG.md` — insert new version section at top
+9. Present full summary for approval
+10. Commit: `git add pyproject.toml CHANGELOG.md && git commit`
+11. Push and create GitHub PR via `gh pr create`
+
+**Reference Implementation**
+The VS Code extension release skills at `/Users/yossiattas/projects/rules/plugins/sb-vsextension/skills` provide the structural pattern to follow. Key adaptations:
+* `pyproject.toml` + Edit tool instead of `package.json` + `npm version`
+* GitHub `gh` CLI instead of Bitbucket MCP tools
+* Git commit history instead of PRD-based changelog
+* Single skill only — no "complete release" needed (GitHub Actions handles post-merge)
+
+**Affected Areas**
+* New skill: to be created under a skills directory (TBD — either repo-local or in the rules repo)
+* Reads: `pyproject.toml`, `CHANGELOG.md`, git tags/log
+* Modifies: `pyproject.toml`, `CHANGELOG.md`
+* Creates: release branch, GitHub PR
+
+### Acceptance Criteria
+
+- [ ] Skill triggers on `/mcp-create-release` and related phrases ("create release", "prepare release", "version bump")
+- [ ] Validates environment: confirms `pyproject.toml` exists and git working tree is clean
+- [ ] Asks user to choose between minor and major version bump
+- [ ] Correctly calculates next version (minor: 1.1.0 -> 1.2.0, major: 1.1.0 -> 2.0.0)
+- [ ] Creates `release_{version}` branch from latest main
+- [ ] Handles branch collision (branch already exists: reuse, suffix, or abort)
+- [ ] Bumps version in `pyproject.toml`
+- [ ] Generates changelog entries from git commit history since last tag
+- [ ] Presents changelog draft to user for review before writing
+- [ ] Updates `CHANGELOG.md` in correct format (`## X.Y.Z — YYYY-MM-DD` with Added/Changed/Fixed sections)
+- [ ] Commits with descriptive message and Co-Authored-By trailer
+- [ ] Pushes branch and creates GitHub PR via `gh pr create`
+- [ ] Handles edge cases: no commits since last tag, dirty tree, no tags exist
+- [ ] Includes comprehensive error handling table and limitations section
+- [ ] Follows the structural pattern of the VS Code extension release skills
+
+---
+
+## Proposed Ticket Content
+
+<!-- Markdown format for JIRA Cloud -->
+
+**Description (Markdown for JIRA):**
+```markdown
+### Background
+The SafeBreach MCP repo currently requires manual release preparation: bumping the version in `pyproject.toml`, writing changelog entries from commit history, creating a release branch, and opening a PR. Once the PR is merged to main, GitHub Actions automatically validates the changelog, creates a git tag, and publishes a GitHub Release. A Claude Code skill should automate the preparation steps.
+
+### Technical Context
+* Version source of truth: `pyproject.toml` line 3 (`version = "X.Y.Z"`)
+* Changelog format: "Keep a Changelog" — `## X.Y.Z — YYYY-MM-DD` with Added/Changed/Fixed sections
+* GitHub Actions `release.yml` triggers on pyproject.toml changes to main, validates changelog, creates tag + release
+* Git tag format: bare semantic version (e.g., `1.1.0`, no "v" prefix)
+* Release branch convention: `release_{version}` (e.g., `release_1.2.0`)
+* Changes identified from git commit history since last tag (not PRDs)
+* PRs created via `gh pr create` on GitHub
+
+### Skill Workflow (`/mcp-create-release`)
+1. Validate environment — read `pyproject.toml`, check git status is clean
+2. Ask version bump type — minor or major (via AskUserQuestion)
+3. Read current version from `pyproject.toml` and calculate next version
+4. Create release branch: `release_{next_version}` from main
+5. Bump version in `pyproject.toml` using Edit tool
+6. Generate changelog entries from `git log {last_tag}..HEAD --oneline`
+7. Present changelog draft to user for review/editing
+8. Update `CHANGELOG.md` — insert new version section at top
+9. Present full summary for approval
+10. Commit: `git add pyproject.toml CHANGELOG.md && git commit`
+11. Push and create GitHub PR via `gh pr create`
+
+### Reference Implementation
+The VS Code extension release skills at the rules repo (`sb-vsextension` plugin) provide the structural pattern. Key adaptations: `pyproject.toml` + Edit instead of `package.json` + `npm version`, GitHub `gh` CLI instead of Bitbucket MCP, git commit history instead of PRD-based changelog, single skill (no "complete release" — GitHub Actions handles post-merge).
+```
+
+**Acceptance Criteria:**
+```markdown
+* Skill triggers on `/mcp-create-release` and related phrases ("create release", "prepare release", "version bump")
+* Validates environment: confirms `pyproject.toml` exists and git working tree is clean
+* Asks user to choose between minor and major version bump
+* Correctly calculates next version (minor: 1.1.0 -> 1.2.0, major: 1.1.0 -> 2.0.0)
+* Creates `release_{version}` branch from latest main
+* Handles branch collision (branch already exists: reuse, suffix, or abort)
+* Bumps version in `pyproject.toml`
+* Generates changelog entries from git commit history since last tag
+* Presents changelog draft to user for review before writing
+* Updates `CHANGELOG.md` in correct format (`## X.Y.Z — YYYY-MM-DD` with Added/Changed/Fixed sections)
+* Commits with descriptive message and Co-Authored-By trailer
+* Pushes branch and creates GitHub PR via `gh pr create`
+* Handles edge cases: no commits since last tag, dirty tree, no tags exist
+* Includes comprehensive error handling table and limitations section
+* Follows the structural pattern of the VS Code extension release skills
+```


### PR DESCRIPTION
## Summary
- Add `/mcp-create-release` Claude Code skill that automates the MCP release preparation workflow
- Skill lives at `.claude/skills/mcp-create-release/SKILL.md` with YAML frontmatter for proper discovery
- Handles: version bump in `pyproject.toml`, changelog generation from git history, release branch creation, commit, push, and GitHub PR submission
- Tested via skill-creator eval framework: **100% pass rate** across 21 assertions (3 test cases x 7-8 assertions each), compared to 43% baseline without the skill
- Includes PRD files for SAF-31243

## What the skill does
1. Validates environment (`pyproject.toml` exists, clean git tree)
2. Asks user for minor or major version bump
3. Calculates next version and creates `release_{version}` branch
4. Bumps version in `pyproject.toml`
5. Generates changelog from git commit history since last tag
6. Presents changelog draft for user review
7. Updates `CHANGELOG.md` with correct em-dash format
8. Commits with `chore:` prefix and Co-Authored-By trailer
9. Pushes and creates GitHub PR via `gh` CLI

## Test plan
- [x] Skill-creator evaluation: minor release (7/7 assertions passed)
- [x] Skill-creator evaluation: major release (8/8 assertions passed)
- [x] Skill-creator evaluation: dirty tree edge case (6/6 assertions passed)
- [x] Verified em-dash format in actual CHANGELOG.md files via `head -25`
- [x] Verified `git stash --include-untracked` handles untracked files
- [x] Verified skill loads correctly from `.claude/skills/` in fresh Claude terminal
- [ ] Manual smoke test: run `/mcp-create-release` in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)