### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 — 2026-06-18
+
+### Changed
+
+- `run_studio_attack` now queues a test with its `draft` flag matching the attack's publication status: PUBLISHED attacks are queued
+  with `draft=False` so the run is discoverable in Test Results (parity with a UI quick-run); DRAFT attacks are queued with
+  `draft=True` and the response includes a hint to publish first.
+
+### Fixed
+
+- Outbound backend authentication is now resolved solely from the live MCP request instead of a ContextVar. This prevents a
+  stale/expired token captured from an earlier request (under streamable-http transport) from being sent to the backend and causing
+  401 errors ~15 minutes after a (re)start.
+
 ## 1.3.0 — 2026-05-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.3.0"
+version = "1.4.0"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "safebreach-mcp-server"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 1.4.0

## 1.4.0 — 2026-06-18

### Changed

- `run_studio_attack` now queues a test with its `draft` flag matching the attack's publication status: PUBLISHED attacks are queued with `draft=False` so the run is discoverable in Test Results (parity with a UI quick-run); DRAFT attacks are queued with `draft=True` and the response includes a hint to publish first.

### Fixed

- Outbound backend authentication is now resolved solely from the live MCP request instead of a ContextVar. This prevents a stale/expired token captured from an earlier request (under streamable-http transport) from being sent to the backend and causing 401 errors ~15 minutes after a (re)start.

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.4.0`
3. Create a GitHub Release with the changelog notes