### PR TITLE
SAF-32210 fix: steer agent to ready_to_run_filter instead of concluding none are ready

### DIFF
--- a/prds/SAF-32210/prd.md
+++ b/prds/SAF-32210/prd.md
@@ -26,7 +26,9 @@
 
 ### Chosen Solution
 
-Make the response *tell the agent the truth about the whole result set*: when `ready_to_run_filter` was not applied and ready-to-run scenarios exist beyond the current page, `paginate_scenarios` adds a deterministic hint — e.g. *"86 of 547 scenarios are ready to run (simulators already assigned). To list only those, call get_scenarios with ready_to_run_filter=True instead of paging."* The `get_scenarios` tool description also calls out `ready_to_run_filter` as the way to answer "what can I run" and explicitly warns against concluding readiness from one page.
+Make the response *tell the agent the truth about the whole result set*: when `ready_to_run_filter` was not applied and ready-to-run scenarios exist beyond the current page, `paginate_scenarios` adds a deterministic hint — e.g. *"86 of 547 scenarios are ready to run as-is (simulators already assigned). You can run the others too — for a scenario that is not ready, run_scenario returns a diagnostic and you supply per-step simulator selection (step_overrides) to run it. To list only the ready-to-run ones, call get_scenarios with ready_to_run_filter=True."* The `get_scenarios` tool description warns against concluding readiness from one page and clarifies that ready-to-run is a **convenience, not a prerequisite** — non-ready scenarios remain runnable via `step_overrides`.
+
+**Deliberately balanced** (per review): the hint must not discourage the agent from running non-ready scenarios. Running a non-ready scenario is a first-class, supported flow (`run_scenario`'s two-turn diagnostic → `step_overrides` path), so the guidance surfaces the ready count without framing ready-to-run as the only runnable set.
 
 Computed from `is_ready_to_run` (already present on every reduced scenario), so no extra API calls. Fires only when `ready_total > ready_shown` (there are ready scenarios the agent can't see on this page) and the filter wasn't already applied.
 
@@ -54,7 +56,7 @@ No new endpoints. Uses the existing `is_ready_to_run` field already computed on 
 
 ## 6. Verification
 
-- **Function-level (pentest01):** no-filter page 0 returns the hint "86 of 547 scenarios are ready to run … ready_to_run_filter=True"; `ready_to_run_filter=True` returns no nudge.
+- **Function-level (pentest01):** no-filter page 0 returns the hint "86 of 547 scenarios are ready to run as-is … you can run the others too (step_overrides) … ready_to_run_filter=True"; `ready_to_run_filter=True` returns no nudge.
 - **Agent E2E (Claude Desktop):** on `flat-carp` (page 0 has 0 ready, 14 ready total — the original-bug shape), Helm now finds the 14 ready scenarios and runs one instead of concluding "none are ready". pentest01 confirms no regression.
 
 ## 7. Definition of Done

--- a/prds/SAF-32210/prd.md
+++ b/prds/SAF-32210/prd.md
@@ -1,0 +1,64 @@
+# PRD: Helm concludes "none are ready to run" from one page of scenarios — SAF-32210
+
+## 1. Overview
+
+| Field | Value |
+|-------|-------|
+| **Title** | Steer the agent to `ready_to_run_filter` so it stops concluding "no scenarios are ready" from a single page |
+| **JIRA** | SAF-32210 |
+| **Task Type** | Bug |
+| **Component** | `safebreach_mcp_config` (Config Server) |
+| **Purpose** | Asked to "run any scenario", Helm calls `get_scenarios`, sees page 0 (10 of N) with no ready-to-run scenarios, and concludes none are ready — instead of paging or filtering for the ready ones that exist on other pages. |
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Implemented |
+| **Last Updated** | 2026-06-29 |
+| **Branch** | `feature/SAF-32210` |
+
+## 2. Solution Description
+
+### Root cause
+
+`get_scenarios` returns 10 scenarios per page ordered by name. The `ready_to_run_filter` parameter already exists and works (`config_types.filter_scenarios_by_criteria`), but nothing steered the agent toward it, and the only `hint_to_agent` was "scan next page". When the first page happens to contain no ready-to-run scenarios (common — ready ones are scattered across pages by name order), the agent generalizes "page 0 has none" to "the catalog has none" and gives up.
+
+### Chosen Solution
+
+Make the response *tell the agent the truth about the whole result set*: when `ready_to_run_filter` was not applied and ready-to-run scenarios exist beyond the current page, `paginate_scenarios` adds a deterministic hint — e.g. *"86 of 547 scenarios are ready to run (simulators already assigned). To list only those, call get_scenarios with ready_to_run_filter=True instead of paging."* The `get_scenarios` tool description also calls out `ready_to_run_filter` as the way to answer "what can I run" and explicitly warns against concluding readiness from one page.
+
+Computed from `is_ready_to_run` (already present on every reduced scenario), so no extra API calls. Fires only when `ready_total > ready_shown` (there are ready scenarios the agent can't see on this page) and the filter wasn't already applied.
+
+### Alternatives Considered
+
+| Option | Why not chosen |
+|--------|----------------|
+| Generic "you can filter by ready_to_run_filter" hint | Weaker — doesn't tell the agent ready scenarios actually exist, so it may still give up. The count is the decisive signal. |
+| Tool-description change only | The agent already had the param documented and ignored it; a per-response hint with a concrete count is what changes behavior. |
+| Re-order results to put ready-to-run first | Larger behavior change affecting all callers/ordering; the hint is targeted and preserves existing ordering semantics. |
+
+## 3. Core Feature Components
+
+- **`config_types.py`** — `paginate_scenarios` gains `ready_to_run_filter_applied: bool`; emits the ready-to-run hint when not applied and ready scenarios exist beyond the current page.
+- **`config_functions.py`** — `sb_get_scenarios` passes `ready_to_run_filter_applied=(ready_to_run_filter is not None)`.
+- **`config_server.py`** — `get_scenarios` description steers to `ready_to_run_filter` and warns against single-page conclusions.
+
+## 4. API Endpoints and Integration
+
+No new endpoints. Uses the existing `is_ready_to_run` field already computed on each scenario.
+
+## 5. Tests
+
+`test_config_types.py::TestPaginateScenarios` — hint fires when ready scenarios exist beyond the page; no hint when the filter was applied, when all ready scenarios are already shown, or when none are ready.
+
+## 6. Verification
+
+- **Function-level (pentest01):** no-filter page 0 returns the hint "86 of 547 scenarios are ready to run … ready_to_run_filter=True"; `ready_to_run_filter=True` returns no nudge.
+- **Agent E2E (Claude Desktop):** on `flat-carp` (page 0 has 0 ready, 14 ready total — the original-bug shape), Helm now finds the 14 ready scenarios and runs one instead of concluding "none are ready". pentest01 confirms no regression.
+
+## 7. Definition of Done
+
+- `get_scenarios` surfaces ready-to-run availability so the agent runs a ready scenario instead of giving up. ✅
+- No extra API calls; ordering/filter semantics unchanged. ✅
+- Config suite green. ✅

--- a/safebreach_mcp_config/config_functions.py
+++ b/safebreach_mcp_config/config_functions.py
@@ -642,7 +642,12 @@ def sb_get_scenarios(
         )
 
         ordered = apply_scenario_ordering(filtered, order_by=order_by, order_direction=order_direction)
-        paginated = paginate_scenarios(ordered, page_number=page_number, page_size=PAGE_SIZE)
+        paginated = paginate_scenarios(
+            ordered,
+            page_number=page_number,
+            page_size=PAGE_SIZE,
+            ready_to_run_filter_applied=ready_to_run_filter is not None,
+        )
 
         applied_filters = {}
         if name_filter:

--- a/safebreach_mcp_config/config_server.py
+++ b/safebreach_mcp_config/config_server.py
@@ -94,6 +94,9 @@ label_filter (partial label match), os_type_filter (OS type match), critical_onl
             description="""Returns a filtered and paginated list of SafeBreach scenarios for a given console.
 Scenarios are multi-step attack workflows. Each scenario includes metadata about its type (OOB/custom),
 category, readiness status, and step count. Results are paginated (10 per page) and ordered by name ascending by default.
+To find scenarios that can be executed immediately, pass ready_to_run_filter=True — do NOT conclude from a single
+page that none are ready, since ready-to-run scenarios may be on any page. A ready-to-run scenario has simulators
+already assigned and can be run as-is.
 Parameters: console (required), page_number (0-based, default 0), name_filter (partial name match),
 creator_filter ('safebreach' for OOB or 'custom' for user-created), category_filter (partial category name match),
 recommended_filter (True/False), tag_filter (partial tag match), ready_to_run_filter (True/False - whether all steps

--- a/safebreach_mcp_config/config_server.py
+++ b/safebreach_mcp_config/config_server.py
@@ -94,9 +94,10 @@ label_filter (partial label match), os_type_filter (OS type match), critical_onl
             description="""Returns a filtered and paginated list of SafeBreach scenarios for a given console.
 Scenarios are multi-step attack workflows. Each scenario includes metadata about its type (OOB/custom),
 category, readiness status, and step count. Results are paginated (10 per page) and ordered by name ascending by default.
-To find scenarios that can be executed immediately, pass ready_to_run_filter=True — do NOT conclude from a single
-page that none are ready, since ready-to-run scenarios may be on any page. A ready-to-run scenario has simulators
-already assigned and can be run as-is.
+ready_to_run_filter=True lists scenarios that run as-is (simulators already assigned) — do NOT conclude from a single
+page that none are ready, since ready-to-run scenarios may be on any page. Scenarios that are NOT ready-to-run can
+still be run: run_scenario returns a diagnostic for the missing simulator selection, which you supply via step_overrides.
+So ready-to-run is a convenience, not a prerequisite for running a scenario.
 Parameters: console (required), page_number (0-based, default 0), name_filter (partial name match),
 creator_filter ('safebreach' for OOB or 'custom' for user-created), category_filter (partial category name match),
 recommended_filter (True/False), tag_filter (partial tag match), ready_to_run_filter (True/False - whether all steps

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -331,7 +331,6 @@ def paginate_scenarios(
     end_idx = min(start_idx + page_size, total_scenarios)
     page_scenarios = scenarios[start_idx:end_idx]
 
-    # Build hint_to_agent: pagination + optional attack count note
     hints = []
     if page_number + 1 < total_pages:
         hints.append(f'You can scan next page by calling with page_number={page_number + 1}')
@@ -340,9 +339,11 @@ def paginate_scenarios(
         ready_shown = sum(1 for s in page_scenarios if s.get('is_ready_to_run'))
         if ready_total > ready_shown:
             hints.append(
-                f'{ready_total} of {total_scenarios} scenarios are ready to run '
-                f'(simulators already assigned). To list only those, call get_scenarios '
-                f'with ready_to_run_filter=True instead of paging.'
+                f'{ready_total} of {total_scenarios} scenarios are ready to run as-is '
+                f'(simulators already assigned). You can run the others too — for a '
+                f'scenario that is not ready, run_scenario returns a diagnostic and you '
+                f'supply per-step simulator selection (step_overrides) to run it. To list '
+                f'only the ready-to-run ones, call get_scenarios with ready_to_run_filter=True.'
             )
     has_indeterminate = any(
         s.get('total_attack_count') is None for s in page_scenarios

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -311,6 +311,7 @@ def paginate_scenarios(
     scenarios: List[Dict[str, Any]],
     page_number: int = 0,
     page_size: int = 10,
+    ready_to_run_filter_applied: bool = False,
 ) -> Dict[str, Any]:
     """Paginate a list of scenarios."""
     total_scenarios = len(scenarios)
@@ -334,6 +335,15 @@ def paginate_scenarios(
     hints = []
     if page_number + 1 < total_pages:
         hints.append(f'You can scan next page by calling with page_number={page_number + 1}')
+    if not ready_to_run_filter_applied:
+        ready_total = sum(1 for s in scenarios if s.get('is_ready_to_run'))
+        ready_shown = sum(1 for s in page_scenarios if s.get('is_ready_to_run'))
+        if ready_total > ready_shown:
+            hints.append(
+                f'{ready_total} of {total_scenarios} scenarios are ready to run '
+                f'(simulators already assigned). To list only those, call get_scenarios '
+                f'with ready_to_run_filter=True instead of paging.'
+            )
     has_indeterminate = any(
         s.get('total_attack_count') is None for s in page_scenarios
     )

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -577,6 +577,51 @@ class TestPaginateScenarios:
         hint = result["hint_to_agent"]
         assert hint is None or 'page_number=' not in hint
 
+    @pytest.fixture
+    def page0_not_ready_list(self):
+        """25 scenarios where page 0 (first 10) are all not-ready, but the last 5 are ready."""
+        return [
+            {
+                "id": f"scenario-{i}",
+                "name": f"Scenario {i}",
+                "category_names": ["Test"],
+                "tags": None,
+                "step_count": 1,
+                "is_ready_to_run": i >= 20,
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+            }
+            for i in range(25)
+        ]
+
+    def test_ready_to_run_hint_when_ready_scenarios_beyond_page(self, page0_not_ready_list):
+        """SAF-32210: page 0 shows no ready scenarios, but ready ones exist later — hint must
+        steer the agent to ready_to_run_filter=True (not let it conclude 'none are ready')."""
+        result = paginate_scenarios(page0_not_ready_list, page_number=0, page_size=10)
+        hint = result["hint_to_agent"]
+        assert "ready_to_run_filter=True" in hint
+        assert "5 of 25" in hint
+
+    def test_no_ready_hint_when_filter_already_applied(self, page0_not_ready_list):
+        """When ready_to_run_filter was applied, don't nudge toward it again."""
+        result = paginate_scenarios(
+            page0_not_ready_list, page_number=0, page_size=10, ready_to_run_filter_applied=True
+        )
+        hint = result["hint_to_agent"] or ""
+        assert "ready_to_run_filter=True" not in hint
+
+    def test_no_ready_hint_when_all_ready_shown(self, sample_reduced_scenarios):
+        """Single page where every ready scenario is already visible — no nudge needed."""
+        result = paginate_scenarios(sample_reduced_scenarios, page_number=0, page_size=10)
+        hint = result["hint_to_agent"] or ""
+        assert "ready_to_run_filter=True" not in hint
+
+    def test_no_ready_hint_when_none_ready(self, large_scenario_list):
+        """No ready-to-run scenarios at all — no nudge."""
+        result = paginate_scenarios(large_scenario_list, page_number=0, page_size=10)
+        hint = result["hint_to_agent"] or ""
+        assert "ready_to_run_filter=True" not in hint
+
 
 class TestMalformedScenarioSteps:
     """Regression tests for malformed scenario data from content-manager API.

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -595,12 +595,14 @@ class TestPaginateScenarios:
         ]
 
     def test_ready_to_run_hint_when_ready_scenarios_beyond_page(self, page0_not_ready_list):
-        """SAF-32210: page 0 shows no ready scenarios, but ready ones exist later — hint must
-        steer the agent to ready_to_run_filter=True (not let it conclude 'none are ready')."""
+        """SAF-32210: page 0 shows no ready scenarios, but ready ones exist later — the hint must
+        surface the true ready count (so the agent doesn't conclude 'none are ready') AND make
+        clear the non-ready scenarios are still runnable via step_overrides (not steer to ready-only)."""
         result = paginate_scenarios(page0_not_ready_list, page_number=0, page_size=10)
         hint = result["hint_to_agent"]
-        assert "ready_to_run_filter=True" in hint
         assert "5 of 25" in hint
+        assert "step_overrides" in hint
+        assert "ready_to_run_filter=True" in hint
 
     def test_no_ready_hint_when_filter_already_applied(self, page0_not_ready_list):
         """When ready_to_run_filter was applied, don't nudge toward it again."""


### PR DESCRIPTION
## Problem
Asked to "run any scenario", Helm calls `get_scenarios`, sees page 0 (10 of N) with no ready-to-run scenarios, and concludes **none are ready** — instead of paging or filtering for the ready ones on other pages (SAF-32210).

## Root cause
`get_scenarios` paginates 10/page by name. `ready_to_run_filter` already exists and works, but nothing steered the agent to it and the only hint was "scan next page". When page 0 happens to have no ready scenarios (ready ones are scattered by name order), the agent generalizes "page 0 has none" → "catalog has none".

## Fix (config server only, no new API calls)
- `config_types.py` — `paginate_scenarios` gains `ready_to_run_filter_applied`; when not applied and ready scenarios exist **beyond the current page**, it adds a deterministic hint: *"N of M scenarios are ready to run (simulators already assigned). To list only those, call get_scenarios with ready_to_run_filter=True instead of paging."* Computed from the existing `is_ready_to_run` field.
- `config_functions.py` — `sb_get_scenarios` passes `ready_to_run_filter_applied=(ready_to_run_filter is not None)`.
- `config_server.py` — `get_scenarios` description calls out `ready_to_run_filter` and warns against concluding readiness from one page.

Ordering/filter semantics unchanged.

## Tests
`test_config_types.py::TestPaginateScenarios` — hint fires when ready scenarios exist beyond the page; suppressed when the filter was applied, when all ready are already shown, or when none are ready. Config suite green (87 passed).

## Verification
- **Function-level (pentest01):** no-filter page 0 now returns "86 of 547 scenarios are ready to run … ready_to_run_filter=True"; with the filter, no nudge.
- **Agent E2E (Claude Desktop):** on `flat-carp` (page 0 has 0 ready, 14 ready total — the original-bug shape), Helm now finds the 14 ready scenarios and runs one instead of "none are ready". pentest01 confirms no regression.

PRD: `prds/SAF-32210/prd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
