### PR TITLE
SAF-32805 fix: correct playbook attack id/name simulation filters (wrong key + int/str)

### DIFF
--- a/prds/SAF-32805/prd.md
+++ b/prds/SAF-32805/prd.md
@@ -1,0 +1,62 @@
+# PRD: playbook_attack_id_filter silently returns empty — SAF-32805
+
+## 1. Overview
+
+| Field | Value |
+|-------|-------|
+| **Title** | `get_test_simulations` attack-id / attack-name filters silently return empty (wrong key + int/str), producing false-negative drift results |
+| **JIRA** | SAF-32805 (relates to SB-36136 — Travelers HELM credit burn) |
+| **Task Type** | Bug |
+| **Component** | `safebreach_mcp_data` (Data Server) |
+
+## 1.5. Document Status
+
+| Field | Value |
+|-------|-------|
+| **PRD Status** | Implemented (filter fix + empty-match guard) |
+| **Last Updated** | 2026-06-29 |
+| **Branch** | `feature/SAF-32805-fix-playbook-attack-id-filter` |
+
+## 2. Solution Description
+
+### Root cause (corrects the ticket's stated mechanism)
+
+The ticket describes the cause as an int/str mismatch on `s.get('playbookAttackId') == playbook_attack_id_filter`. That is incomplete. `_apply_simulation_filters` runs on **reduced** simulation entities (`get_reduced_simulation_result_entity`), whose keys are snake_case (`playbook_attack_id` from `moveId`, `playbook_attack_name` from `moveName`). The camelCase keys `playbookAttackId` / `playbookAttackName` **do not exist** on those entities, so `s.get('playbookAttackId')` is `None` and the comparison is always `False` — the filter returns `[]` for every query.
+
+Consequently the ticket's proposed fix, `str(s.get('playbookAttackId')) == str(playbook_attack_id_filter)`, would **still fail** (`str(None)` never matches). The real fix needs the correct key **and** type coercion (since `moveId` is an int and the filter arg is a str). Both the id and name filters are affected.
+
+This has been broken since the initial commit `7182b18` (2025-07-29) — the filters never matched once. In SB-36136 it produced a false "0 detection drifts / new scenario additions" conclusion (true answer: real drifts incl. #4029, #2195); only caught when the user manually supplied counterexample sim `1316205` (attack #3819).
+
+### Chosen Solution
+
+- Fix both filters to the correct snake_case keys, with str-coercion on the id and None-safety on the name:
+  ```python
+  if playbook_attack_id_filter:
+      filtered = [s for s in filtered
+                  if str(s.get('playbook_attack_id')) == str(playbook_attack_id_filter)]
+  if playbook_attack_name_filter:
+      filtered = [s for s in filtered
+                  if playbook_attack_name_filter.lower() in (s.get('playbook_attack_name') or '').lower()]
+  ```
+- Empty-match guard: when filters matched 0 in a **non-empty** test, `sb_get_test_simulations` returns a `hint_to_agent` warning not to infer the attack/criteria is absent (distinguishes "filtered to empty" from "nothing to filter") — directly countering the SB-36136 failure where the agent inferred absence from a false zero.
+
+## 3. Core Feature Components
+
+- `data_functions.py` `_apply_simulation_filters` — correct keys + coercion + None-safety.
+- `data_functions.py` `sb_get_test_simulations` — empty-match guard hint.
+- `test_data_functions.py` — tests updated from the wrong (camelCase) shape to the real reduced shape; added int-id coercion test, end-to-end id match, and the guard test.
+
+## 4. Tests & Verification
+
+- Unit: filter matches int `playbook_attack_id` via str arg; name filter on snake key; guard hint on empty match in non-empty test. Full data suite green (477 passed).
+- Live (pentest01, test `1782728041622.137`): `playbook_attack_id_filter="923"` now returns sim `5192190` (was `0`); name filter "Whiter" returns it; filtering a non-existent attack returns `0` **with** the guard hint.
+
+## 5. Out of scope (remaining for SAF-32805)
+
+**401 retry-with-backoff is NOT in this change.** Acceptance criterion 3 (transient 401s on `get_security_controls_events` auto-recover; persistent ones raise an explicit typed error instead of silent-empty) is not implemented here and remains open.
+
+## 6. Acceptance Criteria status
+
+- ✅ `playbook_attack_id_filter` returns matching sims regardless of int/str typing (regression test added).
+- ✅ Replaying the baseline lookup for attack #3819-style id returns the sim, not empty (verified on pentest01 with attack 923 / sim 5192190).
+- ❌ Transient 401 auto-recovery — **not addressed in this PR.**

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -697,13 +697,26 @@ def sb_get_test_simulations(
         if drifted_only:
             applied_filters['drifted_only'] = drifted_only
         
+        # Guard against false-empty filter results: if filters matched nothing but the test
+        # itself has simulations, warn rather than let the agent infer the attack/criteria is absent.
+        if applied_filters and total_simulations == 0 and len(all_simulations) > 0:
+            hint = (
+                f"0 of {len(all_simulations)} simulations in this test matched the applied filters "
+                f"({', '.join(applied_filters)}). Verify the filter values are correct — do not "
+                "conclude the attack or criteria is absent from the test based on this empty result."
+            )
+        elif page_number + 1 < total_pages:
+            hint = f"You can scan next page by specifying page_number={page_number + 1}"
+        else:
+            hint = None
+
         return {
             "page_number": page_number,
             "total_pages": total_pages,
             "total_simulations": total_simulations,
             "simulations_in_page": page_simulations,
             "applied_filters": applied_filters,
-            "hint_to_agent": f"You can scan next page by specifying page_number={page_number + 1}" if page_number + 1 < total_pages else None
+            "hint_to_agent": hint
         }
         
     except Exception as e:
@@ -843,15 +856,16 @@ def _apply_simulation_filters(
         filtered = [s for s in filtered 
                    if _safe_time_compare(s, end_time, lambda x, y: x <= y)]
     
-    # Apply playbook attack ID filter
+    # Apply playbook attack ID filter. Reduced entities key this as 'playbook_attack_id'
+    # (from moveId, an int); the filter param is a string — compare as strings.
     if playbook_attack_id_filter:
-        filtered = [s for s in filtered 
-                   if s.get('playbookAttackId') == playbook_attack_id_filter]
-    
-    # Apply playbook attack name filter
+        filtered = [s for s in filtered
+                   if str(s.get('playbook_attack_id')) == str(playbook_attack_id_filter)]
+
+    # Apply playbook attack name filter ('playbook_attack_name' on the reduced entity)
     if playbook_attack_name_filter:
-        filtered = [s for s in filtered 
-                   if playbook_attack_name_filter.lower() in s.get('playbookAttackName', '').lower()]
+        filtered = [s for s in filtered
+                   if playbook_attack_name_filter.lower() in (s.get('playbook_attack_name') or '').lower()]
     
     # Apply drift filter
     if drifted_only:

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -609,22 +609,51 @@ class TestDataFunctions:
         assert filtered[0]["simulation_id"] == "sim1"
     
     def test_apply_simulation_filters_playbook(self):
-        """Test playbook attack filtering."""
+        """Playbook attack id/name filtering on the REAL reduced entity shape.
+
+        The filter runs on reduced entities (get_reduced_simulation_result_entity), whose keys
+        are snake_case: playbook_attack_id (from moveId, an int) and playbook_attack_name (str).
+        The id filter param is a string, so the id comparison must coerce types.
+        """
         sim_data = [
-            {"simulation_id": "sim1", "playbookAttackId": "move1", "playbookAttackName": "File Operation"},
-            {"simulation_id": "sim2", "playbookAttackId": "move2", "playbookAttackName": "Network Access"}
+            {"simulation_id": "sim1", "playbook_attack_id": 923, "playbook_attack_name": "Write Trojan to disk"},
+            {"simulation_id": "sim2", "playbook_attack_id": 456, "playbook_attack_name": "Network Access"},
         ]
-        
-        # Test playbook attack ID filter
-        filtered = _apply_simulation_filters(sim_data, playbook_attack_id_filter="move1")
+
+        # id filter: string param vs int field — must still match (type coercion)
+        filtered = _apply_simulation_filters(sim_data, playbook_attack_id_filter="923")
         assert len(filtered) == 1
         assert filtered[0]["simulation_id"] == "sim1"
-        
-        # Test playbook attack name filter
-        filtered = _apply_simulation_filters(sim_data, playbook_attack_name_filter="file")
+
+        # name filter: case-insensitive partial match on the snake_case key
+        filtered = _apply_simulation_filters(sim_data, playbook_attack_name_filter="trojan")
         assert len(filtered) == 1
         assert filtered[0]["simulation_id"] == "sim1"
-    
+
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    def test_get_test_simulations_id_filter_matches_int_attack(self, mock_get_all):
+        """End-to-end: filtering by a string attack id matches the int playbook_attack_id."""
+        mock_get_all.return_value = [
+            {"simulation_id": "5192190", "playbook_attack_id": 923, "playbook_attack_name": "Write Trojan", "status": "missed"},
+            {"simulation_id": "5192189", "playbook_attack_id": 456, "playbook_attack_name": "Other", "status": "missed"},
+        ]
+        res = sb_get_test_simulations("test1", "console", playbook_attack_id_filter="923")
+        assert res["total_simulations"] == 1
+        assert res["simulations_in_page"][0]["simulation_id"] == "5192190"
+
+    @patch('safebreach_mcp_data.data_functions._get_all_simulations_from_cache_or_api')
+    def test_get_test_simulations_empty_filter_match_warns(self, mock_get_all):
+        """Guard: a filter matching nothing in a NON-empty test must warn, not imply absence."""
+        mock_get_all.return_value = [
+            {"simulation_id": "s1", "playbook_attack_id": 923, "playbook_attack_name": "Write Trojan", "status": "missed"},
+            {"simulation_id": "s2", "playbook_attack_id": 456, "playbook_attack_name": "Other", "status": "missed"},
+        ]
+        res = sb_get_test_simulations("test1", "console", playbook_attack_id_filter="999")
+        assert res["total_simulations"] == 0
+        hint = (res.get("hint_to_agent") or "").lower()
+        assert "0 of 2" in hint
+        assert "verify" in hint
+
     def test_safe_time_compare(self):
         """Test safe time comparison with type conversion."""
         # Test integer end_time
@@ -2041,10 +2070,10 @@ class TestDataFunctions:
     def test_apply_simulation_filters_drifted_only_combined_with_other_filters(self):
         """Test drifted_only filter combined with other filters."""
         simulations = [
-            {"id": "sim1", "is_drifted": True, "status": "reported", "playbookAttackName": "File Transfer"},
-            {"id": "sim2", "is_drifted": True, "status": "prevented", "playbookAttackName": "Network Scan"},
-            {"id": "sim3", "is_drifted": False, "status": "reported", "playbookAttackName": "File Transfer"},
-            {"id": "sim4", "is_drifted": True, "status": "logged", "playbookAttackName": "File Transfer"},
+            {"id": "sim1", "is_drifted": True, "status": "reported", "playbook_attack_name": "File Transfer"},
+            {"id": "sim2", "is_drifted": True, "status": "prevented", "playbook_attack_name": "Network Scan"},
+            {"id": "sim3", "is_drifted": False, "status": "reported", "playbook_attack_name": "File Transfer"},
+            {"id": "sim4", "is_drifted": True, "status": "logged", "playbook_attack_name": "File Transfer"},
         ]
         
         # Test drifted_only + status filter


### PR DESCRIPTION
Fixes the filter half of **SAF-32805** (relates to SB-36136 — Travelers HELM credit burn).

## Bug
`get_test_simulations`' `playbook_attack_id_filter` / `playbook_attack_name_filter` filter **reduced** simulation entities (snake_case `playbook_attack_id` from `moveId`, `playbook_attack_name` from `moveName`) but compared the camelCase keys `playbookAttackId` / `playbookAttackName`, which don't exist on those entities. So `.get()` returned `None`/`''` and **both filters silently returned `[]` for every query** — broken since the initial commit `7182b18` (2025-07-29); they never matched once.

In SB-36136 this produced a false "no detection drift / new scenario additions" conclusion (real answer included drifts #4029, #2195) that nearly shipped to the customer; only caught when the user manually supplied sim `1316205` (attack #3819) proving the attack ran.

## Fix
- Correct keys + `str`-coercion on the id (`moveId` is an int, the arg is a str) + None-safety on the name.
- Empty-match guard: when filters match 0 of a **non-empty** test, `hint_to_agent` warns not to infer the attack/criteria is absent (the exact inference that failed in SB-36136).

> Note: the ticket's suggested fix `str(s.get('playbookAttackId'))…` would **still** fail — `playbookAttackId` isn't a key on the reduced entity, so it's `None` regardless of coercion. The real cause is the wrong key **and** int/str; this fixes both.

## Tests / verification
- Existing tests were asserting the wrong (camelCase) shape — corrected to the real reduced shape; added int-id coercion + end-to-end + guard tests. Full data suite green (477).
- Live (pentest01, test `1782728041622.137`): attack `923` → sim `5192190` (was `0`); name "Whiter" → matches; non-existent attack → `0` **with** guard hint.

## Out of scope (still open on SAF-32805)
**401 retry-with-backoff (acceptance criterion 3) is NOT in this PR** — transient 401s on `get_security_controls_events` auto-recover / typed error. Tracked as remaining.

PRD: `prds/SAF-32805/prd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
