### PR TITLE
SAF-32359: take outbound auth only from the current request

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,6 +64,25 @@ def e2e_auth_for_console():
 
 
 @pytest.fixture(autouse=True)
+def route_auth_ctxvar_to_request_ctx(monkeypatch):
+    """Bridge the test auth ContextVar to the live-request reader.
+
+    Tests inject user auth via the _user_auth_artifacts ContextVar, but
+    get_auth_headers_for_console() now reads only the current MCP request
+    (_get_auth_from_mcp_request_ctx). With no real ASGI request in unit tests,
+    route the ContextVar value to that reader so existing injections still work.
+    """
+    from safebreach_mcp_core import token_context
+    real_reader = token_context._get_auth_from_mcp_request_ctx
+    monkeypatch.setattr(
+        token_context,
+        "_get_auth_from_mcp_request_ctx",
+        lambda: token_context._user_auth_artifacts.get() or real_reader(),
+    )
+    yield
+
+
+@pytest.fixture(autouse=True)
 def clear_rate_limit_store():
     """Clear rate limit state between tests to prevent cross-test accumulation."""
     _rate_limit_store.clear()

--- a/docs/SAF-32359-PRD.md
+++ b/docs/SAF-32359-PRD.md
@@ -1,0 +1,68 @@
+# SAF-32359 — Take outbound auth only from the current request
+
+## Summary
+
+`get_auth_headers_for_console` (`safebreach_mcp_core/secret_utils.py`) could return a
+**stale** proxy token for outbound backend calls (ui `/api/data`, `/api/config`,
+`/api/orch`), causing those calls to fail with `401 Unauthorized` until the process was
+restarted.
+
+This change makes the function resolve auth **only from the current MCP request** — the
+live `request_ctx` headers that SIMP forwards — instead of consulting a cached source that
+can go stale.
+
+## Why it is needed
+
+The function previously resolved auth headers from three sources, in priority order:
+
+1. the `_user_auth_artifacts` ContextVar
+2. the live MCP request context (`_get_auth_from_mcp_request_ctx`)
+3. the `_session_auth_artifacts` session store
+
+The ContextVar (source 1) is set on the ASGI middleware task but does **not** propagate to
+the tool-handler task under streamable-http, so it can hold a token captured from an
+earlier request. Because source 1 was consulted first and only checked whether a token was
+*present* (not whether it was still valid), a stale token there short-circuited the lookup
+and was sent to the backend — producing the `401` once it expired (~15 min after a
+(re)start), even though the current request carried a fresh token all along.
+
+## The change
+
+`get_auth_headers_for_console` now uses a single source — the current request:
+
+```python
+def get_auth_headers_for_console(console):
+    bundle = _get_auth_from_mcp_request_ctx()   # the live request's forwarded headers
+    if bundle:
+        return dict(bundle)
+    # no user auth on this request:
+    #   embedded mode  -> raise AuthenticationRequired
+    #   standalone     -> fall back to env-var API key
+```
+
+Removed:
+
+- the `_user_auth_artifacts` ContextVar read (source 1),
+- the `_session_auth_artifacts` session-store read (source 3),
+- the `_needs_fresh_token` JWT-expiry helper (no longer needed — the request token is always
+  the current one).
+
+The per-request token is fresh by construction, so the expired-token failure mode cannot
+occur. Embedded-mode rejection and standalone env-key fallback are unchanged.
+
+## Tests
+
+- Unit tests inject auth via the `_user_auth_artifacts` ContextVar. A single autouse fixture
+  in `conftest.py` (`route_auth_ctxvar_to_request_ctx`) routes that injected value to the
+  request reader when the ContextVar is set, falling back to the real reader otherwise — so
+  existing injections keep working without per-test edits.
+- The obsolete `test_session_store_fallback_isolates_sessions` (exercised the removed
+  source 3) is deleted.
+- Full non-e2e suite passes (pre-existing `test_disable_filtering` failures are unrelated).
+
+## Scope
+
+- File: `safebreach_mcp_core/secret_utils.py` (+ test harness `conftest.py`, one removed test).
+- The `_user_auth_artifacts` ContextVar still exists for the rate limiter and cache-key
+  scoping; fully removing it and the session store / SSE machinery is tracked in SAF-32387.
+- No changes to breach-genie, mcp-proxy, ui, or the backend.

--- a/safebreach_mcp_core/secret_utils.py
+++ b/safebreach_mcp_core/secret_utils.py
@@ -6,12 +6,11 @@ Supports multiple secret storage backends through the SecretProvider interface.
 '''
 
 import logging
-from typing import Optional, Dict, Any
 import os
+from typing import Dict, Any
 from .cache_config import is_caching_enabled
 from .secret_providers import SecretProviderFactory, SecretProvider
 from .environments_metadata import safebreach_envs, get_environment_by_name
-from .token_context import _user_auth_artifacts, mask_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -92,49 +91,24 @@ def check_rbac_response(response) -> None:
 def get_auth_headers_for_console(console: str) -> Dict[str, str]:
     """Return auth headers for outbound backend API calls.
 
-    Priority:
-    1. Per-request user auth bundle (from ContextVar)
-    2. MCP SDK request_ctx — reads POST headers directly from tool handler context
-    3. Session store lookup via session_id from request_ctx
-    4. Embedded mode (SAFEBREACH_LOCAL_ENV set): raise AuthenticationRequired
-       Standalone mode (no SAFEBREACH_LOCAL_ENV): fall back to env-var API key
+    Auth is taken only from the current MCP request (the live request_ctx).
+    When the request carries no user credentials:
+      - Embedded mode (SAFEBREACH_LOCAL_ENV set): raise AuthenticationRequired.
+      - Standalone mode (no SAFEBREACH_LOCAL_ENV): fall back to env-var API key.
     """
-    bundle = _user_auth_artifacts.get()
-
-    # SSE transport fallback (SAF-29974 Slice 6): the ContextVar set on the
-    # /messages/ POST doesn't propagate to the tool handler (SSE GET's create_task
-    # uses a different async context).  Read the POST's headers directly from the
-    # MCP SDK's request_ctx, which IS set on the tool handler's task.
-    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
-        from .token_context import _get_auth_from_mcp_request_ctx
-        mcp_bundle = _get_auth_from_mcp_request_ctx()
-        if mcp_bundle:
-            bundle = mcp_bundle
-
-    # Tertiary fallback: session store lookup via session_id from request_ctx
-    if not bundle or ('x-token' not in bundle and 'cookie' not in bundle):
-        from .token_context import _get_session_id_from_mcp_ctx, _session_auth_artifacts
-        session_id = _get_session_id_from_mcp_ctx()
-        if session_id:
-            entry = _session_auth_artifacts.get(session_id)
-            if entry:
-                bundle = entry[0]
-
+    from .token_context import _get_auth_from_mcp_request_ctx
+    bundle = _get_auth_from_mcp_request_ctx()
     if bundle:
         logger.debug(f"get_auth_headers_for_console('{console}') → user bundle "
                      f"(keys: {list(bundle.keys())})")
-        return dict(bundle)  # copy — callers may mutate
+        return dict(bundle)
 
-    # No user auth in request context.
-    # In embedded mode (SAFEBREACH_LOCAL_ENV set by SIMP) this is an RBAC violation.
-    # In standalone mode (no SAFEBREACH_LOCAL_ENV) fall back to env-var API key.
     if os.environ.get('SAFEBREACH_LOCAL_ENV'):
         logger.warning(f"No user auth in context for '{console}' — rejecting (RBAC enforcement)")
         raise AuthenticationRequired(
             f"Authentication required for console '{console}': no user credentials in request context"
         )
 
-    # Standalone mode — use shared API key from env/secret provider
     logger.debug(f"get_auth_headers_for_console('{console}') → standalone mode, "
                  f"falling back to env-var API key")
     api_key = get_secret_for_console(console)

--- a/tests/test_auth_concurrency.py
+++ b/tests/test_auth_concurrency.py
@@ -194,38 +194,6 @@ class TestConcurrentSessionIsolation:
         assert result_b['x-token'] == 'token-user-B'
         assert result_a['x-token'] != result_b['x-token']
 
-    def test_session_store_fallback_isolates_sessions(self):
-        """When request_ctx headers are empty, session store provides isolation."""
-        # Pre-populate session store with different bundles
-        _session_auth_artifacts['sess-A'] = ({'x-token': 'token-A'}, 1000.0)
-        _session_auth_artifacts['sess-B'] = ({'x-token': 'token-B'}, 1000.0)
-
-        # User A: request_ctx has session_id in query_params but no auth headers
-        req_a = _mock_request(
-            headers={},
-            query_params={'session_id': 'sess-A'},
-        )
-        ctx_a = _mock_request_ctx(req_a)
-
-        with patch(_REQUEST_CTX_PATCH) as mock_rc:
-            mock_rc.get.return_value = ctx_a
-            result_a = get_auth_headers_for_console('default')
-
-        assert result_a['x-token'] == 'token-A'
-
-        # User B: different session_id
-        req_b = _mock_request(
-            headers={},
-            query_params={'session_id': 'sess-B'},
-        )
-        ctx_b = _mock_request_ctx(req_b)
-
-        with patch(_REQUEST_CTX_PATCH) as mock_rc:
-            mock_rc.get.return_value = ctx_b
-            result_b = get_auth_headers_for_console('default')
-
-        assert result_b['x-token'] == 'token-B'
-
 
 class TestGetCacheUserSuffix:
 


### PR DESCRIPTION
get_auth_headers_for_console resolved auth from the _user_auth_artifacts ContextVar first; under streamable-http that ContextVar can hold a token captured from an earlier request and only its presence was checked, so a stale/expired token was sent to the backend and returned 401 ~15 min after a (re)start.

Resolve auth solely from the live MCP request (_get_auth_from_mcp_request_ctx). Drop the ContextVar read, the session-store fallback, and the _needs_fresh_token expiry helper. The per-request token is fresh by construction.

Tests: conftest bridges the ContextVar-based auth injection to the request reader so existing tests keep working; removed the obsolete session-store fallback test. PRD updated.

The ContextVar remains for the rate limiter and cache-key scoping; fully removing it + the session store / SSE machinery is tracked in SAF-32387.