### PR TITLE
SAF-32063 fix: surface security-event correlation phase in test status

### DIFF
--- a/prds/SAF-32063/prd.md
+++ b/prds/SAF-32063/prd.md
@@ -1,0 +1,82 @@
+# PRD: HELM reports COMPLETED while a test is still correlating — SAF-32063
+
+## 1. Overview
+
+| Field | Value |
+|-------|-------|
+| **Title** | Surface the security-event correlation phase so HELM stops reporting still-correlating tests as COMPLETED |
+| **JIRA** | SAF-32063 |
+| **Task Type** | Bug |
+| **Component** | `safebreach_mcp_data` (Data Server) |
+| **Purpose** | When asked "is that test done?", HELM returns `Status: ✅ COMPLETED` while the test is still in "Waiting to correlate" / "Correlating security events". The MCP must reflect the true completion state. |
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Implemented |
+| **Last Updated** | 2026-06-29 |
+| **Branch** | `feature/SAF-32063` |
+
+## 2. Solution Description
+
+### Root cause (confirmed against live pentest01 data)
+
+A test summary's `status` flips to `COMPLETED` when **simulation execution** ends, but every test then runs an asynchronous **security-event log-correlation** phase whose progress is tracked only by `logProcessingCompletionPercentage`. The MCP relayed `status` and never read that field, so it reported `COMPLETED` while correlation was still pending.
+
+Per the integrations team, `logProcessingCompletionPercentage` is the authoritative completion signal: it **always exists and always reaches `1` (100%) for every test, regardless of whether any connector / security-control integration is attached** — correlation simply runs with a delay. A test is fully done only when this field reaches `1`.
+
+Evidence (raw `testsummaries`, all with `status=COMPLETED`, `isCompleted=True`):
+
+| UI phase | `logProcessingCompletionPercentage` |
+|----------|-------------------------------------|
+| Waiting to correlate | `None` (not yet started) |
+| Correlating security events | `0.72` |
+| Completed | `1.0` |
+
+The SafeBreach UI derives the phase from exactly this field (`ui-react .../HomePage/utils.tsx:percentageToTestPhase`).
+
+### Chosen Solution
+
+Derive a `test_phase` from `logProcessingCompletionPercentage` inside `get_reduced_test_summary_mapping` — the single transform both `get_tests` and `get_test_details` flow through — and expose it alongside the raw percentage. `status` is left untouched (existing `status_filter` and consumers depend on it). `get_test_details` emits a `hint_to_agent` instructing the agent not to report a still-correlating test as done.
+
+Phase derivation (mirrors the UI), applied only when `status == 'completed'`:
+
+| `logProcessingCompletionPercentage` | `test_phase` |
+|-------------------------------------|--------------|
+| `None` or `0` | `Waiting to correlate` |
+| `0 < pct < 1` | `Correlating security events` |
+| `1` | `Completed` |
+| otherwise | `Invalid` |
+
+Gating on `status == 'completed'` is intentional: `completed` is the only status value that is misleading. `running` / `paused` / `cancelled` / `failed` already read correctly, so no `test_phase` is added for them.
+
+### Alternatives Considered
+
+| Option | Why not chosen |
+|--------|----------------|
+| Use the `isCompleted` boolean | Disproved by live data — `isCompleted=True` during the correlation phase. |
+| Overwrite the `status` field itself | Breaks `status_filter='completed'` and other consumers that rely on raw status. |
+| Add an integration-config check (`isAnyDefinedIntegration` from the config service) to disambiguate `pct=None` | Made obsolete by the integrations team's confirmation that the field is universal and always reaches 1 — no integration check is needed, and it avoids a cross-domain call from the data server into config. |
+
+## 3. Core Feature Components
+
+- **`data_types.py`** — `_percentage_to_test_phase(pct)` helper; `get_reduced_test_summary_mapping` adds `test_phase` (always when completed) and `log_processing_completion_percentage` (when present).
+- **`data_functions.py`** — `sb_get_test_details` emits a correlation-aware `hint_to_agent` when `test_phase` is `Waiting to correlate` / `Correlating security events`.
+- **`data_server.py`** — `get_tests` and `get_test_details` tool descriptions document `test_phase` and state it is the authoritative completion signal.
+
+## 4. API Endpoints and Integration
+
+No new endpoints. Reads the existing `logProcessingCompletionPercentage` field already returned by `GET /api/data/v1/accounts/{account_id}/testsummaries`.
+
+## 5. Tests
+
+- `test_data_types.py::TestTestSummaryMapping` — correlating / waiting / completed / invalid / absent-percentage / non-completed-status cases.
+- `test_data_functions.py::TestDataFunctions::test_sb_get_test_details_correlation_pending_hint` — verifies the hint steers the agent away from COMPLETED and surfaces progress.
+- Updated `TestStorageHintForTerminalTests::test_terminal_test_has_delete_hint` to represent a fully-correlated test (`logProcessingCompletionPercentage: 1`).
+
+## 6. Definition of Done
+
+- `get_test_details` / `get_tests` expose `test_phase`; a completed-but-correlating test reports a non-`Completed` phase and a hint not to call it done. ✅
+- `status` semantics unchanged. ✅
+- Data-server suite green. ✅

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -491,10 +491,21 @@ def sb_get_test_details(test_id: str, console: str = "default",
 
         # Add contextual hints
         final_status = (return_details.get('status', '') or '').lower()
+        test_phase = return_details.get('test_phase')
+        correlation_pending = test_phase in ("Waiting to correlate", "Correlating security events")
         if final_status not in terminal_statuses:
             return_details['hint_to_agent'] = (
                 f"Test is still {return_details.get('status', 'in progress')}. "
                 "Poll again in 30 seconds using get_test_details with the same test_id."
+            )
+        elif correlation_pending:
+            pct = return_details.get('log_processing_completion_percentage')
+            pct_str = f" ({round(pct * 100)}% complete)" if isinstance(pct, (int, float)) and 0 < pct < 1 else ""
+            return_details['hint_to_agent'] = (
+                f"Simulation execution has finished, but security-event correlation is still in "
+                f"progress{pct_str} — detection/prevention results are not final yet. Report the test "
+                "as still correlating (not fully complete), and re-check with get_test_details until "
+                "correlation is complete."
             )
         else:
             # Terminal test — hint about delete for storage management (SAF-29972)

--- a/safebreach_mcp_data/data_server.py
+++ b/safebreach_mcp_data/data_server.py
@@ -64,7 +64,9 @@ status_filter ('completed'/'canceled'/'failed'/'running'/None), name_filter (par
 launched_by_filter (partial username match, case-insensitive — e.g. 'sbadmin'), \
 order_by ('end_time'/'start_time'/'name'/'duration'), order_direction ('desc'/'asc').
 Accepts both epoch timestamps and ISO 8601 strings for date parameters.
-Each test includes a launched_by field with the resolved username of who ran the test."""
+Each test includes a launched_by field with the resolved username of who ran the test.
+A test may also include test_phase ('Waiting to correlate'/'Correlating security events'/'Completed') when security-event \
+correlation is tracked — a 'completed' status with a non-'Completed' test_phase means correlation is still in progress."""
         )
         async def get_tests_tool(
             console: str = "default",
@@ -99,6 +101,11 @@ Each test includes a launched_by field with the resolved username of who ran the
             description="""Returns the full details for a specific test by id executed on a given Safebreach management console.
 Always includes simulation status counts (missed, stopped, prevented, detected, logged, no-result, inconsistent) at no extra cost.
 Optionally includes drift count via include_drift_count parameter.
+A test whose `status` is 'completed' may still be running security-event correlation. Check `test_phase` \
+('Waiting to correlate'/'Correlating security events'/'Completed'): while it is not 'Completed', simulation execution \
+has finished but correlation is still in progress and detection/prevention results are not final — describe the test \
+as still correlating (not done) rather than completed. `log_processing_completion_percentage` (0..1) gives correlation \
+progress; `status` alone reflects only execution.
 WARNING: include_drift_count=True may take a significant amount of time for large tests (proportional to the number of simulations) as it must scan all simulation pages. Only request drift count when specifically needed."""
         )
         async def get_test_details_tool(

--- a/safebreach_mcp_data/data_types.py
+++ b/safebreach_mcp_data/data_types.py
@@ -139,6 +139,17 @@ def _build_simulation_status_counts(final_status: Dict[str, Any]) -> List[Dict[s
     ]
 
 
+def _percentage_to_test_phase(percentage):
+    """Map logProcessingCompletionPercentage (None or 0..1) to its correlation phase label."""
+    if percentage is None or percentage == 0:
+        return "Waiting to correlate"
+    if 0 < percentage < 1:
+        return "Correlating security events"
+    if percentage == 1:
+        return "Completed"
+    return "Invalid"
+
+
 def get_reduced_test_summary_mapping(test_summary_entity):
     """
     Returns a reduced test summary entity with only the relevant fields.
@@ -159,6 +170,12 @@ def get_reduced_test_summary_mapping(test_summary_entity):
             reduced_test_summary_entity['findings_count'] = test_summary_entity['findingsCount']
         if 'compromisedHosts' in test_summary_entity:
             reduced_test_summary_entity['compromised_hosts'] = test_summary_entity['compromisedHosts']
+
+    if str(reduced_test_summary_entity.get('status', '')).lower() == 'completed':
+        log_processing_pct = test_summary_entity.get('logProcessingCompletionPercentage')
+        if log_processing_pct is not None:
+            reduced_test_summary_entity['log_processing_completion_percentage'] = log_processing_pct
+        reduced_test_summary_entity['test_phase'] = _percentage_to_test_phase(log_processing_pct)
 
     return reduced_test_summary_entity
 

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -488,6 +488,38 @@ class TestDataFunctions:
         detected_stat = next(s for s in stats if s.get("status") == "detected")
         assert detected_stat["count"] == 2
 
+    @patch('safebreach_mcp_data.data_functions._get_all_tests_from_cache_or_api')
+    def test_sb_get_test_details_correlation_pending_hint(self, mock_get_all_tests):
+        """SAF-32063: a COMPLETED test that is still correlating must not be reported as done.
+
+        status='completed' is terminal, but test_phase shows correlation in progress — the
+        hint must steer the agent away from declaring COMPLETED and toward polling.
+        """
+        mock_get_all_tests.return_value = [
+            {
+                "name": "Corr Test",
+                "test_id": "test-corr",
+                "start_time": 1640995200,
+                "end_time": 1640995800,
+                "duration": 600,
+                "status": "completed",
+                "test_type": "Breach And Attack Simulation (aka BAS aks Validate)",
+                "simulations_statistics": [],
+                "log_processing_completion_percentage": 0.72,
+                "test_phase": "Correlating security events",
+            }
+        ]
+
+        result = sb_get_test_details("test-corr", "test-console")
+
+        hint = result.get("hint_to_agent", "")
+        assert "correlation" in hint.lower()
+        assert "not final" in hint.lower()
+        assert "72%" in hint
+        assert "test_phase" not in hint
+        assert result["status"] == "completed"
+        assert result["test_phase"] == "Correlating security events"
+
     @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
     @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
     @patch('safebreach_mcp_data.data_functions.requests.get')
@@ -3742,7 +3774,7 @@ class TestStorageHintForTerminalTests:
         self, mock_base_url, mock_account_id, mock_get,
         mock_orch_state, mock_user_name
     ):
-        """Completed test includes hint about delete dry-run for storage."""
+        """Fully-correlated completed test includes hint about delete dry-run for storage."""
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -3752,6 +3784,7 @@ class TestStorageHintForTerminalTests:
             "startTime": 1000, "endTime": 2000, "duration": 1000,
             "status": "COMPLETED", "systemTags": [],
             "finalStatus": {"missed": 1}, "ranBy": 100001,
+            "logProcessingCompletionPercentage": 1,
         }]
         mock_list_response.raise_for_status.return_value = None
 

--- a/safebreach_mcp_data/tests/test_data_types.py
+++ b/safebreach_mcp_data/tests/test_data_types.py
@@ -757,6 +757,61 @@ class TestTestSummaryMapping:
         assert result["findings_count"] == 0
         assert result["compromised_hosts"] == 0
 
+    def _base_entity(self, **overrides):
+        entity = {
+            "planName": "Corr Test",
+            "planRunId": "run1",
+            "startTime": 1000,
+            "endTime": 2000,
+            "duration": 1000,
+            "status": "COMPLETED",
+            "systemTags": [],
+            "finalStatus": {},
+        }
+        entity.update(overrides)
+        return entity
+
+    def test_correlating_phase_when_percentage_partial(self):
+        """0 < pct < 1 -> 'Correlating security events', and raw percentage surfaced."""
+        result = get_reduced_test_summary_mapping(self._base_entity(logProcessingCompletionPercentage=0.72))
+        assert result["test_phase"] == "Correlating security events"
+        assert result["log_processing_completion_percentage"] == 0.72
+        assert result["status"] == "COMPLETED"
+
+    def test_waiting_to_correlate_phase_when_percentage_zero(self):
+        """pct == 0 -> 'Waiting to correlate'."""
+        result = get_reduced_test_summary_mapping(self._base_entity(logProcessingCompletionPercentage=0))
+        assert result["test_phase"] == "Waiting to correlate"
+        assert result["log_processing_completion_percentage"] == 0
+
+    def test_completed_phase_when_percentage_one(self):
+        """pct == 1 -> 'Completed'."""
+        result = get_reduced_test_summary_mapping(self._base_entity(logProcessingCompletionPercentage=1))
+        assert result["test_phase"] == "Completed"
+        assert result["log_processing_completion_percentage"] == 1
+
+    def test_invalid_phase_when_percentage_out_of_range(self):
+        """Out-of-range percentage -> 'Invalid'."""
+        result = get_reduced_test_summary_mapping(self._base_entity(logProcessingCompletionPercentage=1.5))
+        assert result["test_phase"] == "Invalid"
+
+    def test_completed_test_absent_percentage_is_waiting_to_correlate(self):
+        """A completed test whose percentage hasn't appeared yet -> 'Waiting to correlate'.
+
+        logProcessingCompletionPercentage always exists and always reaches 1, but with delay;
+        the absent/None window after execution is the waiting-to-correlate phase.
+        """
+        result = get_reduced_test_summary_mapping(self._base_entity())
+        assert result["test_phase"] == "Waiting to correlate"
+        assert "log_processing_completion_percentage" not in result
+
+    def test_non_completed_status_has_no_test_phase(self):
+        """Running/paused/cancelled/failed tests keep their status verbatim, no test_phase."""
+        result = get_reduced_test_summary_mapping(
+            self._base_entity(status="RUNNING", logProcessingCompletionPercentage=0)
+        )
+        assert "test_phase" not in result
+
 
 class TestPeerBenchmarkTransform:
     """Test suite for the peer benchmark score rename mapping and transform helper (SAF-29415)."""


### PR DESCRIPTION
## Problem
When asked "is that test done?", HELM reports a test as `✅ COMPLETED` while it is still in "Waiting to correlate" / "Correlating security events".

## Root cause
A test summary's `status` flips to `COMPLETED` when *simulation execution* ends, but security-event log-correlation then runs asynchronously, tracked only by `logProcessingCompletionPercentage`. The MCP relayed `status` and ignored that field.

## Fix
- `data_types.py` — `_percentage_to_test_phase()` helper; `get_reduced_test_summary_mapping` adds `test_phase` (+ raw `log_processing_completion_percentage`), gated on `status == 'completed'` (the only misleading status). Single choke-point feeds both `get_tests` and `get_test_details`. `status` left untouched so `status_filter` and other consumers are unaffected.
- `data_functions.py` — `get_test_details` emits a `hint_to_agent` when correlation is pending so the agent doesn't report the test as done.
- `data_server.py` — `get_tests` / `get_test_details` descriptions document `test_phase`.

## Tests
Unit tests for `None`/`0`/partial/`1`/invalid/non-completed phases + the correlation-pending hint. Full data suite green (482 passed).

## Verification
Live pentest01 captures + Claude Desktop E2E: HELM now answers "still correlating (~35%), results not final" in plain language instead of "✅ COMPLETED".

PRD: `prds/SAF-32063/prd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
