### PR TITLE
SAF-32018: Fix stale running-test simulation counts in get_test_details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,12 +266,6 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 - `SB_MCP_CACHE_PLAYBOOK=true|false` — Playbook server
 - `SB_MCP_CACHE_STUDIO=true|false` — Studio server
 
-**Running-test live counts (SAF-32018):**
-- `SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS` — soft cap (default `5000`) on the number of
-  simulations `get_test_details` will page from the live `executionsHistoryResults` source when
-  recomputing counts for a **non-terminal** test. Above the cap it keeps the lagging
-  `testsummaries.finalStatus` aggregate and routes the agent to `get_test_simulations` via a hint.
-
 **Error Handling**: Functions include timeout configurations (120 seconds for API calls) and comprehensive logging for debugging SafeBreach API interactions.
 
 **Data Pagination**: All listing operations use `PAGE_SIZE = 10` with proper pagination handling for large datasets.
@@ -338,14 +332,15 @@ Rate limiting environment variables:
 **Data Server (Port 8001):**
 3. `get_tests` ✨ **Enhanced** - Filtered and paginated test execution history with advanced filtering options (test type, time windows, status, name patterns) and customizable ordering
 4. `get_test_details` ✨ **Enhanced** - Full details with always-inline status counts, optional streaming drift count, and Propagate findings.
-  **SAF-32018**: for a **non-terminal (running) test**, `simulations_statistics` is recomputed
-  from the **live `executionsHistoryResults` source** (what the UI shows) instead of the lagging
-  `testsummaries.finalStatus` aggregate — so running-test counts are accurate, not stale.
-  Soft-capped by `SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS` (default 5000): above the cap, or on
-  fetch failure, it keeps the aggregate and emits a `hint_to_agent` routing to `get_test_simulations`
-  (whose `total_simulations` with a `status_filter` is the live count). Terminal tests are unchanged
-  (cheap reconciled aggregate). Other count/finding paths that cannot recount live (`get_tests`,
-  findings, security-control events, drift tools) carry a running-test caveat hint instead
+  **SAF-32018**: for a **non-terminal (running) test**, `simulations_statistics` is refreshed from
+  a **fresh single-test `testsummaries/{id}` call** instead of the (up-to-30-min) cached test-list
+  snapshot. Root cause of the original bug: the running-test path served a stale *cached*
+  `finalStatus` whose counts were never refreshed (only the status was). A fresh `finalStatus`
+  tracks the live UI aggregation to within ~1 simulation, so this single cheap call fixes the
+  staleness — no per-simulation paging. A `hint_to_agent` flags the counts as point-in-time while
+  running and routes to `get_test_simulations` for the live filtered grid. Terminal tests are
+  unchanged. Other count/finding paths (`get_tests`, findings, security-control events, drift tools)
+  carry a running-test caveat hint instead
 5. `get_test_simulations` ✨ **Enhanced** - Filtered and paginated simulations within a test with status, time window, playbook attack filtering, and drift analysis filtering
 6. `get_test_simulation_details` ✨ **Enhanced** - Returns a **curated hybrid result** (logs excluded): the flat snake_case envelope (simulation_id, status, attacker/target nodes, attack info, result_details) PLUS `simulation_steps_by_node` — the per-node execution steps (each tagged `role`=attacker/target/host, with `task_status`/`error`) forming the forensic middle tier — and a snake_case `logs_embedded` routing flag. Heavy per-node LOGS/OUTPUT and the raw v3 document are NOT relayed. **Primary investigation entry point** — inspect result + steps first; escalate to `get_paginated_simulation_logs` only when insufficient (`logs_embedded=true` → `get_full_simulation_logs` instead). Optional MITRE techniques, basic attack logs, and drift analysis merged into the envelope. Falls back to the curated list-API summary (empty `simulation_steps_by_node`) on consoles without the v3 endpoint
 7. `get_security_controls_events` - Security control events with filtering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,12 @@ per-type LRU eviction and TTL expiration. Cache sizes are intentionally small to
 - `SB_MCP_CACHE_PLAYBOOK=true|false` — Playbook server
 - `SB_MCP_CACHE_STUDIO=true|false` — Studio server
 
+**Running-test live counts (SAF-32018):**
+- `SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS` — soft cap (default `5000`) on the number of
+  simulations `get_test_details` will page from the live `executionsHistoryResults` source when
+  recomputing counts for a **non-terminal** test. Above the cap it keeps the lagging
+  `testsummaries.finalStatus` aggregate and routes the agent to `get_test_simulations` via a hint.
+
 **Error Handling**: Functions include timeout configurations (120 seconds for API calls) and comprehensive logging for debugging SafeBreach API interactions.
 
 **Data Pagination**: All listing operations use `PAGE_SIZE = 10` with proper pagination handling for large datasets.
@@ -331,7 +337,15 @@ Rate limiting environment variables:
 
 **Data Server (Port 8001):**
 3. `get_tests` ✨ **Enhanced** - Filtered and paginated test execution history with advanced filtering options (test type, time windows, status, name patterns) and customizable ordering
-4. `get_test_details` ✨ **Enhanced** - Full details with always-inline status counts, optional streaming drift count, and Propagate findings
+4. `get_test_details` ✨ **Enhanced** - Full details with always-inline status counts, optional streaming drift count, and Propagate findings.
+  **SAF-32018**: for a **non-terminal (running) test**, `simulations_statistics` is recomputed
+  from the **live `executionsHistoryResults` source** (what the UI shows) instead of the lagging
+  `testsummaries.finalStatus` aggregate — so running-test counts are accurate, not stale.
+  Soft-capped by `SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS` (default 5000): above the cap, or on
+  fetch failure, it keeps the aggregate and emits a `hint_to_agent` routing to `get_test_simulations`
+  (whose `total_simulations` with a `status_filter` is the live count). Terminal tests are unchanged
+  (cheap reconciled aggregate). Other count/finding paths that cannot recount live (`get_tests`,
+  findings, security-control events, drift tools) carry a running-test caveat hint instead
 5. `get_test_simulations` ✨ **Enhanced** - Filtered and paginated simulations within a test with status, time window, playbook attack filtering, and drift analysis filtering
 6. `get_test_simulation_details` ✨ **Enhanced** - Returns a **curated hybrid result** (logs excluded): the flat snake_case envelope (simulation_id, status, attacker/target nodes, attack info, result_details) PLUS `simulation_steps_by_node` — the per-node execution steps (each tagged `role`=attacker/target/host, with `task_status`/`error`) forming the forensic middle tier — and a snake_case `logs_embedded` routing flag. Heavy per-node LOGS/OUTPUT and the raw v3 document are NOT relayed. **Primary investigation entry point** — inspect result + steps first; escalate to `get_paginated_simulation_logs` only when insufficient (`logs_embedded=true` → `get_full_simulation_logs` instead). Optional MITRE techniques, basic attack logs, and drift analysis merged into the envelope. Falls back to the curated list-API summary (empty `simulation_steps_by_node`) on consoles without the v3 endpoint
 7. `get_security_controls_events` - Security control events with filtering

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/context.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/context.md
@@ -126,6 +126,86 @@ every 5s across the full run (~200s, 125 sims):
 
 **Status:** Phase 8 Complete — investigation comment posted to SAF-32018 (comment 191903)
 
+---
+
+## planning-dev-task — Phase 4: Full inventory of stale count-bearing read paths
+
+Goal: decide between (A) real live-count code path in every affected read path vs. (B) a
+non-terminal "counts may lag" hint. Decision hinges on real-fix feasibility per path.
+
+| Path | Source | Stale while running? | Live alternative? | Real-fix cost | Terminal-aware? | Shares `_build_simulation_status_counts`? |
+|------|--------|----------------------|-------------------|---------------|-----------------|-------------------------------------------|
+| `get_test_details` | testsummaries.finalStatus | YES | YES (executionsHistoryResults) | Moderate (page 1 test) | YES (`:447`) | YES |
+| `get_tests` (list) | finalStatus per test | YES | YES per test | **Prohibitive** (≤1000 tests → 1000+ paged fetches) | NO | YES |
+| `get_studio_attack_latest_result` (test_overview) | finalStatus (inline @ `studio_functions.py:1538`) | YES | YES | Moderate (page 1 test) | YES (`:1555`) | NO — **duplicated inline logic** |
+| `get_test_simulations` | executionsHistoryResults (direct) | **No — already LIVE** | n/a (is the source) | n/a | implicit | NO (`get_reduced_simulation_result_entity`) |
+| `get_test_findings_counts` / `_details` | propagateSummary findings | YES (post-processing) | **NO live per-finding source** | **Infeasible** | NO | independent |
+| `get_security_controls_events` / `_details` | SIEM eventLogs | YES (external SIEM lag) | **NO (external)** | **Infeasible** | NO | independent |
+| `get_simulation_result_drifts` / `_status_drifts` / `get_security_control_drifts` | backend drift API | YES | only by re-implementing backend logic | **Infeasible** | NO | independent |
+| `get_test_drifts` | executionsHistoryResults | already live (incomplete mid-run) | n/a | n/a | implicit | independent |
+
+### Decisive facts
+1. **The "real fix" is NOT achievable in all paths.** Findings, security-control events, and the
+   drift tools have **no live alternative** — the lag is genuinely upstream (post-processing / SIEM
+   / backend drift service). A "real fix" there would mean re-implementing backend aggregation in
+   the MCP — infeasible and wrong.
+2. **`get_tests` real fix is prohibitive** — live counts for a list would require paging
+   `executionsHistoryResults` for every running test (up to 1000+ fetches per call).
+3. **Only 2 single-test paths can take a cheap real fix:** `get_test_details` and the Studio
+   `test_overview` block (which also has a **duplicated inline** copy of the count logic at
+   `studio_functions.py:1538` that bypasses the centralized helper).
+4. **The authoritative live count already exists** as a tool: `get_test_simulations` with a
+   `status_filter` returns `total_simulations` straight from `executionsHistoryResults` (proven to
+   reconcile with finalStatus at terminal: 67==67, 125/94).
+
+## planning-dev-task — Phase 5: Chosen approach (HYBRID)
+
+Decision: **Hybrid** — real-fix where cheap/feasible, routing-hint everywhere else.
+Rationale: a pure real-fix cannot cover all paths (findings/SIEM/drift have NO live source;
+`get_tests` is prohibitive). A bare hint is uniform but leaves headline numbers aggregate-sourced.
+Hybrid gives correct values where cheap + honest, actionable expectations everywhere.
+
+### Part A — Real live-count fix (gated to NON-TERMINAL tests)
+Applies to the two single-test count paths:
+- `sb_get_test_details` (`data_functions.py:416`)
+- Studio `test_overview` block (`studio_functions.py:1538`) — also fold its inline duplicate into
+  the centralized helper.
+
+Mechanism: when the test is non-terminal (reuse SAF-31111 `terminal_statuses` detection), compute
+`simulations_statistics` from the live `executionsHistoryResults` source (via
+`_get_all_simulations_from_cache_or_api` → count by status) instead of `finalStatus`.
+Terminal tests are unchanged (cheap aggregate, already reconciled).
+
+**Perf guardrail: SOFT CAP + FALLBACK.** Recount live only when the test's known total
+(from `finalStatus`) is ≤ a configurable threshold (default ~5000 sims). Beyond it, keep the
+aggregate count and attach the routing hint ("test too large for live recount; use
+get_test_simulations with a status filter for an exact live count"). Threshold via constant/env.
+
+### Part B — Universal routing hint (NON-TERMINAL tests)
+Attach a hint on every count/finding-bearing path when its test(s) are non-terminal:
+- Hint-only paths (counts stay aggregate-sourced): `get_tests` (if any test in page is running),
+  `get_test_findings_counts`/`_details`, `get_security_controls_events`/`_details`, the drift tools.
+  Text: "Test still running — these counts/findings may lag live results; for an exact live
+  simulation count call `get_test_simulations` with the relevant `status_filter`."
+- Real-fix paths (`get_test_details`, Studio test_overview): counts are now LIVE, so the hint
+  instead clarifies the count is point-in-time and will keep changing while running (retain the
+  existing 'poll again' guidance); fallback case (over soft cap) uses the routing-hint text.
+
+### Out of scope / follow-up notes
+- We do NOT re-implement backend aggregation for findings/SIEM/drift (no live source).
+- `get_tests` is intentionally hint-only (per-test live recount across a list is prohibitive).
+
+### Test strategy (TDD)
+- Reproduce: assert non-terminal `get_test_details` counts == live `executionsHistoryResults`
+  counts (fails today). Reuse repro scripts in this folder.
+- Terminal tests: counts unchanged (aggregate path).
+- Soft-cap fallback: over-threshold non-terminal test keeps aggregate + emits routing hint.
+- Hint presence on each hint-only path for a non-terminal test; absent for terminal.
+- Studio test_overview: live counts for non-terminal + uses centralized helper (no inline dup).
+
+**Status:** Phase 7 complete — PRD approved; JIRA RCA field populated; SAF-32018 "is caused by"
+SAF-28298 link created. Ready for implementation (tdd-implementing-prd).
+
 ## Problem Analysis
 
 _(to be populated in Phase 5)_

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/context.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/context.md
@@ -1,0 +1,131 @@
+# Context: SAF-32018
+
+**Status:** Phase 3: Context Created
+**Mode:** Improve existing ticket
+**Branch:** `bugfix/SAF-32018-stale-running-test-counts`
+**Repo:** `/Users/yossiattas/Public/safebreach-mcp`
+
+## Ticket Summary
+
+| Field | Value |
+|-------|-------|
+| Key | SAF-32018 |
+| Type | Bug (High) |
+| Status | To Do — Saf sprint 91 |
+| Assignee | Yossi Attas |
+| Reporter | Hadas Cohen |
+| Labels | CTEM-dev, HELM-AI-Agent |
+| Env | pentest01.safebreach.com, Mgmt/Sim 2026Q2.4 |
+
+**Title:** HELM | Data Discrepancy - Agent reports incorrect count of "Missed" simulations due to stale background API cache
+
+**Reported behavior:** While a test execution is actively running, the HELM agent (this MCP
+server) reports a stale "Missed" simulation count (e.g. 28) while the live UI filter shows the
+updated value (e.g. 80). The agent rationalizes this as "an API caching issue on the backend
+side." Workaround: wait for the test to finish so the cache reconciles.
+
+**Steps to reproduce (from ticket):**
+1. Navigate to Analysis → Simulation Results for an ongoing active test run.
+2. Apply the left-sidebar filter to show Result: Missed.
+3. Verify the header shows Filter Simulations (80) matching the grid.
+4. Ask the HELM agent to verify/check the count of missed simulations for that running test.
+5. Note HELM's stated count → it reports 28 (stale), not 80.
+
+**Expected:** HELM returns the accurate, real-time count (80) matching the UI.
+**Actual:** HELM returns a stale count (28) and blames backend caching.
+
+## Task Scope
+
+- Repo: safebreach-mcp (this repo) — confirmed by user.
+- Focus: Caching staleness for **running (non-terminal) tests** — root-cause why running-test
+  status counts are served stale, and whether non-terminal tests should bypass / short-TTL the
+  client-side cache.
+
+## Investigation Findings
+
+### Where the count comes from (call chain)
+- `get_test_details` tool → `sb_get_test_details()` — `data_functions.py:416`
+- → `_find_test_in_cached_list()` → `_get_all_tests_from_cache_or_api()` — `data_functions.py:204`
+  - Calls `GET /api/data/v1/accounts/{account_id}/testsummaries?size=1000` (`data_functions.py:235`)
+- → `get_reduced_test_summary_mapping()` — `data_types.py:142`
+- → `_build_simulation_status_counts(finalStatus)` — `data_types.py:82` — extracts the 7 status
+  counts (missed/stopped/prevented/detected/logged/no-result/inconsistent) **from the API's
+  `finalStatus` aggregate object**. This becomes `simulations_statistics`.
+- The single-test fallback endpoint `/testsummaries/{test_id}` (`_fetch_single_test`,
+  `data_functions.py:531`) derives counts from the **same** `finalStatus` aggregate.
+
+### Existing running-test handling (SAF-31111)
+- `sb_get_test_details` already detects non-terminal status (`terminal_statuses =
+  {'completed','canceled','failed'}`, `data_functions.py:447-449`) and refreshes:
+  - Phase 1 — orchestrator queue `get_orchestrator_test_state()` (`queue_state.py:25`): returns
+    only `"RUNNING"` / `"PAUSED"` / `None`. **No counts.** Updates only `status` (`:456`).
+  - Phase 2 (only if orchestrator returns None) — single-test endpoint refresh of
+    `simulations_statistics` (`:466`), but from the **same lagging `finalStatus` aggregate**.
+
+### THE ROOT CAUSE (corrects the "line 456" framing)
+For a **running** test the count is sourced from `testsummaries.finalStatus`, a backend aggregate
+that is computed lazily/periodically and **lags the live per-simulation results** during an active
+run. The UI's "Filter Simulations (80)" counts **live simulation rows**. The MCP faithfully relays
+the lagging aggregate → reports 28. The agent's "backend caching" is a real upstream lag, not the
+MCP's own cache.
+
+- **MCP's own cache is NOT the primary cause.** `SB_MCP_CACHE_DATA` defaults to **false**
+  (`cache_config.py`), so each call hits `testsummaries` fresh and *still* returns 28. The
+  `tests_cache` 1800s TTL (`data_functions.py:36`) is only an **aggravating** factor when caching
+  is explicitly enabled.
+- Fixing `:456` to "also refresh counts" is **not viable**: the orchestrator has no counts, and
+  the single-test endpoint shares the same lagging aggregate.
+
+### The live, accurate count source already exists
+- `sb_get_test_simulations()` (`data_functions.py:619`) fetches `executionsHistoryResults`
+  (paginated, `data_functions.py:739`) and counts client-side. With `status_filter='missed'`,
+  `total_simulations` is the **live** count — the same source/value the UI shows (80). This is the
+  candidate accurate source for running-test counts.
+
+### Other stale-prone paths during a running test (secondary)
+- `sb_get_test_simulations` → `simulations_cache` 600s TTL (only when caching enabled)
+- findings: `findings_cache` 600s; security events: `security_control_events_cache` 600s
+- All only bite when `SB_MCP_CACHE_DATA=true`.
+
+### Tests (where new coverage goes)
+- `safebreach_mcp_data/tests/test_data_functions.py` — `test_sb_get_test_details_*` (uses a
+  *completed* test today; no running-test-count case), cache tests at `:196`, `:219`
+- `safebreach_mcp_data/tests/test_data_types.py` — `_build_simulation_status_counts` /
+  `get_reduced_test_summary_mapping` tests (`:656+`)
+- `safebreach_mcp_core/tests/test_safebreach_cache.py`, `test_cache_config.py`
+
+### Empirical verification (against pentest01, 2026-06-22)
+Ran `verify_lag.py` (in this PRD folder) using the repo's own functions:
+- **Completed tests:** aggregate `finalStatus.missed` == live `executionsHistoryResults` missed
+  count, exactly (67 == 67 across 3 recent completed tests). → counting `executionsHistoryResults`
+  is the correct live source, AND the two sources **converge at terminal** (matches the ticket's
+  "wait for completion and it reconciles" workaround).
+- **No running test** existed at that instant, so live divergence was not personally captured;
+  the divergence (28 vs 80 during an active run) is documented by the reporter's screen recording
+  on the ticket.
+- Conclusion: root cause confirmed to the extent possible without a live running test —
+  consistent with field evidence + method validation + architecture.
+
+### LIVE REPRODUCTION CONFIRMED (running test 1782107855457.2, 2026-06-22)
+User manually triggered a live test; `poll_lag.py` (this PRD folder) sampled aggregate vs live
+every 5s across the full run (~200s, 125 sims):
+- During **RUNNING**, live (`executionsHistoryResults`) consistently led the aggregate
+  (`finalStatus`) at almost every sample. Examples:
+  - t=0:  agg_total=10 / live=13 ; agg_missed=6  / live=8
+  - t=75: agg_total=64 / live=68 ; agg_missed=43 / live=46
+  - t=85: agg_total=80 / live=82 ; agg_missed=55 / live=57
+- At **t=200 the test hit COMPLETED and both reconciled exactly** (125/125 total, 94/94 missed)
+  — reproduces the ticket's "wait for completion to reconcile" workaround.
+- Observed gap was small (±1..4) because this was a fast 125-sim test; the field report's
+  28-vs-80 reflects a larger/slower run where `finalStatus` lagged much further — **same
+  mechanism**.
+- **TDD reproduction basis:** for a non-terminal test, `get_test_details` counts (from
+  `finalStatus`) lag the `executionsHistoryResults`-derived counts; a regression test can assert
+  they match (fails today, passes after fix). Verification scripts kept in this PRD folder
+  (`verify_lag.py`, `poll_lag.py`).
+
+**Status:** Phase 8 Complete — investigation comment posted to SAF-32018 (comment 191903)
+
+## Problem Analysis
+
+_(to be populated in Phase 5)_

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/poll_lag.py
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/poll_lag.py
@@ -1,0 +1,70 @@
+"""
+SAF-32018 live-divergence capture.
+
+Polls a RUNNING test, comparing:
+  - aggregate total: sum of get_test_details.simulations_statistics (testsummaries.finalStatus)
+  - live total:      get_test_simulations total_simulations (executionsHistoryResults)
+Records a timeseries and flags any sample where the two diverge.
+"""
+import time
+import logging
+
+logging.disable(logging.INFO)
+logging.getLogger().setLevel(logging.ERROR)
+
+from safebreach_mcp_data.data_functions import sb_get_test_details, sb_get_test_simulations
+
+CONSOLE = "pentest01"
+TID = "1782107855457.2"
+SAMPLES = 60
+INTERVAL = 5  # seconds
+
+
+def agg_total_and_missed(d):
+    total = 0
+    missed = 0
+    for s in d.get("simulations_statistics", []):
+        if "count" in s and "status" in s:
+            total += s["count"] or 0
+            if s["status"] == "missed":
+                missed = s["count"] or 0
+    return total, missed
+
+
+max_div = 0
+saw = False
+print(f"{'t(s)':>5} {'status':>9} {'agg_tot':>8} {'live_tot':>8} {'agg_mis':>8} {'live_mis':>8}  note")
+start = None
+for i in range(SAMPLES):
+    try:
+        d = sb_get_test_details(TID, CONSOLE)
+        status = d.get("status")
+        a_tot, a_mis = agg_total_and_missed(d)
+        live = sb_get_test_simulations(TID, CONSOLE, page_number=0)
+        l_tot = live.get("total_simulations") or 0
+        lm = sb_get_test_simulations(TID, CONSOLE, page_number=0, status_filter="missed")
+        l_mis = lm.get("total_simulations") or 0
+        div = abs(l_tot - a_tot)
+        note = ""
+        if div > 0:
+            note = f"DIVERGENCE total {l_tot - a_tot:+d}"
+            saw = True
+            max_div = max(max_div, div)
+        if l_mis != a_mis:
+            note += f" | missed {l_mis - a_mis:+d}"
+            saw = True
+        print(f"{i*INTERVAL:>5} {str(status):>9} {a_tot:>8} {l_tot:>8} {a_mis:>8} {l_mis:>8}  {note}")
+        if status and status.upper() in ("COMPLETED", "CANCELED", "FAILED"):
+            print(f"\nTest reached terminal status {status}; stopping.")
+            break
+    except Exception as e:
+        print(f"{i*INTERVAL:>5}  ERROR: {type(e).__name__}: {e}")
+    time.sleep(INTERVAL)
+
+print("\n=== VERDICT ===")
+if saw:
+    print(f"CONFIRMED: aggregate (finalStatus) lagged live (executionsHistoryResults). "
+          f"Max total divergence observed = {max_div}.")
+else:
+    print("No divergence captured in this window (aggregate stayed in sync). "
+          "Try a longer/denser window or a larger test.")

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
@@ -24,10 +24,10 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Approved |
-| **Last Updated** | 2026-06-22 09:40 |
+| **PRD Status** | Complete |
+| **Last Updated** | 2026-06-22 11:10 |
 | **Owner** | Yossi Attas (with Claude Code) |
-| **Current Phase** | N/A (not yet in implementation) |
+| **Current Phase** | Complete (8 of 8 phases) |
 
 ## 2. Solution Description
 
@@ -147,25 +147,26 @@ No new APIs. The fix re-routes which **existing** data-API source feeds the coun
 ## 7. Definition of Done
 
 **Core Functionality:**
-- [ ] For a non-terminal test under the soft cap, `get_test_details` per-status counts match the
+- [x] For a non-terminal test under the soft cap, `get_test_details` per-status counts match the
       live `executionsHistoryResults`-derived counts (UI values), not `finalStatus`.
-- [ ] For a terminal test, counts and behavior are unchanged.
-- [ ] Over the soft cap, `get_test_details` keeps the aggregate count and emits the routing hint.
-- [ ] Studio `test_overview` mirrors the same behavior and uses the centralized helper (inline
-      duplicate removed).
-- [ ] `get_tests`, findings tools, security-event tools, and drift tools attach the routing hint
-      when their test(s) are non-terminal, and do not when terminal.
+- [x] For a terminal test, counts and behavior are unchanged.
+- [x] Over the soft cap, `get_test_details` keeps the aggregate count and emits the routing hint.
+- [x] Studio `test_overview` routes to live counts via hint (kept aggregate + self-contained;
+      cross-server de-dup intentionally dropped — see Phase 3 note).
+- [x] `get_tests`, findings tools, security-event tools, and drift tools attach the routing/caveat
+      hint when their test(s) are non-terminal, and do not when terminal.
 
 **Quality Gates:**
-- [ ] New + existing unit tests pass across all servers (`config`, `data`, `utilities`,
-      `playbook`, `studio`).
-- [ ] A regression test reproduces the original bug (fails on pre-fix code, passes after).
-- [ ] No regression in terminal-test responses (golden assertions).
-- [ ] CLAUDE.md updated for the soft-cap env var and the running-test count behavior.
+- [x] New + existing unit tests pass across all servers (1344 passed; 5 pre-existing
+      `test_disable_filtering` failures exist on `origin/main`, unrelated to this change).
+- [x] A regression test reproduces the original bug (28-vs-80; fails on pre-fix code, passes after).
+- [x] No regression in terminal-test responses.
+- [x] CLAUDE.md updated for the soft-cap env var and the running-test count behavior.
 
 **Deployment Readiness:**
-- [ ] Soft-cap threshold env var documented; sensible default.
-- [ ] Behavior verified against pentest01 on a live running test (repro scripts in PRD folder).
+- [x] Soft-cap threshold env var documented; sensible default (5000).
+- [x] Behavior verified against pentest01 on a live running test (repro scripts in PRD folder;
+      live divergence + reconcile-at-terminal captured during ticket prep).
 
 ## 8. Testing Strategy
 
@@ -196,14 +197,14 @@ only by the routing hint.
 
 | Phase | Status | Completed | Commit SHA | Notes |
 |-------|--------|-----------|------------|-------|
-| Phase 1: Live count helper + soft-cap constant | ⏳ Pending | - | - | |
-| Phase 2: Non-terminal live recount in get_test_details | ⏳ Pending | - | - | TDD repro |
-| Phase 3: Studio test_overview parity + de-dup | ⏳ Pending | - | - | |
-| Phase 4: Routing hint — get_tests | ⏳ Pending | - | - | |
-| Phase 5: Routing hint — findings paths | ⏳ Pending | - | - | |
-| Phase 6: Routing hint — security-control events | ⏳ Pending | - | - | |
-| Phase 7: Routing hint — drift tools | ⏳ Pending | - | - | |
-| Phase 8: Make soft cap configurable + docs | ⏳ Pending | - | - | |
+| Phase 1: Live count helper + soft-cap constant | ✅ Complete | 2026-06-22 | 56ecac7 | 5 unit tests |
+| Phase 2: Non-terminal live recount in get_test_details | ✅ Complete | 2026-06-22 | e2430fc | 5 tests incl. 28-vs-80 repro |
+| Phase 3: Studio test_overview parity + de-dup | ✅ Complete | 2026-06-22 | c1ee914 | Hint-routes to live (kept aggregate; no cross-server coupling — see note) |
+| Phase 4: Routing hint — get_tests | ✅ Complete | 2026-06-22 | d120f90 | 2 tests |
+| Phase 5: Routing hint — findings paths | ✅ Complete | 2026-06-22 | e93032d | 3 tests; + shared _is_test_non_terminal |
+| Phase 6: Routing hint — security-control events | ✅ Complete | 2026-06-22 | b478cda | 2 tests (listing surface) |
+| Phase 7: Routing hint — drift tools | ✅ Complete | 2026-06-22 | 1607979 | 2 tests (both grouping helpers) |
+| Phase 8: Make soft cap configurable + docs | ✅ Complete | 2026-06-22 | bd7460f | 3 tests; CLAUDE.md updated |
 
 ### Phase 1 — Live count helper + soft-cap constant
 - **Semantic change**: Add a shared helper that derives `simulations_statistics` from a list of
@@ -361,3 +362,4 @@ configurable threshold for safe rollout.
 |------|-------------------|
 | 2026-06-22 09:30 | PRD created — initial draft |
 | 2026-06-22 09:40 | PRD approved by owner; ready for implementation |
+| 2026-06-22 11:10 | All 8 phases implemented via TDD (commits 56ecac7..bd7460f); PRD marked Complete |

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
@@ -363,3 +363,5 @@ configurable threshold for safe rollout.
 | 2026-06-22 09:30 | PRD created — initial draft |
 | 2026-06-22 09:40 | PRD approved by owner; ready for implementation |
 | 2026-06-22 11:10 | All 8 phases implemented via TDD (commits 56ecac7..bd7460f); PRD marked Complete |
+| 2026-06-22 11:30 | Green-tree fixes: stale SafeBreachAuth patch in test_disable_filtering (d31bc42); self-discovering test_get_test_drifts_e2e (5389908) |
+| 2026-06-22 11:45 | Gap fix from manual testing: get_test_simulations now emits a partial/point-in-time hint for running tests (3e4195d) |

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
@@ -24,337 +24,187 @@
 
 | Field | Value |
 |-------|-------|
-| **PRD Status** | Complete |
-| **Last Updated** | 2026-06-22 11:10 |
+| **PRD Status** | Complete (RCA corrected — see §2 banner) |
+| **Last Updated** | 2026-06-22 12:30 |
 | **Owner** | Yossi Attas (with Claude Code) |
 | **Current Phase** | Complete (8 of 8 phases) |
 
 ## 2. Solution Description
 
-### Chosen Solution — Hybrid
-A pure "real fix in all paths" was found to be **impossible**: findings, security-control events,
-and the drift tools have **no live alternative** (their lag is upstream — post-processing, external
-SIEM indexes, and a backend drift service), and a live recount for the `get_tests` list would
-require paging `executionsHistoryResults` for every running test (≤1000+ fetches per call).
+> **⚠️ RCA & approach REVISED 2026-06-22 (post PR-review).** An earlier version of this PRD
+> concluded that `testsummaries.finalStatus` *upstream-lags* the live per-simulation data and that
+> `get_test_details` therefore had to recount by paging `executionsHistoryResults` (soft-capped at
+> 5000). **That conclusion was wrong** — the "lag" I measured was an artifact of the multi-second
+> paging window of the live() call itself. Controlled, back-to-back measurement on a *growing* test
+> showed `executionsHistorySuggestions` (the UI's own breakdown source), `detailedTestSummaries`,
+> and `testsummaries.finalStatus` all agree to within **0–1 simulation**. The sections below reflect
+> the corrected, cheaper fix.
 
-Therefore:
-- **Part A — Real live-count fix (gated to non-terminal tests, soft-capped):** in the two
-  single-test count paths where the live source is one cheap paged fetch — `sb_get_test_details`
-  and the Studio `test_overview` block — compute `simulations_statistics` from the live
-  `executionsHistoryResults` source instead of `finalStatus`. Reuse the existing SAF-31111
-  terminal/non-terminal detection. Apply a **soft size cap**: if the test's known total exceeds a
-  configurable threshold, keep the aggregate and emit the routing hint instead.
-- **Part B — Universal routing hint (non-terminal tests):** every other count/finding-bearing path
-  attaches a hint when its test(s) are non-terminal, telling the agent the counts may lag and to
-  call `get_test_simulations` with the relevant `status_filter` for the exact live count
-  (`total_simulations` is the authoritative live value).
+### Root Cause (corrected)
+The MCP introduced the staleness itself, in two layers on the running-test path of `get_test_details`:
+1. counts were read from the **cached test list** (`tests_cache`, up-to-30-min TTL), and
+2. the SAF-31111 running-test refresh updated only **status**, never the **counts**.
+So the agent could serve a counts snapshot up to 30 minutes old (28) while the UI showed live (80).
+A **fresh** `finalStatus` (single-test `testsummaries/{id}` call) tracks the UI's live aggregation
+(`executionsHistoryResults.total` / `executionsHistorySuggestions`) to within ~1 sim — so the
+upstream aggregate is *not* the problem.
+
+### Chosen Solution
+- **`get_test_details` (non-terminal):** refresh `simulations_statistics` from the **fresh
+  single-test `testsummaries/{id}` call** (defeats the stale cache + the never-refreshed counts) and
+  add a **point-in-time hint** that routes to `get_test_simulations` for the live filtered grid.
+  One cheap call; **no `executionsHistoryResults` paging, no soft cap.**
+- **Cheap hints elsewhere (non-terminal):** `get_tests`, findings, security-control events, and the
+  drift tools carry a running-test caveat; `get_test_simulations` notes its `total_simulations` is
+  partial/point-in-time while running. (These were correct in the original implementation and are
+  kept.)
 
 ### Alternatives Considered
-- **Real fix in every path.** Pros: every headline number correct. Cons: **infeasible** — no live
-  source for findings/SIEM/drift; prohibitive for `get_tests`. Rejected.
-- **Hint only, all paths.** Pros: uniform, lowest risk, trivial. Cons: detail tools keep returning
-  the stale aggregate as the headline number; relies entirely on the agent following the hint.
-  Rejected as insufficient for the primary user-facing path.
-- **MCP cache-TTL tuning (shorten `tests_cache`).** Pros: trivial. Cons: **does not fix the bug** —
-  caching defaults to OFF and the lag is upstream of the MCP cache. Rejected.
+- **Page `executionsHistoryResults` and recount (the earlier approach).** Rejected: expensive
+  (pages every simulation), needed a 5000 soft cap that can make large running tests wrong, and
+  solves a lag that does not actually exist (fresh `finalStatus` already matches the UI within ~1).
+- **`detailedTestSummaries`.** Rejected as the count source: it carries the **same** `finalStatus`
+  aggregate as `testsummaries` (verified equal), so it's no fresher — and the UI never calls it.
+- **`executionsHistorySuggestions`.** Viable (it's the UI's exact breakdown source, one cheap call),
+  but `finalStatus` from the single-test endpoint is equally fresh, even simpler, and already part
+  of the response — so we use that.
 
 ### Decision Rationale
-The hybrid is the only approach that gives correct *values* where it is cheap and feasible, correct
-*expectations* everywhere, and never fabricates numbers the backend has not computed.
+The bug was in-MCP staleness, so the fix is to stop serving stale counts on the running-test path
+with a single fresh call — not to re-derive counts the backend already computes accurately.
 
 ## 3. Core Feature Components
 
-### Component A — Live status-count derivation (shared helper)
-- **Purpose**: New shared helper that builds the `simulations_statistics` array (the 7 statuses:
-  missed/stopped/prevented/detected/logged/no-result/inconsistent) from a list of **live**
-  simulation entities (as returned by `_get_all_simulations_from_cache_or_api`), in the exact same
-  shape as the existing `_build_simulation_status_counts(finalStatus)`.
-- **Key Features**: Counts by each simulation's `final_status`/status field; returns identical
-  structure so it is a drop-in for non-terminal paths. New code in `data_types.py`.
+### Component A — Fresh-count refresh in `get_test_details` (non-terminal)
+- **Purpose**: For a non-terminal test, refresh `simulations_statistics` (and status/end_time) from
+  the **fresh single-test `testsummaries/{id}` call** instead of the stale cached list value.
+- **Key Features**: Reuses `terminal_statuses` detection and the existing `_fetch_single_test`;
+  keeps the orchestrator-queue call for real-time status (SAF-31111). One cheap call, no paging.
+  Adds a point-in-time `hint_to_agent` routing to `get_test_simulations`.
 
-### Component B — Non-terminal live recount in `get_test_details` (soft-capped)
-- **Purpose**: For non-terminal tests, replace the aggregate counts with the live-derived counts;
-  fall back to aggregate + routing hint beyond the soft cap.
-- **Key Features**: Reuses `terminal_statuses` detection (`data_functions.py:447`) and the existing
-  `_get_all_simulations_from_cache_or_api`. Adjusts the existing non-terminal hint to reflect that
-  counts are now live-but-point-in-time (or the routing hint in the capped fallback case).
-
-### Component C — Studio `test_overview` parity + de-duplication
-- **Purpose**: Apply the same non-terminal live recount in `get_studio_attack_latest_result`'s
-  test-overview block, and **remove the inline duplicate** of the count logic
-  (`studio_functions.py:1538`) by calling the centralized helper.
+### Component B — Studio `test_overview` routing hint
+- **Purpose**: `get_studio_attack_latest_result`'s test-overview keeps the (correctly test-scoped)
+  `finalStatus` aggregate and adds a non-terminal hint routing to `get_test_details` (live for
+  running tests) / `get_test_simulations`. Kept self-contained (no cross-server coupling).
 
 ### Component D — Universal routing hint
 - **Purpose**: Attach a non-terminal routing hint to the hint-only paths: `get_tests`,
   `get_test_findings_counts`/`_details`, `get_security_controls_events`/`_details`, and the drift
   tools (`get_simulation_result_drifts`, `get_simulation_status_drifts`,
   `get_security_control_drifts`).
-- **Key Features**: Cheap test-status check (cached test list / orchestrator queue) to decide
-  whether to attach the hint; consistent hint text directing to `get_test_simulations`.
-
-### Component E — Configurable soft-cap threshold
-- **Purpose**: Expose the live-recount size threshold as a constant + environment variable, and
-  document it in CLAUDE.md.
+- **Key Features**: Cheap test-status check (`_is_test_non_terminal`, orchestrator queue) to decide
+  whether to attach the hint; consistent hint text. Findings/SIEM/drift have no live source, so the
+  hint is a "may be incomplete, re-query after completion" caveat rather than a live-count route.
 
 ## 4. API Endpoints and Integration
 
-No new APIs. The fix re-routes which **existing** data-API source feeds the counts.
+No new APIs. The fix changes *which freshness* of an existing endpoint feeds the running-test counts.
 
 **Consumed (existing):**
-- **Test summaries (aggregate, lagging mid-run)** — `GET /api/data/v1/accounts/{account_id}/testsummaries?size=1000` and `/testsummaries/{test_id}`. Field: `finalStatus` → current count source.
-- **Executions history results (live per-simulation)** — `GET /api/data/v1/accounts/{account_id}/executionsHistoryResults` (paged, page_size=100). The live source already used by `sb_get_test_simulations`. New count source for non-terminal detail paths.
-- **Orchestrator queue (real-time status)** — `GET /api/orch/v4/accounts/{account_id}/queue` (`queue_state.py`). Used for the cheap non-terminal status check.
+- **Single-test summary (fresh, used for running-test counts)** — `GET /api/data/v1/accounts/{account_id}/testsummaries/{test_id}`. Field: `finalStatus`. Verified to track the UI's live aggregation to within ~1 simulation.
+- **Test-list summary (cached, the stale source of the bug)** — `GET .../testsummaries?size=1000` via `tests_cache` (≤30-min TTL).
+- **Orchestrator queue (real-time status)** — `GET /api/orch/v4/accounts/{account_id}/queue` (`queue_state.py`).
+- **UI reference (for verification only)** — `executionsHistoryResults.total` (grid count) and `executionsHistorySuggestions` (per-status breakdown). The MCP does NOT need these for `get_test_details`.
 - Headers unchanged (`x-apitoken` via `get_auth_headers_for_console`).
 
 ## 5. Example Agent Flow
 
-**Primary scenario — "How many missed simulations so far?" on a running test:**
-1. User asks the HELM agent for the missed count during an active test.
-2. Agent calls `get_test_details(test_id)`.
-3. Test is non-terminal and under the soft cap → tool recounts from `executionsHistoryResults` and
-   returns `missed = 80` (matching the UI), plus a hint that the count is point-in-time and the
-   test is still running (poll again).
-4. Agent reports 80. ✅ (previously 28).
+**Primary — "How many missed simulations so far?" on a running test:**
+1. Agent calls `get_test_details(test_id)`.
+2. Test is non-terminal → tool refreshes counts from the fresh `testsummaries/{id}` call (≈UI value)
+   and returns `missed = 80` with a point-in-time hint.
+3. Agent reports 80 ✅ (previously a stale cached 28).
 
-**Alternative — very large running test (over soft cap):**
-- `get_test_details` returns the aggregate count plus a routing hint: "test too large for a live
-  recount; call `get_test_simulations` with `status_filter='missed'` for the exact live count." The
-  agent follows the hint and reports the live `total_simulations`.
-
-**Alternative — findings/security/drift on a running test:**
-- Tool returns its (upstream) value plus the routing hint that the number may lag while running.
+**Findings/security/drift on a running test:** tool returns its value plus a caveat that it may be
+incomplete while running (no live source to switch to).
 
 ## 6. Non-Functional Requirements
 
-**Performance:**
-- The live recount for a non-terminal detail call costs the same as one `get_test_simulations`
-  call (~1 fetch/100 sims), and reuses `simulations_cache` when caching is enabled.
-- **Soft cap** bounds worst-case latency: tests whose known total exceeds the threshold skip the
-  recount and route via hint. Threshold default ~5000 simulations, configurable.
-- Terminal tests pay **zero** extra cost (unchanged aggregate path).
+**Performance:** one extra cheap single-test API call for a non-terminal `get_test_details` (no
+per-simulation paging, no cap). Terminal tests are unchanged. Hint-only paths add at most one cheap
+orchestrator status check.
 
-**Technical Constraints / Backward Compatibility:**
-- Response shape of `simulations_statistics` is **unchanged** (same 7-status array); only the
-  source of the numbers changes for non-terminal tests. Terminal-test behavior is byte-for-byte
-  unchanged.
-- New hint fields are additive (`hint_to_agent`), consistent with existing conventions.
-- Caching remains opt-in (`SB_MCP_CACHE_DATA`); fix is correct with caching on or off.
-
-**Monitoring/Observability:**
-- Log when a non-terminal recount is performed vs. when the soft-cap fallback triggers (info-level),
-  to aid future tuning of the threshold.
+**Backward Compatibility:** `simulations_statistics` shape unchanged (same 7-status array); only its
+freshness changes for non-terminal tests. New `hint_to_agent` text is additive. Correct with caching
+on or off.
 
 ## 7. Definition of Done
 
 **Core Functionality:**
-- [x] For a non-terminal test under the soft cap, `get_test_details` per-status counts match the
-      live `executionsHistoryResults`-derived counts (UI values), not `finalStatus`.
-- [x] For a terminal test, counts and behavior are unchanged.
-- [x] Over the soft cap, `get_test_details` keeps the aggregate count and emits the routing hint.
-- [x] Studio `test_overview` routes to live counts via hint (kept aggregate + self-contained;
-      cross-server de-dup intentionally dropped — see Phase 3 note).
-- [x] `get_tests`, findings tools, security-event tools, and drift tools attach the routing/caveat
-      hint when their test(s) are non-terminal, and do not when terminal.
+- [x] For a non-terminal test, `get_test_details` counts are refreshed from the fresh
+      `testsummaries/{id}` call (not the stale cached list), matching the UI within ~1 sim.
+- [x] No `executionsHistoryResults` paging / soft cap in `get_test_details`.
+- [x] For a terminal test, counts and behavior are unchanged (no refresh, no paging).
+- [x] On refresh failure, degrade to cached counts + hint (never raise).
+- [x] `get_tests`, findings, security-events, drift tools, and `get_test_simulations` carry the
+      correct running-test hint/caveat when non-terminal, and not when terminal.
 
 **Quality Gates:**
-- [x] New + existing unit tests pass across all servers (1344 passed; 5 pre-existing
-      `test_disable_filtering` failures exist on `origin/main`, unrelated to this change).
-- [x] A regression test reproduces the original bug (28-vs-80; fails on pre-fix code, passes after).
-- [x] No regression in terminal-test responses.
-- [x] CLAUDE.md updated for the soft-cap env var and the running-test count behavior.
-
-**Deployment Readiness:**
-- [x] Soft-cap threshold env var documented; sensible default (5000).
-- [x] Behavior verified against pentest01 on a live running test (repro scripts in PRD folder;
-      live divergence + reconcile-at-terminal captured during ticket prep).
+- [x] Unit tests pass across all servers (no `executionsHistoryResults`-recount machinery remains —
+      verified by dead-symbol grep).
+- [x] Regression test: a stale-cached running test (missed=28) is corrected to the fresh value
+      (missed=80) by `get_test_details`.
+- [x] E2E green on pentest01 (107 passed / 5 skipped / 0 failed before this revision; re-verified).
+- [x] CLAUDE.md updated to describe the fresh-single-test fix (env var removed).
 
 ## 8. Testing Strategy
 
-**Unit Testing (pytest):**
-- **Component A helper**: counts per status from a synthetic live-simulation list; equals the
-  `finalStatus`-based helper for an equivalent reconciled set.
-- **`get_test_details`**:
-  - Non-terminal + under cap → live counts (mock `_get_all_simulations_from_cache_or_api` to differ
-    from `finalStatus`; assert live wins). *This is the TDD reproduction.*
-  - Terminal → aggregate path unchanged.
-  - Non-terminal + over cap → aggregate retained + routing hint present.
-- **Studio `test_overview`**: live counts for non-terminal; uses centralized helper (assert no
-  inline duplication path); over-cap fallback.
-- **Hint-only paths**: routing hint present for non-terminal test(s), absent for terminal — for
-  `get_tests`, findings counts/details, security events, and each drift tool.
-- Follow memory gotchas: `json.dumps` spacing in assertions; update all renamed-param call sites.
+**Unit (pytest):**
+- `get_test_details`: non-terminal refreshes counts from `_fetch_single_test` (stale 28 → fresh 80)
+  and does NOT page `executionsHistoryResults`; terminal does neither; refresh failure falls back to
+  cached counts; point-in-time hint present for non-terminal.
+- Hint-only paths: hint/caveat present for non-terminal, absent for terminal — `get_tests`, findings
+  counts/details, security events, each drift grouping helper, and `get_test_simulations`.
 
-**Integration / E2E:**
-- E2E (`@pytest.mark.e2e`, `E2E_CONSOLE=pentest01`): on a live running test, assert
-  `get_test_details` missed count tracks `get_test_simulations(status_filter='missed')`
-  `total_simulations` within tolerance, and both reconcile at COMPLETED. Repro scripts
-  (`verify_lag.py`, `poll_lag.py`) document the manual procedure.
+**E2E (`E2E_CONSOLE=pentest01`):** existing data/studio E2E. The self-discovering
+`test_get_test_drifts_e2e` replaced the brittle hardcoded-ID version.
 
-**Coverage Gaps**: A truly live findings/SIEM/drift count is out of scope (no live source) — covered
-only by the routing hint.
+## 9. Implementation (as built)
 
-## 9. Implementation Phases
+> The work was first implemented along an `executionsHistoryResults`-recount design (commits
+> 56ecac7, e2430fc, bd7460f) that a post-PR-review RCA showed to be unnecessary (see the banner in
+> §2). Those changes were **reverted/replaced** by the fresh-single-test approach. The table below
+> is the **final landed state**; superseded commits are noted for history only.
 
-| Phase | Status | Completed | Commit SHA | Notes |
-|-------|--------|-----------|------------|-------|
-| Phase 1: Live count helper + soft-cap constant | ✅ Complete | 2026-06-22 | 56ecac7 | 5 unit tests |
-| Phase 2: Non-terminal live recount in get_test_details | ✅ Complete | 2026-06-22 | e2430fc | 5 tests incl. 28-vs-80 repro |
-| Phase 3: Studio test_overview parity + de-dup | ✅ Complete | 2026-06-22 | c1ee914 | Hint-routes to live (kept aggregate; no cross-server coupling — see note) |
-| Phase 4: Routing hint — get_tests | ✅ Complete | 2026-06-22 | d120f90 | 2 tests |
-| Phase 5: Routing hint — findings paths | ✅ Complete | 2026-06-22 | e93032d | 3 tests; + shared _is_test_non_terminal |
-| Phase 6: Routing hint — security-control events | ✅ Complete | 2026-06-22 | b478cda | 2 tests (listing surface) |
-| Phase 7: Routing hint — drift tools | ✅ Complete | 2026-06-22 | 1607979 | 2 tests (both grouping helpers) |
-| Phase 8: Make soft cap configurable + docs | ✅ Complete | 2026-06-22 | bd7460f | 3 tests; CLAUDE.md updated |
-
-### Phase 1 — Live count helper + soft-cap constant
-- **Semantic change**: Add a shared helper that derives `simulations_statistics` from a list of
-  live simulation entities, plus a module constant for the soft-cap threshold.
-- **Implementation details**: New function in `data_types.py` (e.g. `build_simulation_status_counts_from_live`)
-  that takes the mapped simulation list and tallies each of the 7 statuses, returning the identical
-  array structure as `_build_simulation_status_counts`. Define `LIVE_RECOUNT_MAX_SIMULATIONS`
-  (default ~5000) in `data_functions.py`. Inputs: list of simulation dicts. Output: list of
-  `{status, count}` dicts. Edge cases: unknown/extra statuses ignored or bucketed consistently with
-  the existing helper; empty list → all zeros.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_types.py` | New live-count helper |
-  | `safebreach_mcp_data/data_functions.py` | Add soft-cap constant |
-  | `safebreach_mcp_data/tests/test_data_types.py` | Unit tests for helper |
-- **Git commit**: `feat(SAF-32018): add live simulation status-count helper + soft-cap constant`
-
-### Phase 2 — Non-terminal live recount in `get_test_details`
-- **Semantic change**: For non-terminal tests under the soft cap, source `simulations_statistics`
-  from live simulations; otherwise keep aggregate + routing hint.
-- **Implementation details**: In `sb_get_test_details` (`data_functions.py:416`), after the existing
-  non-terminal detection: if the test's known total (from current `simulations_statistics`/
-  `finalStatus`) ≤ `LIVE_RECOUNT_MAX_SIMULATIONS`, call `_get_all_simulations_from_cache_or_api`,
-  run the Phase-1 helper, and replace `simulations_statistics`. Else, leave aggregate and set the
-  routing hint. Update the non-terminal `hint_to_agent`: when live, "counts are live as of now;
-  test still running, poll again"; when capped, the routing hint. Terminal path untouched.
-  Error handling: if the live fetch fails, fall back to aggregate + routing hint (log a warning) —
-  never raise.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Live recount + hint logic in `sb_get_test_details` |
-  | `safebreach_mcp_data/tests/test_data_functions.py` | TDD repro + terminal-unchanged + over-cap tests |
-- **Git commit**: `fix(SAF-32018): live simulation counts for non-terminal get_test_details`
-
-### Phase 3 — Studio `test_overview` parity + de-duplication
-- **Semantic change**: Reuse the centralized helper in `get_studio_attack_latest_result` and apply
-  the same non-terminal live recount + soft-cap fallback.
-- **Implementation details**: Replace the inline status-count construction at
-  `studio_functions.py:1538` with the Phase-1 helper. For non-terminal resolved test under cap,
-  recount from live simulations; else aggregate + routing hint. Reuse the existing terminal check at
-  `studio_functions.py:1555`.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_studio/studio_functions.py` | Use central helper + live recount in test_overview |
-  | `safebreach_mcp_studio/tests/...` | Tests for live/terminal/over-cap + no inline dup |
-- **Git commit**: `fix(SAF-32018): live counts + de-dup status logic in studio test_overview`
-
-### Phase 4 — Routing hint: `get_tests`
-- **Semantic change**: Attach a routing hint to the `get_tests` response when any test in the
-  returned page is non-terminal.
-- **Implementation details**: In `sb_get_tests`, after building the page, if any test's status is
-  non-terminal, add a top-level `hint_to_agent` noting per-test counts may lag for running tests and
-  to use `get_test_details`/`get_test_simulations` for live values. No per-test paging.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Conditional hint in `sb_get_tests` |
-  | `safebreach_mcp_data/tests/test_data_functions.py` | Hint present/absent tests |
-- **Git commit**: `fix(SAF-32018): routing hint for running tests in get_tests`
-
-### Phase 5 — Routing hint: findings paths
-- **Semantic change**: Attach the routing hint to `get_test_findings_counts` and
-  `get_test_findings_details` when the test is non-terminal.
-- **Implementation details**: Cheap status check (cached test list / orchestrator) for the test_id;
-  if non-terminal, add a hint that findings are still accumulating and may lag. No recount.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Conditional hint in findings tools |
-  | `safebreach_mcp_data/tests/...` | Tests |
-- **Git commit**: `fix(SAF-32018): routing hint for running tests in findings tools`
-
-### Phase 6 — Routing hint: security-control events
-- **Semantic change**: Attach the routing hint to `get_security_controls_events` /
-  `get_security_control_event_details` when the test is non-terminal.
-- **Implementation details**: Same cheap status check + hint noting SIEM-sourced events may lag for
-  running tests.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Conditional hint |
-  | `safebreach_mcp_data/tests/...` | Tests |
-- **Git commit**: `fix(SAF-32018): routing hint for running tests in security-control events`
-
-### Phase 7 — Routing hint: drift tools
-- **Semantic change**: Attach a caveat hint to `get_simulation_result_drifts`,
-  `get_simulation_status_drifts`, `get_security_control_drifts` indicating running tests in the
-  window may have incomplete drift data.
-- **Implementation details**: Add to existing hint construction in each drift tool a note about
-  in-flight tests; no recount.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Hints in drift tools |
-  | `safebreach_mcp_data/tests/...` | Tests |
-- **Git commit**: `fix(SAF-32018): running-test caveat in drift tools`
-
-### Phase 8 — Configurable soft cap + docs
-- **Semantic change**: Make the soft-cap threshold configurable via env var and document behavior.
-- **Implementation details**: Read `LIVE_RECOUNT_MAX_SIMULATIONS` from env (default ~5000). Update
-  CLAUDE.md: document the running-test live-count behavior, the env var, and the routing hint.
-- **Changes**:
-  | File | Change |
-  |------|--------|
-  | `safebreach_mcp_data/data_functions.py` | Env-var read for threshold |
-  | `CLAUDE.md` | Document behavior + env var |
-- **Git commit**: `docs(SAF-32018): document running-test live counts + soft-cap env var`
+| Area | Status | Final commit | Notes |
+|------|--------|-------------|-------|
+| `get_test_details` fresh-single-test refresh + point-in-time hint | ✅ | _(this revision)_ | Replaced the recount of 56ecac7/e2430fc; removed helper, soft cap, env var |
+| `get_tests` running-test hint | ✅ | d120f90 | kept |
+| findings hint + `_is_test_non_terminal` | ✅ | e93032d | kept |
+| security-control events caveat | ✅ | b478cda | kept |
+| drift tools caveat | ✅ | 1607979 | kept |
+| `get_test_simulations` partial-while-running hint | ✅ | 3e4195d | kept |
+| Studio `test_overview` routing hint | ✅ | c1ee914 | kept (aggregate + hint; self-contained) |
+| green-tree test fixes (deny-list, self-discovering drift E2E) | ✅ | d31bc42, 5389908 | kept |
 
 ## 10. Risks and Assumptions
 
 **Technical Risks:**
-- **Perf on large running tests** (Medium): mitigated by the soft cap + cache reuse + non-terminal
-  gating.
-- **Regression in terminal-test counts** (Medium): mitigated by gating strictly on non-terminal and
-  golden assertions on terminal responses.
-- **Status-check cost in hint-only paths** (Low): use the cheapest available signal (cached test
-  list / orchestrator), avoid extra paging.
-- **Agent ignores routing hint on capped/hint-only paths** (Low/accepted): inherent to hint-based
-  paths where no live source exists.
+- **Regression in terminal-test counts** (Low): gated strictly on non-terminal; terminal path untouched.
+- **Hint-only paths' status-check cost** (Low): single cheap orchestrator check.
 
-**Assumptions Under Question:**
-- `executionsHistoryResults` is the authoritative live source — **validated** (matches UI; reconciles
-  to `finalStatus` at terminal: 67==67, 125/94).
-- Default soft-cap (~5000) is a reasonable balance — to confirm/tune via the observability logs.
-
-**Mitigation:** Phased, independently-committable changes; each phase verified before the next;
-configurable threshold for safe rollout.
+**Assumptions:**
+- A fresh `testsummaries/{id}` `finalStatus` tracks the UI's live aggregation within ~1 sim —
+  **verified** by controlled back-to-back measurement (`executionsHistorySuggestions` ≈
+  `detailedTestSummaries` ≈ `testsummaries` within 0–1 on a growing test).
+- The original 28-vs-80 gap was in-MCP staleness (30-min cache + counts never refreshed on the
+  running-test path), not upstream lag — strongly supported by that measurement.
 
 ## 11. Future Enhancements
-- A genuine live findings/drift count if/when the backend exposes a live source.
-- Optional server-side count endpoint to avoid client-side paging for large running tests.
-- Consider live counts for `get_tests` if a bulk live-count API becomes available.
+- If a future need for an exact live per-status breakdown arises, `executionsHistorySuggestions`
+  (the UI's own one-call aggregation) is the natural source — no paging required.
 
 ## 12. Executive Summary
-- **Issue**: The HELM agent reports stale simulation status counts for running tests (28 vs UI's
-  80) because counts come from the lagging `testsummaries.finalStatus` aggregate.
-- **What Was Built**: Live per-simulation recount for non-terminal tests in the two single-test
-  detail paths (`get_test_details`, Studio `test_overview`) with a soft size cap, plus a universal
-  routing hint on all other count/finding-bearing paths directing the agent to the authoritative
-  live count tool. Studio's inline count duplicate folded into the central helper.
-- **Key Technical Decisions**: Hybrid (real fix where cheap/feasible + hint everywhere), because a
-  real fix is impossible for findings/SIEM/drift and prohibitive for `get_tests`; gate on
-  non-terminal status; soft-cap to bound latency; never fabricate upstream-unavailable numbers.
-- **Scope Changes**: Real live recount limited to two single-test paths; all other paths are
-  hint-only by design.
-- **Business Value**: Eliminates "agent contradicts the UI" during live tests for the primary
-  tools, and makes the limitation explicit + actionable everywhere else.
+- **Issue**: For a running test, `get_test_details` reported a stale "Missed" count (28 vs the UI's
+  80) and reconciled only after the test finished.
+- **Root cause**: in-MCP staleness — counts came from the ≤30-min cached test list and the
+  running-test refresh updated only status, never the counts. A fresh `finalStatus` matches the UI.
+- **What was built**: for a non-terminal test, `get_test_details` refreshes counts from one fresh
+  `testsummaries/{id}` call + a point-in-time hint; cheap running-test hints/caveats on the other
+  count/finding paths. No per-simulation paging, no soft cap.
+- **Course correction**: an initial `executionsHistoryResults`-recount design was reverted after a
+  controlled measurement disproved the "upstream lag" premise — keeping the fix cheap and correct.
+- **Business value**: the agent's running-test counts now match the UI within ~1 sim at negligible cost.
 
 ## 14. Change Log
 
@@ -365,3 +215,4 @@ configurable threshold for safe rollout.
 | 2026-06-22 11:10 | All 8 phases implemented via TDD (commits 56ecac7..bd7460f); PRD marked Complete |
 | 2026-06-22 11:30 | Green-tree fixes: stale SafeBreachAuth patch in test_disable_filtering (d31bc42); self-discovering test_get_test_drifts_e2e (5389908) |
 | 2026-06-22 11:45 | Gap fix from manual testing: get_test_simulations now emits a partial/point-in-time hint for running tests (3e4195d) |
+| 2026-06-22 12:30 | **RCA corrected after PR review + ui-react investigation.** Controlled measurement disproved the "finalStatus upstream-lags" premise (it was a paging-window artifact; fresh finalStatus ≈ UI within ~1 sim). Reverted the executionsHistoryResults recount / soft cap / env var / helper; replaced with a fresh single-test `testsummaries/{id}` refresh for non-terminal get_test_details. Kept all hint-only changes. PRD §2–§12 rewritten to match. |

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/prd.md
@@ -1,0 +1,363 @@
+# Stale Running-Test Simulation Counts — SAF-32018
+
+## 1. Overview
+
+- **Title**: HELM — stale simulation status counts for running tests (SAF-32018)
+- **Task Type**: Bug fix + small refactor
+- **Purpose**: When asked for a simulation status count (e.g. "Missed") on a test that is still
+  running, the HELM agent reports a stale number sourced from the lazily-updated
+  `testsummaries.finalStatus` aggregate, which lags the live per-simulation results shown in the
+  UI. The agent reported 28 while the UI showed 80. This fix makes running-test counts accurate
+  where cheap, and everywhere else routes the agent to the authoritative live count.
+- **Target Consumer**: SafeBreach customers and SEs using the HELM AI agent against live/running
+  tests; internally, anyone querying test progress mid-run via MCP.
+- **Target Roles (RBAC)**: No change — inherits existing data-API RBAC of the consuming tools.
+- **Key Benefits**:
+  1. Accurate point-in-time counts for running tests in the primary detail tools.
+  2. Honest, actionable expectations everywhere else (counts may lag → use the live tool).
+  3. No fabricated numbers for data the backend has not yet computed (findings/SIEM/drift).
+- **Business Alignment**: Trust in the HELM agent's reported numbers; eliminates a class of
+  "agent contradicts the UI" incidents during active testing.
+- **Originating Request**: JIRA SAF-32018 (reporter Hadas Cohen, env pentest01, Mgmt 2026Q2.4).
+
+## 1.5 Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Approved |
+| **Last Updated** | 2026-06-22 09:40 |
+| **Owner** | Yossi Attas (with Claude Code) |
+| **Current Phase** | N/A (not yet in implementation) |
+
+## 2. Solution Description
+
+### Chosen Solution — Hybrid
+A pure "real fix in all paths" was found to be **impossible**: findings, security-control events,
+and the drift tools have **no live alternative** (their lag is upstream — post-processing, external
+SIEM indexes, and a backend drift service), and a live recount for the `get_tests` list would
+require paging `executionsHistoryResults` for every running test (≤1000+ fetches per call).
+
+Therefore:
+- **Part A — Real live-count fix (gated to non-terminal tests, soft-capped):** in the two
+  single-test count paths where the live source is one cheap paged fetch — `sb_get_test_details`
+  and the Studio `test_overview` block — compute `simulations_statistics` from the live
+  `executionsHistoryResults` source instead of `finalStatus`. Reuse the existing SAF-31111
+  terminal/non-terminal detection. Apply a **soft size cap**: if the test's known total exceeds a
+  configurable threshold, keep the aggregate and emit the routing hint instead.
+- **Part B — Universal routing hint (non-terminal tests):** every other count/finding-bearing path
+  attaches a hint when its test(s) are non-terminal, telling the agent the counts may lag and to
+  call `get_test_simulations` with the relevant `status_filter` for the exact live count
+  (`total_simulations` is the authoritative live value).
+
+### Alternatives Considered
+- **Real fix in every path.** Pros: every headline number correct. Cons: **infeasible** — no live
+  source for findings/SIEM/drift; prohibitive for `get_tests`. Rejected.
+- **Hint only, all paths.** Pros: uniform, lowest risk, trivial. Cons: detail tools keep returning
+  the stale aggregate as the headline number; relies entirely on the agent following the hint.
+  Rejected as insufficient for the primary user-facing path.
+- **MCP cache-TTL tuning (shorten `tests_cache`).** Pros: trivial. Cons: **does not fix the bug** —
+  caching defaults to OFF and the lag is upstream of the MCP cache. Rejected.
+
+### Decision Rationale
+The hybrid is the only approach that gives correct *values* where it is cheap and feasible, correct
+*expectations* everywhere, and never fabricates numbers the backend has not computed.
+
+## 3. Core Feature Components
+
+### Component A — Live status-count derivation (shared helper)
+- **Purpose**: New shared helper that builds the `simulations_statistics` array (the 7 statuses:
+  missed/stopped/prevented/detected/logged/no-result/inconsistent) from a list of **live**
+  simulation entities (as returned by `_get_all_simulations_from_cache_or_api`), in the exact same
+  shape as the existing `_build_simulation_status_counts(finalStatus)`.
+- **Key Features**: Counts by each simulation's `final_status`/status field; returns identical
+  structure so it is a drop-in for non-terminal paths. New code in `data_types.py`.
+
+### Component B — Non-terminal live recount in `get_test_details` (soft-capped)
+- **Purpose**: For non-terminal tests, replace the aggregate counts with the live-derived counts;
+  fall back to aggregate + routing hint beyond the soft cap.
+- **Key Features**: Reuses `terminal_statuses` detection (`data_functions.py:447`) and the existing
+  `_get_all_simulations_from_cache_or_api`. Adjusts the existing non-terminal hint to reflect that
+  counts are now live-but-point-in-time (or the routing hint in the capped fallback case).
+
+### Component C — Studio `test_overview` parity + de-duplication
+- **Purpose**: Apply the same non-terminal live recount in `get_studio_attack_latest_result`'s
+  test-overview block, and **remove the inline duplicate** of the count logic
+  (`studio_functions.py:1538`) by calling the centralized helper.
+
+### Component D — Universal routing hint
+- **Purpose**: Attach a non-terminal routing hint to the hint-only paths: `get_tests`,
+  `get_test_findings_counts`/`_details`, `get_security_controls_events`/`_details`, and the drift
+  tools (`get_simulation_result_drifts`, `get_simulation_status_drifts`,
+  `get_security_control_drifts`).
+- **Key Features**: Cheap test-status check (cached test list / orchestrator queue) to decide
+  whether to attach the hint; consistent hint text directing to `get_test_simulations`.
+
+### Component E — Configurable soft-cap threshold
+- **Purpose**: Expose the live-recount size threshold as a constant + environment variable, and
+  document it in CLAUDE.md.
+
+## 4. API Endpoints and Integration
+
+No new APIs. The fix re-routes which **existing** data-API source feeds the counts.
+
+**Consumed (existing):**
+- **Test summaries (aggregate, lagging mid-run)** — `GET /api/data/v1/accounts/{account_id}/testsummaries?size=1000` and `/testsummaries/{test_id}`. Field: `finalStatus` → current count source.
+- **Executions history results (live per-simulation)** — `GET /api/data/v1/accounts/{account_id}/executionsHistoryResults` (paged, page_size=100). The live source already used by `sb_get_test_simulations`. New count source for non-terminal detail paths.
+- **Orchestrator queue (real-time status)** — `GET /api/orch/v4/accounts/{account_id}/queue` (`queue_state.py`). Used for the cheap non-terminal status check.
+- Headers unchanged (`x-apitoken` via `get_auth_headers_for_console`).
+
+## 5. Example Agent Flow
+
+**Primary scenario — "How many missed simulations so far?" on a running test:**
+1. User asks the HELM agent for the missed count during an active test.
+2. Agent calls `get_test_details(test_id)`.
+3. Test is non-terminal and under the soft cap → tool recounts from `executionsHistoryResults` and
+   returns `missed = 80` (matching the UI), plus a hint that the count is point-in-time and the
+   test is still running (poll again).
+4. Agent reports 80. ✅ (previously 28).
+
+**Alternative — very large running test (over soft cap):**
+- `get_test_details` returns the aggregate count plus a routing hint: "test too large for a live
+  recount; call `get_test_simulations` with `status_filter='missed'` for the exact live count." The
+  agent follows the hint and reports the live `total_simulations`.
+
+**Alternative — findings/security/drift on a running test:**
+- Tool returns its (upstream) value plus the routing hint that the number may lag while running.
+
+## 6. Non-Functional Requirements
+
+**Performance:**
+- The live recount for a non-terminal detail call costs the same as one `get_test_simulations`
+  call (~1 fetch/100 sims), and reuses `simulations_cache` when caching is enabled.
+- **Soft cap** bounds worst-case latency: tests whose known total exceeds the threshold skip the
+  recount and route via hint. Threshold default ~5000 simulations, configurable.
+- Terminal tests pay **zero** extra cost (unchanged aggregate path).
+
+**Technical Constraints / Backward Compatibility:**
+- Response shape of `simulations_statistics` is **unchanged** (same 7-status array); only the
+  source of the numbers changes for non-terminal tests. Terminal-test behavior is byte-for-byte
+  unchanged.
+- New hint fields are additive (`hint_to_agent`), consistent with existing conventions.
+- Caching remains opt-in (`SB_MCP_CACHE_DATA`); fix is correct with caching on or off.
+
+**Monitoring/Observability:**
+- Log when a non-terminal recount is performed vs. when the soft-cap fallback triggers (info-level),
+  to aid future tuning of the threshold.
+
+## 7. Definition of Done
+
+**Core Functionality:**
+- [ ] For a non-terminal test under the soft cap, `get_test_details` per-status counts match the
+      live `executionsHistoryResults`-derived counts (UI values), not `finalStatus`.
+- [ ] For a terminal test, counts and behavior are unchanged.
+- [ ] Over the soft cap, `get_test_details` keeps the aggregate count and emits the routing hint.
+- [ ] Studio `test_overview` mirrors the same behavior and uses the centralized helper (inline
+      duplicate removed).
+- [ ] `get_tests`, findings tools, security-event tools, and drift tools attach the routing hint
+      when their test(s) are non-terminal, and do not when terminal.
+
+**Quality Gates:**
+- [ ] New + existing unit tests pass across all servers (`config`, `data`, `utilities`,
+      `playbook`, `studio`).
+- [ ] A regression test reproduces the original bug (fails on pre-fix code, passes after).
+- [ ] No regression in terminal-test responses (golden assertions).
+- [ ] CLAUDE.md updated for the soft-cap env var and the running-test count behavior.
+
+**Deployment Readiness:**
+- [ ] Soft-cap threshold env var documented; sensible default.
+- [ ] Behavior verified against pentest01 on a live running test (repro scripts in PRD folder).
+
+## 8. Testing Strategy
+
+**Unit Testing (pytest):**
+- **Component A helper**: counts per status from a synthetic live-simulation list; equals the
+  `finalStatus`-based helper for an equivalent reconciled set.
+- **`get_test_details`**:
+  - Non-terminal + under cap → live counts (mock `_get_all_simulations_from_cache_or_api` to differ
+    from `finalStatus`; assert live wins). *This is the TDD reproduction.*
+  - Terminal → aggregate path unchanged.
+  - Non-terminal + over cap → aggregate retained + routing hint present.
+- **Studio `test_overview`**: live counts for non-terminal; uses centralized helper (assert no
+  inline duplication path); over-cap fallback.
+- **Hint-only paths**: routing hint present for non-terminal test(s), absent for terminal — for
+  `get_tests`, findings counts/details, security events, and each drift tool.
+- Follow memory gotchas: `json.dumps` spacing in assertions; update all renamed-param call sites.
+
+**Integration / E2E:**
+- E2E (`@pytest.mark.e2e`, `E2E_CONSOLE=pentest01`): on a live running test, assert
+  `get_test_details` missed count tracks `get_test_simulations(status_filter='missed')`
+  `total_simulations` within tolerance, and both reconcile at COMPLETED. Repro scripts
+  (`verify_lag.py`, `poll_lag.py`) document the manual procedure.
+
+**Coverage Gaps**: A truly live findings/SIEM/drift count is out of scope (no live source) — covered
+only by the routing hint.
+
+## 9. Implementation Phases
+
+| Phase | Status | Completed | Commit SHA | Notes |
+|-------|--------|-----------|------------|-------|
+| Phase 1: Live count helper + soft-cap constant | ⏳ Pending | - | - | |
+| Phase 2: Non-terminal live recount in get_test_details | ⏳ Pending | - | - | TDD repro |
+| Phase 3: Studio test_overview parity + de-dup | ⏳ Pending | - | - | |
+| Phase 4: Routing hint — get_tests | ⏳ Pending | - | - | |
+| Phase 5: Routing hint — findings paths | ⏳ Pending | - | - | |
+| Phase 6: Routing hint — security-control events | ⏳ Pending | - | - | |
+| Phase 7: Routing hint — drift tools | ⏳ Pending | - | - | |
+| Phase 8: Make soft cap configurable + docs | ⏳ Pending | - | - | |
+
+### Phase 1 — Live count helper + soft-cap constant
+- **Semantic change**: Add a shared helper that derives `simulations_statistics` from a list of
+  live simulation entities, plus a module constant for the soft-cap threshold.
+- **Implementation details**: New function in `data_types.py` (e.g. `build_simulation_status_counts_from_live`)
+  that takes the mapped simulation list and tallies each of the 7 statuses, returning the identical
+  array structure as `_build_simulation_status_counts`. Define `LIVE_RECOUNT_MAX_SIMULATIONS`
+  (default ~5000) in `data_functions.py`. Inputs: list of simulation dicts. Output: list of
+  `{status, count}` dicts. Edge cases: unknown/extra statuses ignored or bucketed consistently with
+  the existing helper; empty list → all zeros.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_types.py` | New live-count helper |
+  | `safebreach_mcp_data/data_functions.py` | Add soft-cap constant |
+  | `safebreach_mcp_data/tests/test_data_types.py` | Unit tests for helper |
+- **Git commit**: `feat(SAF-32018): add live simulation status-count helper + soft-cap constant`
+
+### Phase 2 — Non-terminal live recount in `get_test_details`
+- **Semantic change**: For non-terminal tests under the soft cap, source `simulations_statistics`
+  from live simulations; otherwise keep aggregate + routing hint.
+- **Implementation details**: In `sb_get_test_details` (`data_functions.py:416`), after the existing
+  non-terminal detection: if the test's known total (from current `simulations_statistics`/
+  `finalStatus`) ≤ `LIVE_RECOUNT_MAX_SIMULATIONS`, call `_get_all_simulations_from_cache_or_api`,
+  run the Phase-1 helper, and replace `simulations_statistics`. Else, leave aggregate and set the
+  routing hint. Update the non-terminal `hint_to_agent`: when live, "counts are live as of now;
+  test still running, poll again"; when capped, the routing hint. Terminal path untouched.
+  Error handling: if the live fetch fails, fall back to aggregate + routing hint (log a warning) —
+  never raise.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Live recount + hint logic in `sb_get_test_details` |
+  | `safebreach_mcp_data/tests/test_data_functions.py` | TDD repro + terminal-unchanged + over-cap tests |
+- **Git commit**: `fix(SAF-32018): live simulation counts for non-terminal get_test_details`
+
+### Phase 3 — Studio `test_overview` parity + de-duplication
+- **Semantic change**: Reuse the centralized helper in `get_studio_attack_latest_result` and apply
+  the same non-terminal live recount + soft-cap fallback.
+- **Implementation details**: Replace the inline status-count construction at
+  `studio_functions.py:1538` with the Phase-1 helper. For non-terminal resolved test under cap,
+  recount from live simulations; else aggregate + routing hint. Reuse the existing terminal check at
+  `studio_functions.py:1555`.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_studio/studio_functions.py` | Use central helper + live recount in test_overview |
+  | `safebreach_mcp_studio/tests/...` | Tests for live/terminal/over-cap + no inline dup |
+- **Git commit**: `fix(SAF-32018): live counts + de-dup status logic in studio test_overview`
+
+### Phase 4 — Routing hint: `get_tests`
+- **Semantic change**: Attach a routing hint to the `get_tests` response when any test in the
+  returned page is non-terminal.
+- **Implementation details**: In `sb_get_tests`, after building the page, if any test's status is
+  non-terminal, add a top-level `hint_to_agent` noting per-test counts may lag for running tests and
+  to use `get_test_details`/`get_test_simulations` for live values. No per-test paging.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Conditional hint in `sb_get_tests` |
+  | `safebreach_mcp_data/tests/test_data_functions.py` | Hint present/absent tests |
+- **Git commit**: `fix(SAF-32018): routing hint for running tests in get_tests`
+
+### Phase 5 — Routing hint: findings paths
+- **Semantic change**: Attach the routing hint to `get_test_findings_counts` and
+  `get_test_findings_details` when the test is non-terminal.
+- **Implementation details**: Cheap status check (cached test list / orchestrator) for the test_id;
+  if non-terminal, add a hint that findings are still accumulating and may lag. No recount.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Conditional hint in findings tools |
+  | `safebreach_mcp_data/tests/...` | Tests |
+- **Git commit**: `fix(SAF-32018): routing hint for running tests in findings tools`
+
+### Phase 6 — Routing hint: security-control events
+- **Semantic change**: Attach the routing hint to `get_security_controls_events` /
+  `get_security_control_event_details` when the test is non-terminal.
+- **Implementation details**: Same cheap status check + hint noting SIEM-sourced events may lag for
+  running tests.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Conditional hint |
+  | `safebreach_mcp_data/tests/...` | Tests |
+- **Git commit**: `fix(SAF-32018): routing hint for running tests in security-control events`
+
+### Phase 7 — Routing hint: drift tools
+- **Semantic change**: Attach a caveat hint to `get_simulation_result_drifts`,
+  `get_simulation_status_drifts`, `get_security_control_drifts` indicating running tests in the
+  window may have incomplete drift data.
+- **Implementation details**: Add to existing hint construction in each drift tool a note about
+  in-flight tests; no recount.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Hints in drift tools |
+  | `safebreach_mcp_data/tests/...` | Tests |
+- **Git commit**: `fix(SAF-32018): running-test caveat in drift tools`
+
+### Phase 8 — Configurable soft cap + docs
+- **Semantic change**: Make the soft-cap threshold configurable via env var and document behavior.
+- **Implementation details**: Read `LIVE_RECOUNT_MAX_SIMULATIONS` from env (default ~5000). Update
+  CLAUDE.md: document the running-test live-count behavior, the env var, and the routing hint.
+- **Changes**:
+  | File | Change |
+  |------|--------|
+  | `safebreach_mcp_data/data_functions.py` | Env-var read for threshold |
+  | `CLAUDE.md` | Document behavior + env var |
+- **Git commit**: `docs(SAF-32018): document running-test live counts + soft-cap env var`
+
+## 10. Risks and Assumptions
+
+**Technical Risks:**
+- **Perf on large running tests** (Medium): mitigated by the soft cap + cache reuse + non-terminal
+  gating.
+- **Regression in terminal-test counts** (Medium): mitigated by gating strictly on non-terminal and
+  golden assertions on terminal responses.
+- **Status-check cost in hint-only paths** (Low): use the cheapest available signal (cached test
+  list / orchestrator), avoid extra paging.
+- **Agent ignores routing hint on capped/hint-only paths** (Low/accepted): inherent to hint-based
+  paths where no live source exists.
+
+**Assumptions Under Question:**
+- `executionsHistoryResults` is the authoritative live source — **validated** (matches UI; reconciles
+  to `finalStatus` at terminal: 67==67, 125/94).
+- Default soft-cap (~5000) is a reasonable balance — to confirm/tune via the observability logs.
+
+**Mitigation:** Phased, independently-committable changes; each phase verified before the next;
+configurable threshold for safe rollout.
+
+## 11. Future Enhancements
+- A genuine live findings/drift count if/when the backend exposes a live source.
+- Optional server-side count endpoint to avoid client-side paging for large running tests.
+- Consider live counts for `get_tests` if a bulk live-count API becomes available.
+
+## 12. Executive Summary
+- **Issue**: The HELM agent reports stale simulation status counts for running tests (28 vs UI's
+  80) because counts come from the lagging `testsummaries.finalStatus` aggregate.
+- **What Was Built**: Live per-simulation recount for non-terminal tests in the two single-test
+  detail paths (`get_test_details`, Studio `test_overview`) with a soft size cap, plus a universal
+  routing hint on all other count/finding-bearing paths directing the agent to the authoritative
+  live count tool. Studio's inline count duplicate folded into the central helper.
+- **Key Technical Decisions**: Hybrid (real fix where cheap/feasible + hint everywhere), because a
+  real fix is impossible for findings/SIEM/drift and prohibitive for `get_tests`; gate on
+  non-terminal status; soft-cap to bound latency; never fabricate upstream-unavailable numbers.
+- **Scope Changes**: Real live recount limited to two single-test paths; all other paths are
+  hint-only by design.
+- **Business Value**: Eliminates "agent contradicts the UI" during live tests for the primary
+  tools, and makes the limitation explicit + actionable everywhere else.
+
+## 14. Change Log
+
+| Date | Change Description |
+|------|-------------------|
+| 2026-06-22 09:30 | PRD created — initial draft |
+| 2026-06-22 09:40 | PRD approved by owner; ready for implementation |

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/summary.md
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/summary.md
@@ -1,0 +1,68 @@
+# Summary: SAF-32018 (refined)
+
+**Mode:** Improve existing ticket (Bug, High)
+**Branch:** `bugfix/SAF-32018-stale-running-test-counts`
+**Repo:** safebreach-mcp
+
+## Proposed Title
+HELM | `get_test_details` reports stale simulation status counts for a RUNNING test (sources the lagging `testsummaries.finalStatus` aggregate instead of live per-simulation data)
+
+## Problem (refined)
+When the agent is asked for a simulation status count (e.g. "Missed") on a test that is **still
+running**, `get_test_details` returns a count that **lags the live UI** (reported 28 vs UI's 80).
+The gap disappears once the test completes.
+
+## Root Cause (empirically confirmed)
+`get_test_details.simulations_statistics` is built from the SafeBreach **`testsummaries.finalStatus`
+aggregate** (`data_types.py:82` ← `data_functions.py:235`). That aggregate is recomputed
+lazily/periodically on the backend and **lags the live per-simulation results during an active
+run**. The UI counts **live simulation rows** (the `executionsHistoryResults` source). The MCP
+faithfully relays the lagging aggregate. The agent's "backend caching" remark is essentially
+correct — it is genuine upstream aggregate lag.
+
+**It is NOT the MCP's own cache:** `SB_MCP_CACHE_DATA` defaults to `false`, so the bug reproduces
+with MCP caching off (every call hits `testsummaries` fresh and still returns the lagging number).
+The `tests_cache` 1800s TTL only aggravates it when caching is explicitly enabled.
+
+**It is NOT fixable by the existing SAF-31111 refresh at `data_functions.py:456`:** the orchestrator
+queue (`queue_state.py:25`) carries only status (`RUNNING`/`PAUSED`), no counts; and the single-test
+fallback endpoint shares the *same* lagging `finalStatus` aggregate.
+
+## Empirical Evidence (TDD reproduction)
+Live test `1782107855457.2` on pentest01, sampled every 5s across the full run:
+- During RUNNING, live (`executionsHistoryResults`) consistently led the aggregate
+  (`finalStatus`) — e.g. agg_missed=55 vs live=57; agg_total=64 vs live=68.
+- At COMPLETED, both reconciled exactly (125/125 total, 94/94 missed).
+- Validation on completed tests: aggregate == live (67 == 67) — confirms `executionsHistoryResults`
+  counting is the correct live source.
+- Scripts retained: `verify_lag.py`, `poll_lag.py` (PRD folder).
+
+## Affected Areas
+- **Primary:** `sb_get_test_details` / `_build_simulation_status_counts` count path for non-terminal
+  tests (`data_functions.py:416`, `data_types.py:82`).
+- **Secondary (same lag class, only when caching enabled):** `get_test_simulations` counts,
+  findings counts, security-control events.
+
+## Candidate Direction (for implementation, not finalized here)
+For **non-terminal** tests, derive `simulations_statistics` from the **live** source
+(`executionsHistoryResults`, already used by `sb_get_test_simulations`) instead of the lagging
+`finalStatus` aggregate. Keep the cheap aggregate for **terminal** tests (where it has reconciled).
+Surface that a running count is point-in-time (existing "poll again" hint).
+
+## Acceptance Criteria (proposed)
+1. For a **RUNNING** test, `get_test_details` returns per-status counts (missed/stopped/prevented/
+   detected/logged/no-result/inconsistent) that match the live `executionsHistoryResults`-derived
+   counts (the values shown in the UI filter), not the lagging `finalStatus` aggregate.
+2. For a **terminal** test (completed/canceled/failed), behavior and counts are unchanged.
+3. A regression test reproduces the bug: asserts running-test counts match the live source
+   (fails on current code, passes after fix). Uses the SAF-31111 terminal/non-terminal detection.
+4. Cost is only paid for non-terminal tests; terminal tests keep using the cheap aggregate.
+5. The "test still running — poll again" hint is retained so the count is understood as
+   point-in-time.
+6. (Decision to confirm) Whether the secondary stale-prone paths (`get_test_simulations`,
+   findings, security-control events) are addressed here or split into a follow-up.
+
+## Open Questions for the team
+- Should the secondary read paths be in scope, or a follow-up ticket?
+- Performance ceiling: large running tests require paging all `executionsHistoryResults`; acceptable,
+  or cap/short-circuit beyond a size threshold?

--- a/prds/bugfix-SAF-32018-stale-running-test-counts/verify_lag.py
+++ b/prds/bugfix-SAF-32018-stale-running-test-counts/verify_lag.py
@@ -1,0 +1,80 @@
+"""
+SAF-32018 empirical verification.
+
+Hypothesis: for a RUNNING test, testsummaries.finalStatus (the aggregate that feeds
+get_test_details.simulations_statistics) lags the live per-simulation results that
+executionsHistoryResults (what get_test_simulations counts) returns.
+
+Strategy:
+  1. List tests on pentest01, find non-terminal (running/paused) ones.
+  2. For each candidate, read the aggregate 'missed' count (finalStatus via get_test_details)
+     and the live 'missed' count (counted from executionsHistoryResults via get_test_simulations).
+  3. Compare. A mismatch on a running test confirms the lag.
+  4. Also sanity-check a recent COMPLETED test: the two should agree (validates the method).
+"""
+import sys
+
+CONSOLE = "pentest01"
+
+from safebreach_mcp_data.data_functions import (
+    sb_get_tests,
+    sb_get_test_details,
+    sb_get_test_simulations,
+)
+
+
+def missed_from_details(test_id):
+    d = sb_get_test_details(test_id, CONSOLE)
+    for s in d.get("simulations_statistics", []):
+        if s.get("status") == "missed":
+            return s.get("count"), d.get("status")
+    return None, d.get("status")
+
+
+def missed_live(test_id):
+    r = sb_get_test_simulations(test_id, CONSOLE, page_number=0, status_filter="missed")
+    return r.get("total_simulations")
+
+
+def report(label, test_id):
+    agg, status = missed_from_details(test_id)
+    live = missed_live(test_id)
+    flag = "  <-- MISMATCH" if (agg is not None and live is not None and agg != live) else ""
+    print(f"[{label}] test={test_id} status={status} aggregate_missed={agg} live_missed={live}{flag}")
+    return status, agg, live
+
+
+def main():
+    # Find running tests
+    running = sb_get_tests(CONSOLE, status_filter="running")
+    run_tests = running.get("tests_in_page", [])
+    print(f"Running tests found: {len(run_tests)}")
+    saw_mismatch = False
+    for t in run_tests[:5]:
+        status, agg, live = report("RUNNING", t["test_id"])
+        if agg is not None and live is not None and agg != live:
+            saw_mismatch = True
+
+    # Sanity check: a recent completed test (counts should agree)
+    completed = sb_get_tests(CONSOLE, status_filter="completed", order_by="end_time", order_direction="desc")
+    comp_tests = completed.get("tests_in_page", [])
+    print(f"\nCompleted tests sampled for sanity check: {min(3, len(comp_tests))}")
+    for t in comp_tests[:3]:
+        report("COMPLETED", t["test_id"])
+
+    print("\n=== VERDICT ===")
+    if not run_tests:
+        print("No RUNNING test available right now — cannot observe live lag this moment.")
+        print("Completed-test rows above validate that aggregate==live once finalStatus reconciles.")
+    elif saw_mismatch:
+        print("CONFIRMED: aggregate (finalStatus) lags live (executionsHistoryResults) on a RUNNING test.")
+    else:
+        print("No mismatch observed on the running test(s) at this instant (aggregate may be momentarily in sync).")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+        raise

--- a/safebreach_mcp_core/tests/test_disable_filtering.py
+++ b/safebreach_mcp_core/tests/test_disable_filtering.py
@@ -14,7 +14,7 @@ import asyncio
 
 import pytest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from mcp.server.fastmcp.exceptions import ToolError
 from safebreach_mcp_core import safebreach_base as mod
@@ -27,8 +27,9 @@ def _make_tool(name: str):
 def _build_base_with_tools(tools_by_name: dict):
     """Construct a SafeBreachMCPBase, attach a fake tool manager, install
     the filter. Caller monkeypatches `_DISABLE_TOOL_LIST` to drive scenarios."""
-    with patch.object(mod, "SafeBreachAuth"):
-        base = mod.SafeBreachMCPBase("test-server")
+    # SafeBreachAuth was removed from safebreach_base in SAF-29974, so the base
+    # constructor no longer creates an auth object — instantiate directly (no patch needed).
+    base = mod.SafeBreachMCPBase("test-server")
 
     fake_manager = MagicMock()
     fake_manager.list_tools.side_effect = lambda: list(tools_by_name.values())

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -51,6 +51,13 @@ PAGE_SIZE = 10
 # in a later phase.
 LIVE_RECOUNT_MAX_SIMULATIONS = 5000
 
+# SAF-32018: window-based drift tools cannot cheaply tell which tests in the window are
+# still running, and there is no live drift source. Append this caveat to drift summaries.
+_DRIFT_RUNNING_CAVEAT = (
+    "Note: any tests still running within this window may have incomplete drift data until "
+    "they complete — re-query after they finish for final drift results."
+)
+
 
 def _normalize_numeric(value: Any) -> Optional[float]:
     """
@@ -2665,7 +2672,7 @@ def _group_and_paginate_drifts(
             "total_groups": len(groups),
             "drift_groups": summary_groups,
             "applied_filters": applied_filters,
-            "hint_to_agent": hint,
+            "hint_to_agent": f"{hint} {_DRIFT_RUNNING_CAVEAT}",
         }
 
     # Drill-down mode: find the requested group
@@ -3058,7 +3065,7 @@ def _group_and_paginate_sc_drifts(
             "total_groups": len(groups),
             "drift_groups": summary_groups,
             "applied_filters": applied_filters,
-            "hint_to_agent": hint,
+            "hint_to_agent": f"{hint} {_DRIFT_RUNNING_CAVEAT}",
         }
 
     # Drill-down mode

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -1349,14 +1349,27 @@ def sb_get_security_controls_events(
         if destination_host_filter:
             applied_filters['destination_host_filter'] = destination_host_filter
         
+        base_hint = (
+            f"Retrieved {len(reduced_events)} security control events for test {test_id} and "
+            f"simulation {simulation_id}. " +
+            (f"You can scan next page by calling with page_number={page_number + 1}"
+             if page_number + 1 < total_pages else "This is the last page.")
+        )
+        # SAF-32018: security-control events arrive with external SIEM indexing lag; while the
+        # test runs the event set may be incomplete. There is no live source to switch to — warn.
+        if _is_test_non_terminal(test_id, console):
+            base_hint += (
+                " Note: the test is still running — security-control events arrive with SIEM "
+                "indexing lag and may be incomplete. Re-query after the test completes."
+            )
+
         return {
             "page_number": page_number,
             "total_pages": total_pages,
             "total_events": total_events,
             "events_in_page": reduced_events,
             "applied_filters": applied_filters,
-            "hint_to_agent": f"Retrieved {len(reduced_events)} security control events for test {test_id} and simulation {simulation_id}. " +
-                           (f"You can scan next page by calling with page_number={page_number + 1}" if page_number + 1 < total_pages else "This is the last page.")
+            "hint_to_agent": base_hint
         }
         
     except Exception as e:

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -196,13 +196,33 @@ def sb_get_tests(
         if order_direction != "desc":
             applied_filters['order_direction'] = order_direction
         
+        # SAF-32018: if any test on this page is non-terminal, its simulations_statistics
+        # come from the lagging testsummaries.finalStatus aggregate. Warn and route the agent
+        # to the live sources (get_test_details is live for running tests; get_test_simulations
+        # with a status_filter gives the exact live count). Per-test live recount across a list
+        # is intentionally NOT done here (would require paging every running test).
+        terminal_statuses = {'completed', 'canceled', 'failed'}
+        running_in_page = any(
+            (t.get('status', '') or '').lower() not in terminal_statuses for t in page_tests
+        )
+        pagination_hint = (
+            f"You can scan next page by specifying page_number={page_number + 1}"
+            if page_number + 1 < total_pages else None
+        )
+        running_hint = (
+            "Some tests on this page are still running; their simulations_statistics come from a "
+            "periodically-updated summary and may lag the live results. For live counts call "
+            "get_test_details (live for running tests) or get_test_simulations with a status_filter."
+        ) if running_in_page else None
+        combined_hint = " ".join(h for h in (pagination_hint, running_hint) if h) or None
+
         return {
             "page_number": page_number,
             "total_pages": total_pages,
             "total_tests": total_tests,
             "tests_in_page": page_tests,
             "applied_filters": applied_filters,
-            "hint_to_agent": f"You can scan next page by specifying page_number={page_number + 1}" if page_number + 1 < total_pages else None
+            "hint_to_agent": combined_hint
         }
         
     except Exception as e:

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -27,6 +27,7 @@ from .data_types import (
     get_full_security_control_events_mapping,
     group_and_enrich_drift_records,
     get_reduced_peer_benchmark_response,
+    build_simulation_status_counts_from_simulations,
 )
 from .drifts_metadata import drift_types_mapping
 
@@ -482,6 +483,45 @@ def sb_get_test_details(test_id: str, console: str = "default",
             logger.info("Test '%s' not found in cached list, falling back to single-test endpoint", test_id)
             return_details = _fetch_single_test(test_id, console)
 
+        # SAF-32018: for a NON-TERMINAL test, recompute simulations_statistics from the
+        # live executionsHistoryResults source. The testsummaries.finalStatus aggregate
+        # (the default source) lags the live per-simulation results during an active run,
+        # so it under-reports counts until the test completes. Soft-capped: above
+        # LIVE_RECOUNT_MAX_SIMULATIONS we keep the aggregate and route the agent to
+        # get_test_simulations for an exact live count. Best-effort: any failure degrades
+        # to the aggregate (never raises).
+        live_recount_note = None
+        post_refresh_status = (return_details.get('status', '') or '').lower()
+        if post_refresh_status not in terminal_statuses:
+            known_total = sum(
+                s.get('count', 0)
+                for s in return_details.get('simulations_statistics', [])
+                if 'count' in s
+            )
+            if known_total <= LIVE_RECOUNT_MAX_SIMULATIONS:
+                try:
+                    live_sims = _get_all_simulations_from_cache_or_api(test_id, console)
+                    return_details['simulations_statistics'] = (
+                        build_simulation_status_counts_from_simulations(live_sims)
+                    )
+                    live_recount_note = 'live'
+                    logger.info(
+                        "SAF-32018: recomputed live counts for running test '%s' from %d simulations",
+                        test_id, len(live_sims),
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "SAF-32018: live recount failed for running test '%s': %s — using aggregate counts",
+                        test_id, e,
+                    )
+                    live_recount_note = 'failed'
+            else:
+                logger.info(
+                    "SAF-32018: running test '%s' over soft cap (%d > %d) — keeping aggregate counts",
+                    test_id, known_total, LIVE_RECOUNT_MAX_SIMULATIONS,
+                )
+                live_recount_note = 'capped'
+
         if include_drift_count:
             drift_count = _count_drifted_simulations(test_id, console)
             return_details['simulations_statistics'].append({
@@ -500,10 +540,29 @@ def sb_get_test_details(test_id: str, console: str = "default",
         # Add contextual hints
         final_status = (return_details.get('status', '') or '').lower()
         if final_status not in terminal_statuses:
-            return_details['hint_to_agent'] = (
-                f"Test is still {return_details.get('status', 'in progress')}. "
-                "Poll again in 30 seconds using get_test_details with the same test_id."
-            )
+            if live_recount_note == 'live':
+                # Counts were recomputed from the live source — accurate as of now.
+                return_details['hint_to_agent'] = (
+                    f"Test is still {return_details.get('status', 'in progress')}. "
+                    "These simulation counts are live as of now and will keep changing while "
+                    "the test runs — poll again in ~30 seconds using get_test_details with the "
+                    "same test_id."
+                )
+            elif live_recount_note in ('capped', 'failed'):
+                # Counts are the lagging aggregate — route the agent to the live source.
+                return_details['hint_to_agent'] = (
+                    f"Test is still {return_details.get('status', 'in progress')}. "
+                    "These simulation counts come from a periodically-updated summary and may "
+                    "lag the live results while the test runs. For an exact live count of a "
+                    "given status, call get_test_simulations with the relevant status_filter "
+                    "(its total_simulations is the live count). Poll again in ~30 seconds with "
+                    "get_test_details for updated totals."
+                )
+            else:
+                return_details['hint_to_agent'] = (
+                    f"Test is still {return_details.get('status', 'in progress')}. "
+                    "Poll again in 30 seconds using get_test_details with the same test_id."
+                )
         else:
             # Terminal test — hint about delete for storage management (SAF-29972)
             return_details['hint_to_agent'] = (

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -7,6 +7,7 @@ specifically for test and simulation data management.
 
 import copy
 import logging
+import os
 import time
 from typing import Dict, List, Optional, Any, Iterable
 
@@ -50,6 +51,25 @@ PAGE_SIZE = 10
 # the aggregate plus a routing hint to get_test_simulations. Made env-configurable
 # in a later phase.
 LIVE_RECOUNT_MAX_SIMULATIONS = 5000
+
+
+def _get_live_recount_cap() -> int:
+    """Resolve the live-recount soft cap (SAF-32018), env-overridable at call time.
+
+    Reads ``SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS`` and falls back to the module
+    default ``LIVE_RECOUNT_MAX_SIMULATIONS`` when unset or non-integer.
+    """
+    raw = os.environ.get('SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS')
+    if raw is None:
+        return LIVE_RECOUNT_MAX_SIMULATIONS
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "SAF-32018: invalid SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS=%r — using default %d",
+            raw, LIVE_RECOUNT_MAX_SIMULATIONS,
+        )
+        return LIVE_RECOUNT_MAX_SIMULATIONS
 
 # SAF-32018: window-based drift tools cannot cheaply tell which tests in the window are
 # still running, and there is no live drift source. Append this caveat to drift summaries.
@@ -525,7 +545,7 @@ def sb_get_test_details(test_id: str, console: str = "default",
                 for s in return_details.get('simulations_statistics', [])
                 if 'count' in s
             )
-            if known_total <= LIVE_RECOUNT_MAX_SIMULATIONS:
+            if known_total <= _get_live_recount_cap():
                 try:
                     live_sims = _get_all_simulations_from_cache_or_api(test_id, console)
                     return_details['simulations_statistics'] = (

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -1557,6 +1557,22 @@ def _apply_findings_filters(
     return filtered_findings
 
 
+def _is_test_non_terminal(test_id: str, console: str) -> bool:
+    """
+    Best-effort check whether a test is currently RUNNING/PAUSED (SAF-32018).
+
+    Uses the real-time orchestrator queue (the same signal as SAF-31111). Returns
+    False on any error or when the test is not in the queue (terminal/unknown) — so
+    a failure degrades to "no running-test hint", never raises.
+    """
+    try:
+        from safebreach_mcp_core.queue_state import get_orchestrator_test_state
+        return get_orchestrator_test_state(test_id, console) is not None
+    except Exception as e:
+        logger.warning("SAF-32018: non-terminal check failed for test '%s': %s", test_id, e)
+        return False
+
+
 def sb_get_test_findings_counts(
     test_id: str,
     console: str = "default",
@@ -1609,7 +1625,16 @@ def sb_get_test_findings_counts(
             'applied_filters': applied_filters,
             'retrieved_at': time.time()
         }
-        
+
+        # SAF-32018: findings are indexed asynchronously; while the test runs these
+        # counts may be incomplete. There is no live findings source, so warn and
+        # advise re-querying after completion.
+        if _is_test_non_terminal(test_id, console):
+            result['hint_to_agent'] = (
+                "Test is still running — findings are still being indexed and these counts may "
+                "be incomplete. Re-query after the test completes for the final findings set."
+            )
+
         logger.info("Retrieved %d findings of %d types for %s:%s", len(filtered_findings), len(type_counts), console, test_id)
         return result
         
@@ -1692,9 +1717,21 @@ def sb_get_test_findings_details(
         }
         
         # Add hint for pagination
+        hints = []
         if page_number + 1 < total_pages:
-            result['hint_to_agent'] = f"You can scan next page by calling with page_number={page_number + 1}. There are {total_pages} total pages."
-        
+            hints.append(
+                f"You can scan next page by calling with page_number={page_number + 1}. "
+                f"There are {total_pages} total pages."
+            )
+        # SAF-32018: findings index asynchronously — warn while the test is still running.
+        if _is_test_non_terminal(test_id, console):
+            hints.append(
+                "Test is still running — findings are still being indexed and may be "
+                "incomplete. Re-query after the test completes for the final findings set."
+            )
+        if hints:
+            result['hint_to_agent'] = " ".join(hints)
+
         logger.info("Retrieved page %d of %d (%d findings) for %s:%s", page_number, total_pages, len(page_findings), console, test_id)
         return result
         

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -7,7 +7,6 @@ specifically for test and simulation data management.
 
 import copy
 import logging
-import os
 import time
 from typing import Dict, List, Optional, Any, Iterable
 
@@ -28,7 +27,6 @@ from .data_types import (
     get_full_security_control_events_mapping,
     group_and_enrich_drift_records,
     get_reduced_peer_benchmark_response,
-    build_simulation_status_counts_from_simulations,
 )
 from .drifts_metadata import drift_types_mapping
 
@@ -43,33 +41,6 @@ peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600
 
 # Configuration constants
 PAGE_SIZE = 10
-
-# SAF-32018: soft cap for live simulation recount on non-terminal tests.
-# For a running test, counts are recomputed from the live executionsHistoryResults
-# source (which requires paging all simulations) instead of the lagging
-# testsummaries.finalStatus aggregate. Above this size, skip the recount and keep
-# the aggregate plus a routing hint to get_test_simulations. Made env-configurable
-# in a later phase.
-LIVE_RECOUNT_MAX_SIMULATIONS = 5000
-
-
-def _get_live_recount_cap() -> int:
-    """Resolve the live-recount soft cap (SAF-32018), env-overridable at call time.
-
-    Reads ``SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS`` and falls back to the module
-    default ``LIVE_RECOUNT_MAX_SIMULATIONS`` when unset or non-integer.
-    """
-    raw = os.environ.get('SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS')
-    if raw is None:
-        return LIVE_RECOUNT_MAX_SIMULATIONS
-    try:
-        return int(raw)
-    except (ValueError, TypeError):
-        logger.warning(
-            "SAF-32018: invalid SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS=%r — using default %d",
-            raw, LIVE_RECOUNT_MAX_SIMULATIONS,
-        )
-        return LIVE_RECOUNT_MAX_SIMULATIONS
 
 # SAF-32018: window-based drift tools cannot cheaply tell which tests in the window are
 # still running, and there is no live drift source. Append this caveat to drift summaries.
@@ -495,79 +466,43 @@ def sb_get_test_details(test_id: str, console: str = "default",
         # Try the list endpoint first (via cache) — it includes findingsCount/compromisedHosts
         return_details = _find_test_in_cached_list(test_id, console)
 
-        # If cached entry shows a non-terminal status, fetch fresh status.
-        # The cached list can be up to 30 minutes stale, and transient
-        # statuses (RUNNING, QUEUED, etc.) may have changed since caching.
-        # SAF-31111: Check orchestrator queue first (real-time) before the
-        # data API, which has 10-15s eventual consistency lag.
+        # SAF-32018 + SAF-31111: a non-terminal (running) test taken from the cached list can be
+        # stale in TWO ways — the tests_cache holds an up-to-30-min-old snapshot, and the
+        # running-test path previously refreshed only the status, never the COUNTS. That stale,
+        # never-refreshed finalStatus was the root cause of SAF-32018 (agent reported 28 while the
+        # UI showed 80). Fix: for a non-terminal test, refresh from fresh sources —
+        #   - real-time status from the orchestrator queue (no eventual-consistency lag), and
+        #   - fresh simulation counts from the single-test /testsummaries/{id} endpoint, whose
+        #     finalStatus tracks the live UI aggregation to within ~1 simulation (verified) — far
+        #     cheaper than paging every simulation.
         terminal_statuses = {'completed', 'canceled', 'failed'}
         cached_status = (return_details.get('status', '') or '').lower() if return_details else ''
         if return_details is not None and cached_status not in terminal_statuses:
-            logger.info("Test '%s' shows non-terminal status '%s' in cache — fetching fresh", test_id, cached_status)
+            logger.info("Test '%s' is non-terminal ('%s') — refreshing status and counts", test_id, cached_status)
 
-            # Phase 1: orchestrator queue (real-time, no lag)
+            # Real-time status from the orchestrator queue (no lag).
             from safebreach_mcp_core.queue_state import get_orchestrator_test_state
             orch_state = get_orchestrator_test_state(test_id, console)
             if orch_state is not None:
                 return_details['status'] = orch_state
                 logger.info("Test '%s' status from orchestrator queue: %s", test_id, orch_state)
-            else:
-                # Phase 2: data API single-test endpoint (eventual consistency)
-                try:
-                    fresh = _fetch_single_test(test_id, console)
-                    # Merge: use fresh status/end_time but keep cached extras
-                    # (findingsCount, compromisedHosts) that single-test omits
+
+            # Fresh counts (and status/end_time fallback) from the single-test endpoint.
+            try:
+                fresh = _fetch_single_test(test_id, console)
+                if orch_state is None:
                     return_details['status'] = fresh.get('status', return_details['status'])
-                    return_details['end_time'] = fresh.get('end_time', return_details['end_time'])
-                    return_details['simulations_statistics'] = fresh.get(
-                        'simulations_statistics', return_details['simulations_statistics']
-                    )
-                except Exception as e:
-                    logger.warning("Failed to refresh RUNNING test '%s': %s — using cached data", test_id, e)
+                return_details['end_time'] = fresh.get('end_time', return_details['end_time'])
+                return_details['simulations_statistics'] = fresh.get(
+                    'simulations_statistics', return_details['simulations_statistics']
+                )
+            except Exception as e:
+                logger.warning("Failed to refresh non-terminal test '%s': %s — using cached data", test_id, e)
 
         if return_details is None:
             # Fallback: single-test endpoint (missing findingsCount/compromisedHosts)
             logger.info("Test '%s' not found in cached list, falling back to single-test endpoint", test_id)
             return_details = _fetch_single_test(test_id, console)
-
-        # SAF-32018: for a NON-TERMINAL test, recompute simulations_statistics from the
-        # live executionsHistoryResults source. The testsummaries.finalStatus aggregate
-        # (the default source) lags the live per-simulation results during an active run,
-        # so it under-reports counts until the test completes. Soft-capped: above
-        # LIVE_RECOUNT_MAX_SIMULATIONS we keep the aggregate and route the agent to
-        # get_test_simulations for an exact live count. Best-effort: any failure degrades
-        # to the aggregate (never raises).
-        live_recount_note = None
-        post_refresh_status = (return_details.get('status', '') or '').lower()
-        if post_refresh_status not in terminal_statuses:
-            known_total = sum(
-                s.get('count', 0)
-                for s in return_details.get('simulations_statistics', [])
-                if 'count' in s
-            )
-            if known_total <= _get_live_recount_cap():
-                try:
-                    live_sims = _get_all_simulations_from_cache_or_api(test_id, console)
-                    return_details['simulations_statistics'] = (
-                        build_simulation_status_counts_from_simulations(live_sims)
-                    )
-                    live_recount_note = 'live'
-                    logger.info(
-                        "SAF-32018: recomputed live counts for running test '%s' from %d simulations",
-                        test_id, len(live_sims),
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "SAF-32018: live recount failed for running test '%s': %s — using aggregate counts",
-                        test_id, e,
-                    )
-                    live_recount_note = 'failed'
-            else:
-                logger.info(
-                    "SAF-32018: running test '%s' over soft cap (%d > %d) — keeping aggregate counts",
-                    test_id, known_total, LIVE_RECOUNT_MAX_SIMULATIONS,
-                )
-                live_recount_note = 'capped'
 
         if include_drift_count:
             drift_count = _count_drifted_simulations(test_id, console)
@@ -587,29 +522,16 @@ def sb_get_test_details(test_id: str, console: str = "default",
         # Add contextual hints
         final_status = (return_details.get('status', '') or '').lower()
         if final_status not in terminal_statuses:
-            if live_recount_note == 'live':
-                # Counts were recomputed from the live source — accurate as of now.
-                return_details['hint_to_agent'] = (
-                    f"Test is still {return_details.get('status', 'in progress')}. "
-                    "These simulation counts are live as of now and will keep changing while "
-                    "the test runs — poll again in ~30 seconds using get_test_details with the "
-                    "same test_id."
-                )
-            elif live_recount_note in ('capped', 'failed'):
-                # Counts are the lagging aggregate — route the agent to the live source.
-                return_details['hint_to_agent'] = (
-                    f"Test is still {return_details.get('status', 'in progress')}. "
-                    "These simulation counts come from a periodically-updated summary and may "
-                    "lag the live results while the test runs. For an exact live count of a "
-                    "given status, call get_test_simulations with the relevant status_filter "
-                    "(its total_simulations is the live count). Poll again in ~30 seconds with "
-                    "get_test_details for updated totals."
-                )
-            else:
-                return_details['hint_to_agent'] = (
-                    f"Test is still {return_details.get('status', 'in progress')}. "
-                    "Poll again in 30 seconds using get_test_details with the same test_id."
-                )
+            # SAF-32018: counts were just refreshed from the live summary, but the test is still
+            # running so they are point-in-time and will keep changing. Flag that and point to the
+            # live filtered grid for exact per-status drill-down.
+            return_details['hint_to_agent'] = (
+                f"Test is still {return_details.get('status', 'in progress')}. "
+                "These simulation counts are refreshed as of now but are point-in-time and will "
+                "keep changing while the test runs — poll again in ~30 seconds with "
+                "get_test_details. For the live filtered grid of a given status, use "
+                "get_test_simulations with the relevant status_filter."
+            )
         else:
             # Terminal test — hint about delete for storage management (SAF-29972)
             return_details['hint_to_agent'] = (

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -42,6 +42,14 @@ peer_benchmark_cache = SafeBreachCache(name="peer_benchmark", maxsize=3, ttl=600
 # Configuration constants
 PAGE_SIZE = 10
 
+# SAF-32018: soft cap for live simulation recount on non-terminal tests.
+# For a running test, counts are recomputed from the live executionsHistoryResults
+# source (which requires paging all simulations) instead of the lagging
+# testsummaries.finalStatus aggregate. Above this size, skip the recount and keep
+# the aggregate plus a routing hint to get_test_simulations. Made env-configurable
+# in a later phase.
+LIVE_RECOUNT_MAX_SIMULATIONS = 5000
+
 
 def _normalize_numeric(value: Any) -> Optional[float]:
     """

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -811,13 +811,26 @@ def sb_get_test_simulations(
         if drifted_only:
             applied_filters['drifted_only'] = drifted_only
         
+        # SAF-32018: these simulations are the live source, but for a running test they
+        # reflect only what has completed so far — total_simulations is point-in-time, not
+        # the final total. Flag that so the agent doesn't treat it as complete.
+        sim_hints = []
+        if page_number + 1 < total_pages:
+            sim_hints.append(f"You can scan next page by specifying page_number={page_number + 1}")
+        if _is_test_non_terminal(test_id, console):
+            sim_hints.append(
+                "Test is still running — these simulations and total_simulations reflect only "
+                "what has completed so far (partial, point-in-time). Poll again with "
+                "get_test_simulations for updated results."
+            )
+
         return {
             "page_number": page_number,
             "total_pages": total_pages,
             "total_simulations": total_simulations,
             "simulations_in_page": page_simulations,
             "applied_filters": applied_filters,
-            "hint_to_agent": f"You can scan next page by specifying page_number={page_number + 1}" if page_number + 1 < total_pages else None
+            "hint_to_agent": " ".join(sim_hints) if sim_hints else None
         }
         
     except Exception as e:

--- a/safebreach_mcp_data/data_types.py
+++ b/safebreach_mcp_data/data_types.py
@@ -139,30 +139,6 @@ def _build_simulation_status_counts(final_status: Dict[str, Any]) -> List[Dict[s
     ]
 
 
-def build_simulation_status_counts_from_simulations(
-    simulations: List[Dict[str, Any]]
-) -> List[Dict[str, Any]]:
-    """
-    Build simulations_statistics from a LIVE per-simulation list (SAF-32018).
-
-    For a running test, testsummaries.finalStatus lags the live per-simulation
-    results (executionsHistoryResults). This helper tallies the live simulation
-    statuses and returns the SAME shape as ``_build_simulation_status_counts``
-    (status / explanation / count, in the same order) by delegating to it with a
-    counts dict — so explanations and ordering stay in a single source of truth.
-
-    Each simulation's ``status`` field uses the same hyphenated values as the
-    finalStatus keys (missed, stopped, prevented, detected, logged, no-result,
-    inconsistent). Matching is case-insensitive; missing/empty statuses are ignored.
-    """
-    counts: Dict[str, int] = {}
-    for simulation in simulations:
-        status = (simulation.get('status') or '').lower()
-        if status:
-            counts[status] = counts.get(status, 0) + 1
-    return _build_simulation_status_counts(counts)
-
-
 def get_reduced_test_summary_mapping(test_summary_entity):
     """
     Returns a reduced test summary entity with only the relevant fields.

--- a/safebreach_mcp_data/data_types.py
+++ b/safebreach_mcp_data/data_types.py
@@ -139,6 +139,30 @@ def _build_simulation_status_counts(final_status: Dict[str, Any]) -> List[Dict[s
     ]
 
 
+def build_simulation_status_counts_from_simulations(
+    simulations: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """
+    Build simulations_statistics from a LIVE per-simulation list (SAF-32018).
+
+    For a running test, testsummaries.finalStatus lags the live per-simulation
+    results (executionsHistoryResults). This helper tallies the live simulation
+    statuses and returns the SAME shape as ``_build_simulation_status_counts``
+    (status / explanation / count, in the same order) by delegating to it with a
+    counts dict — so explanations and ordering stay in a single source of truth.
+
+    Each simulation's ``status`` field uses the same hyphenated values as the
+    finalStatus keys (missed, stopped, prevented, detected, logged, no-result,
+    inconsistent). Matching is case-insensitive; missing/empty statuses are ignored.
+    """
+    counts: Dict[str, int] = {}
+    for simulation in simulations:
+        status = (simulation.get('status') or '').lower()
+        if status:
+            counts[status] = counts.get(status, 0) + 1
+    return _build_simulation_status_counts(counts)
+
+
 def get_reduced_test_summary_mapping(test_summary_entity):
     """
     Returns a reduced test summary entity with only the relevant fields.

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4387,3 +4387,22 @@ class TestFindingsRunningHint:
         mock_findings.return_value = [{"type": "Vuln", "name": "x"}]
         result = sb_get_test_findings_details("t1", "c", page_number=0)
         assert "still running" in (result.get("hint_to_agent") or "").lower()
+
+
+class TestSecurityEventsRunningHint:
+    """SAF-32018: security-control events listing warns when the test is still running."""
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_security_control_events_from_cache_or_api')
+    def test_running_adds_caveat(self, mock_events, mock_orch):
+        mock_events.return_value = []
+        result = sb_get_security_controls_events("t1", "sim1", "c")
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "still running" in hint
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value=None)
+    @patch('safebreach_mcp_data.data_functions._get_all_security_control_events_from_cache_or_api')
+    def test_terminal_no_caveat(self, mock_events, mock_orch):
+        mock_events.return_value = []
+        result = sb_get_security_controls_events("t1", "sim1", "c")
+        assert "still running" not in (result.get("hint_to_agent") or "").lower()

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4406,3 +4406,17 @@ class TestSecurityEventsRunningHint:
         mock_events.return_value = []
         result = sb_get_security_controls_events("t1", "sim1", "c")
         assert "still running" not in (result.get("hint_to_agent") or "").lower()
+
+
+class TestDriftRunningCaveat:
+    """SAF-32018: window-based drift tools note that in-flight tests may have incomplete drift data."""
+
+    def test_result_status_drift_summary_has_running_caveat(self):
+        from safebreach_mcp_data.data_functions import _group_and_paginate_drifts
+        res = _group_and_paginate_drifts([], 0, None, {}, 0.0, group_by="result_status")
+        assert "still running" in (res.get("hint_to_agent") or "").lower()
+
+    def test_sc_drift_summary_has_running_caveat(self):
+        from safebreach_mcp_data.data_functions import _group_and_paginate_sc_drifts
+        res = _group_and_paginate_sc_drifts([], "ctrl", 0, None, {}, 0.0)
+        assert "still running" in (res.get("hint_to_agent") or "").lower()

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4323,3 +4323,40 @@ class TestGetTestDetailsLiveCounts:
         stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
         assert stats["missed"] == 28
         assert "get_test_simulations" in (result.get("hint_to_agent") or "")
+
+
+class TestGetTestsRunningHint:
+    """SAF-32018: get_tests warns + routes to live counts when the page has a running test."""
+
+    def _test(self, test_id, status, end_time):
+        return {
+            "name": f"Plan {test_id}",
+            "test_id": test_id,
+            "start_time": 1000,
+            "end_time": end_time,
+            "duration": 600,
+            "status": status,
+            "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
+            "simulations_statistics": [{"status": "missed", "explanation": "...", "count": 1}],
+        }
+
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_running_test_in_page_adds_routing_hint(self, mock_tests):
+        mock_tests.return_value = [
+            self._test("t1", "running", 2000),
+            self._test("t2", "completed", 1000),
+        ]
+        result = sb_get_tests(console="c")
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "may lag" in hint
+        assert "get_test_details" in hint
+
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_all_terminal_no_lag_hint(self, mock_tests):
+        mock_tests.return_value = [
+            self._test("t1", "completed", 2000),
+            self._test("t2", "canceled", 1000),
+        ]
+        result = sb_get_tests(console="c")
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "may lag" not in hint

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -6,7 +6,6 @@ This module tests the data functions that handle test and simulation operations.
 
 import copy
 import logging
-import os
 
 import pytest
 import json
@@ -4222,18 +4221,16 @@ class TestSimulationLogsEntryPoints:
         mock_core.assert_not_called()
 
 
-class TestGetTestDetailsLiveCounts:
-    """SAF-32018: get_test_details returns LIVE counts for non-terminal tests.
-
-    For a running test, simulations_statistics must reflect the live
-    executionsHistoryResults source (what the UI shows), not the lagging
-    testsummaries.finalStatus aggregate. Terminal tests keep the cheap aggregate.
-    A soft size cap falls back to the aggregate + a routing hint.
+class TestGetTestDetailsRunningCounts:
+    """SAF-32018: for a NON-TERMINAL test, get_test_details refreshes counts from the FRESH
+    single-test endpoint (testsummaries/{id}), defeating the stale cached finalStatus that
+    caused the bug. It adds a point-in-time hint and does NOT page executionsHistoryResults.
+    Terminal tests are unchanged.
     """
 
     @staticmethod
-    def _aggregate_stats(missed=0, stopped=0, prevented=0, detected=0,
-                         logged=0, no_result=0, inconsistent=0):
+    def _stats(missed=0, stopped=0, prevented=0, detected=0,
+               logged=0, no_result=0, inconsistent=0):
         return [
             {"status": "missed", "explanation": "...", "count": missed},
             {"status": "stopped", "explanation": "...", "count": stopped},
@@ -4244,7 +4241,7 @@ class TestGetTestDetailsLiveCounts:
             {"status": "inconsistent", "explanation": "...", "count": inconsistent},
         ]
 
-    def _running_test(self, missed_aggregate):
+    def _cached_running(self, missed_stale):
         return [{
             "name": "Running Plan",
             "test_id": "run1",
@@ -4253,77 +4250,72 @@ class TestGetTestDetailsLiveCounts:
             "duration": 600,
             "status": "running",
             "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
-            "simulations_statistics": self._aggregate_stats(missed=missed_aggregate),
+            "simulations_statistics": self._stats(missed=missed_stale),
         }]
 
     @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
     @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._fetch_single_test')
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
-    def test_running_test_uses_live_counts(self, mock_tests, mock_sims, mock_orch):
-        """REPRODUCTION: aggregate says 28 missed, live says 80 -> result is 80."""
-        mock_tests.return_value = self._running_test(missed_aggregate=28)
-        mock_sims.return_value = [{"status": "missed"}] * 80 + [{"status": "prevented"}] * 5
-
+    def test_running_refreshes_counts_from_single_endpoint(self, mock_tests, mock_single, mock_sims, mock_orch):
+        """REPRODUCTION: cached/stale aggregate says 28 missed; fresh single-test says 80 -> 80.
+        And NO expensive executionsHistoryResults paging happens."""
+        mock_tests.return_value = self._cached_running(missed_stale=28)
+        mock_single.return_value = {
+            "status": "running",
+            "end_time": 1640995800,
+            "simulations_statistics": self._stats(missed=80, prevented=5),
+        }
         result = sb_get_test_details("run1", "test-console")
-
         stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
         assert stats["missed"] == 80
         assert stats["prevented"] == 5
-        mock_sims.assert_called_once()
+        mock_single.assert_called_once()   # fresh single-test fetch used
+        mock_sims.assert_not_called()      # NO per-simulation paging
 
     @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
-    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._fetch_single_test')
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
-    def test_running_test_live_hint(self, mock_tests, mock_sims, mock_orch):
-        """Non-terminal still emits a poll-again hint after live recount."""
-        mock_tests.return_value = self._running_test(missed_aggregate=28)
-        mock_sims.return_value = [{"status": "missed"}] * 80
+    def test_running_point_in_time_hint(self, mock_tests, mock_single, mock_orch):
+        mock_tests.return_value = self._cached_running(missed_stale=28)
+        mock_single.return_value = {
+            "status": "running", "end_time": 1,
+            "simulations_statistics": self._stats(missed=80),
+        }
         result = sb_get_test_details("run1", "test-console")
-        assert "hint_to_agent" in result and result["hint_to_agent"]
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "point-in-time" in hint
+        assert "get_test_simulations" in hint
 
     @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._fetch_single_test')
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
-    def test_terminal_test_keeps_aggregate(self, mock_tests, mock_sims):
-        """Completed test: aggregate kept, live source NEVER fetched."""
+    def test_terminal_keeps_aggregate_no_refresh(self, mock_tests, mock_single, mock_sims):
+        """Completed test: counts unchanged; no refresh, no paging."""
         mock_tests.return_value = [{
             "name": "Done Plan",
             "test_id": "done1",
-            "start_time": 1640995200,
-            "end_time": 1640995800,
-            "duration": 600,
+            "start_time": 1, "end_time": 2, "duration": 1,
             "status": "completed",
             "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
-            "simulations_statistics": self._aggregate_stats(missed=28),
+            "simulations_statistics": self._stats(missed=28),
         }]
         result = sb_get_test_details("done1", "test-console")
         stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
         assert stats["missed"] == 28
-        mock_sims.assert_not_called()
-
-    @patch('safebreach_mcp_data.data_functions.LIVE_RECOUNT_MAX_SIMULATIONS', 100)
-    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
-    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
-    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
-    def test_over_soft_cap_falls_back_to_aggregate_with_hint(self, mock_tests, mock_sims, mock_orch):
-        """Over the soft cap: keep aggregate, do NOT fetch live, emit routing hint."""
-        mock_tests.return_value = self._running_test(missed_aggregate=6000)  # > cap (100)
-        result = sb_get_test_details("run1", "test-console")
-        stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
-        assert stats["missed"] == 6000
-        mock_sims.assert_not_called()
-        assert "get_test_simulations" in (result.get("hint_to_agent") or "")
+        mock_single.assert_not_called()   # no refresh for a terminal test
+        mock_sims.assert_not_called()     # never pages executionsHistoryResults
 
     @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
-    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api',
-           side_effect=Exception("API down"))
+    @patch('safebreach_mcp_data.data_functions._fetch_single_test', side_effect=Exception("API down"))
     @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
-    def test_live_fetch_failure_falls_back_to_aggregate(self, mock_tests, mock_sims, mock_orch):
-        """Live fetch error: degrade to aggregate + routing hint, never raise."""
-        mock_tests.return_value = self._running_test(missed_aggregate=28)
+    def test_refresh_failure_falls_back_to_cached(self, mock_tests, mock_single, mock_orch):
+        """Single-test refresh error: keep cached counts, never raise, still hint."""
+        mock_tests.return_value = self._cached_running(missed_stale=28)
         result = sb_get_test_details("run1", "test-console")
         stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
         assert stats["missed"] == 28
-        assert "get_test_simulations" in (result.get("hint_to_agent") or "")
+        assert result.get("hint_to_agent")
 
 
 class TestGetTestsRunningHint:
@@ -4421,26 +4413,6 @@ class TestDriftRunningCaveat:
         from safebreach_mcp_data.data_functions import _group_and_paginate_sc_drifts
         res = _group_and_paginate_sc_drifts([], "ctrl", 0, None, {}, 0.0)
         assert "still running" in (res.get("hint_to_agent") or "").lower()
-
-
-class TestLiveRecountCapConfig:
-    """SAF-32018 Phase 8: soft-cap threshold is env-configurable with safe fallback."""
-
-    def test_env_override(self):
-        from safebreach_mcp_data.data_functions import _get_live_recount_cap
-        with patch.dict('os.environ', {'SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS': '50'}):
-            assert _get_live_recount_cap() == 50
-
-    def test_default_when_unset(self):
-        import safebreach_mcp_data.data_functions as m
-        with patch.dict('os.environ', {}, clear=False):
-            os.environ.pop('SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS', None)
-            assert m._get_live_recount_cap() == m.LIVE_RECOUNT_MAX_SIMULATIONS
-
-    def test_invalid_env_falls_back_to_default(self):
-        import safebreach_mcp_data.data_functions as m
-        with patch.dict('os.environ', {'SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS': 'notanint'}):
-            assert m._get_live_recount_cap() == m.LIVE_RECOUNT_MAX_SIMULATIONS
 
 
 class TestGetTestSimulationsRunningHint:

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4360,3 +4360,30 @@ class TestGetTestsRunningHint:
         result = sb_get_tests(console="c")
         hint = (result.get("hint_to_agent") or "").lower()
         assert "may lag" not in hint
+
+
+class TestFindingsRunningHint:
+    """SAF-32018: findings tools warn when the test is still running (findings still indexing)."""
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_findings_from_cache_or_api')
+    def test_counts_running_adds_hint(self, mock_findings, mock_orch):
+        mock_findings.return_value = [{"type": "Vuln"}, {"type": "Vuln"}]
+        result = sb_get_test_findings_counts("t1", "c")
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "still running" in hint
+        assert "finding" in hint
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value=None)
+    @patch('safebreach_mcp_data.data_functions._get_all_findings_from_cache_or_api')
+    def test_counts_terminal_no_hint(self, mock_findings, mock_orch):
+        mock_findings.return_value = [{"type": "Vuln"}]
+        result = sb_get_test_findings_counts("t1", "c")
+        assert "still running" not in (result.get("hint_to_agent") or "").lower()
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_findings_from_cache_or_api')
+    def test_details_running_adds_hint(self, mock_findings, mock_orch):
+        mock_findings.return_value = [{"type": "Vuln", "name": "x"}]
+        result = sb_get_test_findings_details("t1", "c", page_number=0)
+        assert "still running" in (result.get("hint_to_agent") or "").lower()

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -6,6 +6,7 @@ This module tests the data functions that handle test and simulation operations.
 
 import copy
 import logging
+import os
 
 import pytest
 import json
@@ -4420,3 +4421,23 @@ class TestDriftRunningCaveat:
         from safebreach_mcp_data.data_functions import _group_and_paginate_sc_drifts
         res = _group_and_paginate_sc_drifts([], "ctrl", 0, None, {}, 0.0)
         assert "still running" in (res.get("hint_to_agent") or "").lower()
+
+
+class TestLiveRecountCapConfig:
+    """SAF-32018 Phase 8: soft-cap threshold is env-configurable with safe fallback."""
+
+    def test_env_override(self):
+        from safebreach_mcp_data.data_functions import _get_live_recount_cap
+        with patch.dict('os.environ', {'SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS': '50'}):
+            assert _get_live_recount_cap() == 50
+
+    def test_default_when_unset(self):
+        import safebreach_mcp_data.data_functions as m
+        with patch.dict('os.environ', {}, clear=False):
+            os.environ.pop('SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS', None)
+            assert m._get_live_recount_cap() == m.LIVE_RECOUNT_MAX_SIMULATIONS
+
+    def test_invalid_env_falls_back_to_default(self):
+        import safebreach_mcp_data.data_functions as m
+        with patch.dict('os.environ', {'SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS': 'notanint'}):
+            assert m._get_live_recount_cap() == m.LIVE_RECOUNT_MAX_SIMULATIONS

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4441,3 +4441,23 @@ class TestLiveRecountCapConfig:
         import safebreach_mcp_data.data_functions as m
         with patch.dict('os.environ', {'SAFEBREACH_MCP_LIVE_RECOUNT_MAX_SIMULATIONS': 'notanint'}):
             assert m._get_live_recount_cap() == m.LIVE_RECOUNT_MAX_SIMULATIONS
+
+
+class TestGetTestSimulationsRunningHint:
+    """SAF-32018: get_test_simulations flags that results are partial/point-in-time while running."""
+
+    @patch('safebreach_mcp_data.data_functions._is_test_non_terminal', return_value=True)
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    def test_running_adds_partial_hint(self, mock_sims, mock_nonterminal):
+        mock_sims.return_value = [{"status": "missed", "simulation_id": "s1"}]
+        result = sb_get_test_simulations("t1", "c", page_number=0)
+        hint = (result.get("hint_to_agent") or "").lower()
+        assert "still running" in hint
+        assert "partial" in hint or "point-in-time" in hint
+
+    @patch('safebreach_mcp_data.data_functions._is_test_non_terminal', return_value=False)
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    def test_terminal_no_partial_hint(self, mock_sims, mock_nonterminal):
+        mock_sims.return_value = [{"status": "missed", "simulation_id": "s1"}]
+        result = sb_get_test_simulations("t1", "c", page_number=0)
+        assert "still running" not in (result.get("hint_to_agent") or "").lower()

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4219,3 +4219,107 @@ class TestSimulationLogsEntryPoints:
         with pytest.raises(ValueError, match="page_size|1000"):
             sb_search_simulation_logs(simulation_ids='a', page_size=5000, console='c')
         mock_core.assert_not_called()
+
+
+class TestGetTestDetailsLiveCounts:
+    """SAF-32018: get_test_details returns LIVE counts for non-terminal tests.
+
+    For a running test, simulations_statistics must reflect the live
+    executionsHistoryResults source (what the UI shows), not the lagging
+    testsummaries.finalStatus aggregate. Terminal tests keep the cheap aggregate.
+    A soft size cap falls back to the aggregate + a routing hint.
+    """
+
+    @staticmethod
+    def _aggregate_stats(missed=0, stopped=0, prevented=0, detected=0,
+                         logged=0, no_result=0, inconsistent=0):
+        return [
+            {"status": "missed", "explanation": "...", "count": missed},
+            {"status": "stopped", "explanation": "...", "count": stopped},
+            {"status": "prevented", "explanation": "...", "count": prevented},
+            {"status": "detected", "explanation": "...", "count": detected},
+            {"status": "logged", "explanation": "...", "count": logged},
+            {"status": "no-result", "explanation": "...", "count": no_result},
+            {"status": "inconsistent", "explanation": "...", "count": inconsistent},
+        ]
+
+    def _running_test(self, missed_aggregate):
+        return [{
+            "name": "Running Plan",
+            "test_id": "run1",
+            "start_time": 1640995200,
+            "end_time": 1640995800,
+            "duration": 600,
+            "status": "running",
+            "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
+            "simulations_statistics": self._aggregate_stats(missed=missed_aggregate),
+        }]
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_running_test_uses_live_counts(self, mock_tests, mock_sims, mock_orch):
+        """REPRODUCTION: aggregate says 28 missed, live says 80 -> result is 80."""
+        mock_tests.return_value = self._running_test(missed_aggregate=28)
+        mock_sims.return_value = [{"status": "missed"}] * 80 + [{"status": "prevented"}] * 5
+
+        result = sb_get_test_details("run1", "test-console")
+
+        stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
+        assert stats["missed"] == 80
+        assert stats["prevented"] == 5
+        mock_sims.assert_called_once()
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_running_test_live_hint(self, mock_tests, mock_sims, mock_orch):
+        """Non-terminal still emits a poll-again hint after live recount."""
+        mock_tests.return_value = self._running_test(missed_aggregate=28)
+        mock_sims.return_value = [{"status": "missed"}] * 80
+        result = sb_get_test_details("run1", "test-console")
+        assert "hint_to_agent" in result and result["hint_to_agent"]
+
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_terminal_test_keeps_aggregate(self, mock_tests, mock_sims):
+        """Completed test: aggregate kept, live source NEVER fetched."""
+        mock_tests.return_value = [{
+            "name": "Done Plan",
+            "test_id": "done1",
+            "start_time": 1640995200,
+            "end_time": 1640995800,
+            "duration": 600,
+            "status": "completed",
+            "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
+            "simulations_statistics": self._aggregate_stats(missed=28),
+        }]
+        result = sb_get_test_details("done1", "test-console")
+        stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
+        assert stats["missed"] == 28
+        mock_sims.assert_not_called()
+
+    @patch('safebreach_mcp_data.data_functions.LIVE_RECOUNT_MAX_SIMULATIONS', 100)
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_over_soft_cap_falls_back_to_aggregate_with_hint(self, mock_tests, mock_sims, mock_orch):
+        """Over the soft cap: keep aggregate, do NOT fetch live, emit routing hint."""
+        mock_tests.return_value = self._running_test(missed_aggregate=6000)  # > cap (100)
+        result = sb_get_test_details("run1", "test-console")
+        stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
+        assert stats["missed"] == 6000
+        mock_sims.assert_not_called()
+        assert "get_test_simulations" in (result.get("hint_to_agent") or "")
+
+    @patch('safebreach_mcp_core.queue_state.get_orchestrator_test_state', return_value="RUNNING")
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api',
+           side_effect=Exception("API down"))
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_live_fetch_failure_falls_back_to_aggregate(self, mock_tests, mock_sims, mock_orch):
+        """Live fetch error: degrade to aggregate + routing hint, never raise."""
+        mock_tests.return_value = self._running_test(missed_aggregate=28)
+        result = sb_get_test_details("run1", "test-console")
+        stats = {s["status"]: s["count"] for s in result["simulations_statistics"]}
+        assert stats["missed"] == 28
+        assert "get_test_simulations" in (result.get("hint_to_agent") or "")

--- a/safebreach_mcp_data/tests/test_data_types.py
+++ b/safebreach_mcp_data/tests/test_data_types.py
@@ -21,7 +21,6 @@ from safebreach_mcp_data.data_types import (
     _build_node_data,
     build_simulation_steps_by_node,
     get_reduced_peer_benchmark_response,
-    build_simulation_status_counts_from_simulations,
 )
 
 
@@ -1294,56 +1293,3 @@ class TestBuildSimulationStepsByNode:
         assert build_simulation_steps_by_node({}) == []
         assert build_simulation_steps_by_node({"dataObj": {"data": [[]]}}) == []
         assert build_simulation_steps_by_node({"dataObj": {"data": []}}) == []
-
-class TestLiveSimulationStatusCounts:
-    """Tests for build_simulation_status_counts_from_simulations (SAF-32018).
-
-    Builds simulations_statistics from the LIVE per-simulation list
-    (executionsHistoryResults) instead of the lagging testsummaries.finalStatus
-    aggregate. Same output shape as _build_simulation_status_counts.
-    """
-
-    def test_counts_live_simulations_by_status(self):
-        sims = (
-            [{"status": "missed"}] * 80
-            + [{"status": "prevented"}] * 5
-            + [{"status": "detected"}] * 2
-            + [{"status": "no-result"}] * 1
-        )
-        stats = build_simulation_status_counts_from_simulations(sims)
-        assert len(stats) == 7
-        by_status = {s["status"]: s["count"] for s in stats}
-        assert by_status["missed"] == 80
-        assert by_status["prevented"] == 5
-        assert by_status["detected"] == 2
-        assert by_status["no-result"] == 1
-        assert by_status["stopped"] == 0
-        assert by_status["logged"] == 0
-        assert by_status["inconsistent"] == 0
-
-    def test_empty_list_all_zeros(self):
-        stats = build_simulation_status_counts_from_simulations([])
-        assert len(stats) == 7
-        for s in stats:
-            assert s["count"] == 0
-
-    def test_same_shape_as_aggregate_helper(self):
-        """Output structure (keys, status set, order) must match the aggregate helper."""
-        from safebreach_mcp_data.data_types import _build_simulation_status_counts
-        live = build_simulation_status_counts_from_simulations([{"status": "missed"}])
-        agg = _build_simulation_status_counts({"missed": 1})
-        assert [s["status"] for s in live] == [s["status"] for s in agg]
-        for s in live:
-            assert set(s.keys()) == {"status", "explanation", "count"}
-
-    def test_status_matching_is_case_insensitive(self):
-        sims = [{"status": "MISSED"}, {"status": "Missed"}, {"status": "missed"}]
-        stats = build_simulation_status_counts_from_simulations(sims)
-        by_status = {s["status"]: s["count"] for s in stats}
-        assert by_status["missed"] == 3
-
-    def test_missing_or_empty_status_ignored(self):
-        sims = [{"status": "missed"}, {"status": ""}, {}, {"status": None}]
-        stats = build_simulation_status_counts_from_simulations(sims)
-        by_status = {s["status"]: s["count"] for s in stats}
-        assert by_status["missed"] == 1

--- a/safebreach_mcp_data/tests/test_data_types.py
+++ b/safebreach_mcp_data/tests/test_data_types.py
@@ -21,6 +21,7 @@ from safebreach_mcp_data.data_types import (
     _build_node_data,
     build_simulation_steps_by_node,
     get_reduced_peer_benchmark_response,
+    build_simulation_status_counts_from_simulations,
 )
 
 
@@ -1293,3 +1294,56 @@ class TestBuildSimulationStepsByNode:
         assert build_simulation_steps_by_node({}) == []
         assert build_simulation_steps_by_node({"dataObj": {"data": [[]]}}) == []
         assert build_simulation_steps_by_node({"dataObj": {"data": []}}) == []
+
+class TestLiveSimulationStatusCounts:
+    """Tests for build_simulation_status_counts_from_simulations (SAF-32018).
+
+    Builds simulations_statistics from the LIVE per-simulation list
+    (executionsHistoryResults) instead of the lagging testsummaries.finalStatus
+    aggregate. Same output shape as _build_simulation_status_counts.
+    """
+
+    def test_counts_live_simulations_by_status(self):
+        sims = (
+            [{"status": "missed"}] * 80
+            + [{"status": "prevented"}] * 5
+            + [{"status": "detected"}] * 2
+            + [{"status": "no-result"}] * 1
+        )
+        stats = build_simulation_status_counts_from_simulations(sims)
+        assert len(stats) == 7
+        by_status = {s["status"]: s["count"] for s in stats}
+        assert by_status["missed"] == 80
+        assert by_status["prevented"] == 5
+        assert by_status["detected"] == 2
+        assert by_status["no-result"] == 1
+        assert by_status["stopped"] == 0
+        assert by_status["logged"] == 0
+        assert by_status["inconsistent"] == 0
+
+    def test_empty_list_all_zeros(self):
+        stats = build_simulation_status_counts_from_simulations([])
+        assert len(stats) == 7
+        for s in stats:
+            assert s["count"] == 0
+
+    def test_same_shape_as_aggregate_helper(self):
+        """Output structure (keys, status set, order) must match the aggregate helper."""
+        from safebreach_mcp_data.data_types import _build_simulation_status_counts
+        live = build_simulation_status_counts_from_simulations([{"status": "missed"}])
+        agg = _build_simulation_status_counts({"missed": 1})
+        assert [s["status"] for s in live] == [s["status"] for s in agg]
+        for s in live:
+            assert set(s.keys()) == {"status", "explanation", "count"}
+
+    def test_status_matching_is_case_insensitive(self):
+        sims = [{"status": "MISSED"}, {"status": "Missed"}, {"status": "missed"}]
+        stats = build_simulation_status_counts_from_simulations(sims)
+        by_status = {s["status"]: s["count"] for s in stats}
+        assert by_status["missed"] == 3
+
+    def test_missing_or_empty_status_ignored(self):
+        sims = [{"status": "missed"}, {"status": ""}, {}, {"status": None}]
+        stats = build_simulation_status_counts_from_simulations(sims)
+        by_status = {s["status"]: s["count"] for s in stats}
+        assert by_status["missed"] == 1

--- a/safebreach_mcp_data/tests/test_e2e.py
+++ b/safebreach_mcp_data/tests/test_e2e.py
@@ -447,103 +447,93 @@ class TestDataServerE2E:
 
     @pytest.mark.e2e
     def test_get_test_drifts_e2e(self, e2e_console):
-        """Test getting real test drift analysis using known test data.
+        """Drift analysis E2E — self-discovering to avoid hardcoded-ID rot.
 
-        This test uses test ID 1771148836322.15 (test name: "BAS Scheduled Scenario (45~ simulations)")
-        which has drift patterns when compared to its previous test with the same name
-        (baseline test ID: 1770996600455.119):
-
-        Actual drift analysis results:
-        - detected-logged: 1 simulation (negative impact)
-        - logged-inconsistent: 1 simulation (negative impact)
-        Total: 2 drifts (2 status changes + 0 exclusive simulations)
+        Previously this test pinned a specific test ID and baseline pair, which
+        decayed as the shared environment churned (the baseline test eventually
+        no longer existed/matched), requiring repeated patching. Instead, this
+        version discovers a test name that has >=2 completed runs on the console
+        at runtime (so a baseline necessarily exists), runs sb_get_test_drifts on
+        the run with the latest start_time, and asserts the response is
+        well-formed. It does NOT assert exact drift counts (data-dependent). If
+        the environment has no test name with two runs, it skips.
         """
-        # Use specific test ID that has known drift patterns
-        test_id = "1771148836322.15"
+        # Discover a test name with >=2 completed runs by scanning pages.
+        name_to_tests: dict = {}
+        target_name = None
+        for page in range(30):
+            page_res = sb_get_tests(
+                console=e2e_console,
+                page_number=page,
+                status_filter="completed",
+                order_by="end_time",
+                order_direction="desc",
+            )
+            tests = page_res.get("tests_in_page", [])
+            if not tests:
+                break
+            for t in tests:
+                name = t.get("name")
+                if not name:
+                    continue
+                name_to_tests.setdefault(name, []).append(t)
+                if target_name is None and len(name_to_tests[name]) >= 2:
+                    target_name = name
+            if target_name is not None:
+                break
+            if page + 1 >= page_res.get("total_pages", 0):
+                break
 
-        result = sb_get_test_drifts(test_id, console=e2e_console)
+        if target_name is None:
+            pytest.skip(
+                "No test name with >=2 completed runs on this console — "
+                "cannot exercise drift baseline comparison."
+            )
 
-        # Verify response structure
+        # Pick the run with the latest start_time so an earlier run (baseline)
+        # exists strictly before it.
+        runs = sorted(name_to_tests[target_name], key=lambda t: t.get("start_time") or 0)
+        current = runs[-1]
+        current_test_id = current["test_id"]
+
+        result = sb_get_test_drifts(current_test_id, console=e2e_console)
+
+        # Structure assertions only — no hardcoded counts.
         assert isinstance(result, dict)
-        assert 'total_drifts' in result
-        assert 'drifts' in result
-        assert '_metadata' in result
-        assert isinstance(result['drifts'], dict)
+        assert "error" not in result, (
+            f"Drift analysis errored for a discovered baseline pair "
+            f"(name={target_name!r}, current={current_test_id}): {result.get('error')}"
+        )
+        assert isinstance(result.get("total_drifts"), int)
+        assert isinstance(result.get("drifts"), dict)
+        assert "_metadata" in result
 
-        # Verify metadata contains expected fields
-        metadata = result['_metadata']
-        assert metadata['console'] == e2e_console
-        assert metadata['current_test_id'] == test_id
-        assert 'baseline_test_id' in metadata
-        assert 'test_name' in metadata
-        assert 'baseline_simulations_count' in metadata
-        assert 'current_simulations_count' in metadata
-        assert 'analyzed_at' in metadata
+        metadata = result["_metadata"]
+        assert metadata["console"] == e2e_console
+        assert metadata["current_test_id"] == current_test_id
+        assert metadata["test_name"] == target_name
+        assert "baseline_test_id" in metadata
+        assert isinstance(metadata.get("baseline_simulations_count"), int)
+        assert isinstance(metadata.get("current_simulations_count"), int)
+        assert "analyzed_at" in metadata
 
-        # Verify expected metadata values based on actual data
-        assert metadata['baseline_test_id'] == "1770996600455.119"
-        assert metadata['test_name'] == "BAS Scheduled Scenario (45~ simulations)"
-        assert metadata['current_simulations_count'] == 95
-        assert metadata['baseline_simulations_count'] == 95
-        assert metadata['shared_drift_codes'] == 95
-        assert metadata['status_drifts'] == 2
-        assert len(metadata['simulations_exclusive_to_baseline']) == 0
-        assert len(metadata['simulations_exclusive_to_current']) == 0
+        # Each drift entry is well-formed; security impacts come from the valid set.
+        valid_impacts = {"positive", "negative", "neutral", "unknown"}
+        for drift_type, drift_info in result["drifts"].items():
+            assert "drift_type" in drift_info
+            assert "security_impact" in drift_info
+            assert drift_info["security_impact"] in valid_impacts
+            assert "drifted_simulations" in drift_info
+            for drifted_sim in drift_info["drifted_simulations"]:
+                assert "drift_tracking_code" in drifted_sim
+                assert "former_simulation_id" in drifted_sim
+                assert "current_simulation_id" in drifted_sim
 
-        # Verify we have the expected total number of drifts
-        total_drifts = result['total_drifts']
-        assert total_drifts == 2, f"Expected exactly 2 drifts, got {total_drifts}"
-
-        # Count drift types to verify expected patterns
-        drift_type_counts = {}
-        for drift_type, drift_info in result['drifts'].items():
-            assert 'drift_type' in drift_info
-            assert 'security_impact' in drift_info
-            assert 'drifted_simulations' in drift_info
-
-            # Count simulations for this drift type
-            drift_type_counts[drift_type] = len(drift_info['drifted_simulations'])
-
-            # Verify each drifted simulation has required fields
-            for drifted_sim in drift_info['drifted_simulations']:
-                assert 'drift_tracking_code' in drifted_sim
-                assert 'former_simulation_id' in drifted_sim
-                assert 'current_simulation_id' in drifted_sim
-
-        # Verify the expected drift patterns exist with expected counts
-        expected_drift_counts = {
-            'detected-logged': 1,        # Negative impact: detected → logged
-            'logged-inconsistent': 1,    # Negative impact: logged → inconsistent
-        }
-
-        # Verify all expected drift patterns are present with exact counts
-        found_patterns = set(drift_type_counts.keys())
-        expected_patterns = set(expected_drift_counts.keys())
-
-        assert found_patterns == expected_patterns, \
-            f"Expected patterns {expected_patterns}, found {found_patterns}. " \
-            f"Missing: {expected_patterns - found_patterns}, Extra: {found_patterns - expected_patterns}"
-
-        # Verify exact counts for each drift type
-        for drift_type, expected_count in expected_drift_counts.items():
-            actual_count = drift_type_counts[drift_type]
-            assert actual_count == expected_count, \
-                f"Expected {expected_count} simulations for {drift_type}, got {actual_count}"
-
-        # Verify security impact classification exists and is valid
-        security_impacts = {drift['security_impact'] for drift in result['drifts'].values()}
-        valid_impacts = {'positive', 'negative', 'neutral', 'unknown'}
-        assert security_impacts.issubset(valid_impacts), \
-            f"Invalid security impacts found: {security_impacts - valid_impacts}"
-
-        # Log results for debugging
-        print(f"\n=== E2E Drift Analysis Results ===")
-        print(f"Total drifts found: {total_drifts}")
-        print(f"Drift type counts: {drift_type_counts}")
-        print(f"Security impacts: {security_impacts}")
-        print(f"Baseline test: {metadata.get('baseline_test_id', 'Unknown')}")
-        print(f"Test name: {metadata.get('test_name', 'Unknown')}")
-        print(f"==================================\n")
+        print("\n=== E2E Drift Analysis (discovered) ===")
+        print(f"Test name: {target_name}")
+        print(f"Current test: {current_test_id}, baseline: {metadata.get('baseline_test_id')}")
+        print(f"Total drifts: {result['total_drifts']}")
+        print("========================================\n")
 
     @pytest.mark.e2e
     def test_get_full_simulation_logs_e2e(self, e2e_console, sample_simulation_id):

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -1535,6 +1535,11 @@ def sb_get_studio_attack_latest_result(
                     check_rbac_response(summary_response)
                     summary_data = summary_response.json()
 
+                    # SAF-32018: test_overview is a coarse status-tracker for this custom
+                    # attack's run, so we keep the cheap test-level finalStatus aggregate here.
+                    # For a RUNNING test this aggregate lags the live per-simulation results;
+                    # the non-terminal hint below routes the agent to get_test_details (which
+                    # returns live counts for running tests) for the exact numbers.
                     final_status = summary_data.get('finalStatus', {})
                     simulation_status_counts = [
                         {"status": status, "count": final_status.get(status, 0)}
@@ -1558,9 +1563,12 @@ def sb_get_studio_attack_latest_result(
                         test_overview['hint_to_agent'] = (
                             f"Test is still {test_overview['status']} "
                             f"({total_found} of {total_simulations} simulations completed so far). "
-                            f"Poll this tool again in 30 seconds, or use "
-                            f"get_test_details(test_id='{resolved_test_id}', console='{console}') "
-                            f"from the Data Server for detailed status."
+                            f"These simulation_status_counts come from a periodically-updated "
+                            f"summary and may lag the live results while the test runs. For exact "
+                            f"live counts, call get_test_details(test_id='{resolved_test_id}', "
+                            f"console='{console}') on the Data Server (it returns live counts for "
+                            f"running tests), or get_test_simulations with a status_filter. "
+                            f"Poll this tool again in ~30 seconds for updated totals."
                         )
                 except Exception as e:
                     logger.warning(f"Failed to fetch test summary for test_id '{resolved_test_id}': {e}")

--- a/safebreach_mcp_studio/tests/test_e2e_run_scenario.py
+++ b/safebreach_mcp_studio/tests/test_e2e_run_scenario.py
@@ -155,16 +155,21 @@ class TestRunScenarioE2E:
         ready_plans = [p for p in plans if compute_scenario_readiness(p)]
         assert len(ready_plans) > 0, f"No ready custom plan on {E2E_CONSOLE}"
 
-        # Pick a plan with enough predicted sims
+        # Pick a plan with enough predicted sims AND no empty step. The real run below uses
+        # allow_partial_steps=False, so a plan with any 0-sim step (e.g. an AI-generated email
+        # step whose attacks are constrained out on the current fleet — root/proxy/package
+        # requirements) would be correctly refused by run_scenario. Structural readiness
+        # (compute_scenario_readiness) is not enough — require every step to actually predict
+        # simulations on this environment.
         ready_plan = None
         for p in ready_plans:
             dry = sb_run_scenario(scenario_id=str(p['id']),
                                  console=E2E_CONSOLE, dry_run=True)
-            if dry.get('predicted_simulations', 0) >= 20:
+            if dry.get('predicted_simulations', 0) >= 20 and not dry.get('empty_steps'):
                 ready_plan = p
                 break
         if ready_plan is None:
-            pytest.skip("No ready custom plan with >=20 predicted sims")
+            pytest.skip("No ready custom plan with >=20 predicted sims and no empty steps")
 
         test_id = None
         passed = False

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -2245,6 +2245,41 @@ class TestGetStudioAttackLatestResult:
     @patch('safebreach_mcp_studio.studio_functions.requests.post')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
+    def test_get_latest_result_running_hint_routes_to_live_counts(
+        self,
+        mock_get_base_url,
+        mock_get_account_id,
+        mock_post,
+        mock_get,
+        mock_execution_result_response,
+        mock_test_summary_running_response
+    ):
+        """SAF-32018: running test_overview counts come from the lagging finalStatus
+        aggregate, so the hint must route the agent to the live source
+        (get_test_details / get_test_simulations) and flag that counts may lag."""
+        mock_get_base_url.return_value = "https://demo.safebreach.com"
+        mock_get_account_id.return_value = "1234567890"
+
+        mock_post_response = Mock()
+        mock_post_response.json.return_value = mock_execution_result_response
+        mock_post_response.status_code = 200
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = mock_test_summary_running_response
+        mock_get_response.status_code = 200
+        mock_get.return_value = mock_get_response
+
+        result = sb_get_studio_attack_latest_result(attack_id=10000291, console="demo")
+
+        hint = result['test_overview']['hint_to_agent']
+        assert 'may lag' in hint.lower()
+        assert 'get_test_details' in hint
+
+    @patch('safebreach_mcp_studio.studio_functions.requests.get')
+    @patch('safebreach_mcp_studio.studio_functions.requests.post')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
+    @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
     def test_get_latest_result_test_overview_completed(
         self,
         mock_get_base_url,


### PR DESCRIPTION
## Summary
Fixes [SAF-32018](https://safebreach.atlassian.net/browse/SAF-32018): while a test is **still running**, the HELM agent reported a **stale "Missed" count** (e.g. 28) that lagged the live UI (e.g. 80), reconciling only after the test finished.

## Root cause (in-MCP staleness — not upstream lag)
`get_test_details` built its counts on the running-test path from a **stale source**, in two layers:
1. counts were read from the **cached test list** (`tests_cache`, ≤30-min TTL), and
2. the SAF-31111 running-test refresh updated only the **status**, never the **counts**.

So the agent could serve a counts snapshot up to 30 minutes old while the UI showed live numbers. A **fresh** `finalStatus` (single-test `testsummaries/{id}` call) tracks the UI's live aggregation (`executionsHistoryResults.total` / `executionsHistorySuggestions`, verified in `ui-react`) to **within ~1 simulation** — so the upstream aggregate is *not* the problem.

> Note: an earlier revision of this branch chased an "upstream finalStatus lag" theory and paged `executionsHistoryResults` (soft-capped at 5000). Controlled back-to-back measurement disproved it — the apparent "lag" was an artifact of that call's own multi-second paging window. That approach was reverted; see the PRD change log.

## The fix
- **`get_test_details` (non-terminal):** refresh `simulations_statistics` from the **fresh `testsummaries/{id}` call** (one cheap request — defeats the stale cache + the never-refreshed counts) and add a **point-in-time hint** routing to `get_test_simulations` for the live filtered grid. No per-simulation paging, no soft cap.
- **Cheap running-test hints elsewhere (non-terminal):** `get_tests`, findings tools, security-control events, drift tools, and `get_test_simulations` (its `total_simulations` is partial/point-in-time while running) carry a caveat. Findings/SIEM/drift have no live source, so the hint is "may be incomplete — re-query after completion".
- **Studio `test_overview`:** keeps its (correctly test-scoped) `finalStatus` aggregate + a hint routing to `get_test_details`; kept self-contained (no cross-server coupling).

## Key changes
- `safebreach_mcp_data/data_functions.py`: fresh-single-test refresh for non-terminal `get_test_details`; `_is_test_non_terminal` helper; running-test hints across `get_tests`, findings, security events, drift tools, `get_test_simulations`.
- `safebreach_mcp_studio/studio_functions.py`: `test_overview` routing hint.
- `CLAUDE.md` + PRD: corrected RCA + behavior.

## Testing
- TDD throughout, incl. a regression test (stale cached `missed=28` → fresh `missed=80`) and a live sanity check on a running test (fresh counts, point-in-time hint, **no** paging).
- **Unit: 1342 passing** across all servers (dead-symbol grep confirms no `executionsHistoryResults`-recount machinery remains).
- **E2E (pentest01): 107 passing, 5 skipped, 0 failing.**
- Three green-tree test fixes also included: stale `SafeBreachAuth` patch in `test_disable_filtering` (SAF-29974 drift); self-discovering `test_get_test_drifts_e2e` (no more hardcoded IDs); `test_run_custom_plan` now requires a plan with no empty steps.

## JIRA
[SAF-32018](https://safebreach.atlassian.net/browse/SAF-32018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
