### PR TITLE
SAF-32805 fix: bounded 401 retry-with-backoff on security-control-events (criterion 3)

### DIFF
--- a/prds/SAF-32805/prd-401-retry.md
+++ b/prds/SAF-32805/prd-401-retry.md
@@ -1,0 +1,39 @@
+# PRD: bounded 401 retry-with-backoff on security-control-events — SAF-32805 (criterion 3)
+
+## 1. Overview
+
+| Field | Value |
+|-------|-------|
+| **Title** | Retry transient 401s on the SafeBreach API call path; raise a typed error on persistent failure instead of abandoning verification |
+| **JIRA** | SAF-32805 (acceptance criterion 3; criteria 1 & 2 are in PR #68) |
+| **Component** | `safebreach_mcp_data` (Data Server) |
+| **Branch** | `feature/SAF-32805-401-retry` |
+
+## 2. Problem
+
+Security-control-event queries (`get_security_controls_events`) hit transient HTTP 401s with no retry. The fetch propagated the 401 as an exception, so the agent abandoned verification mid-analysis (SB-36136) — a transient auth blip read as "couldn't check," nudging false conclusions.
+
+## 3. Root cause / why retry (not refresh)
+
+Auth headers come from the **live per-request user credentials** (`get_auth_headers_for_console` → MCP `request_ctx`) — there is **no server-managed token to refresh**. A 401 here is typically transient (RBAC-gateway propagation / auth race). The only safe recovery is re-issuing the same request after a short backoff; a persistent 401 means genuinely-rejected creds.
+
+## 4. Solution
+
+A local helper `_get_with_auth_retry(url, headers, timeout)` in `data_functions.py`, used by the security-control-events fetch:
+- On HTTP 401: retry up to `_AUTH_RETRY_ATTEMPTS` (default 3, env `SAFEBREACH_MCP_AUTH_RETRY_ATTEMPTS`) with exponential backoff (`_AUTH_RETRY_BACKOFF_SEC`, default 0.5s).
+- On persistent 401: raise `TransientAuthError` — an explicit typed error, never a silent/empty result.
+- Non-401 responses: unchanged — `check_rbac_response` (403 RBAC hint + `raise_for_status`).
+
+Kept as a local helper calling `requests.get` (rather than a new shared module) to stay focused on the incident path and avoid disturbing the ~20 other call sites / their tests. Can be extracted to `safebreach_mcp_core` if a second call path needs it.
+
+## 5. Tests
+
+- `test_get_with_auth_retry_recovers_from_transient_401` — 401→200 retries and returns 200.
+- `test_get_with_auth_retry_persistent_401_raises_typed` — all-401 raises `TransientAuthError` after N attempts.
+- Full data suite green (477); existing security-control-events tests unaffected.
+
+## 6. Acceptance criteria (SAF-32805)
+
+- ✅ Transient 401s auto-recover (retry-with-backoff).
+- ✅ Persistent 401s raise an explicit typed error, never silent-empty.
+- (Criteria 1 & 2 — filter correctness + empty-match guard — delivered in PR #68.)

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -7,6 +7,7 @@ specifically for test and simulation data management.
 
 import copy
 import logging
+import os
 import time
 from typing import Dict, List, Optional, Any, Iterable
 
@@ -1050,6 +1051,43 @@ def sb_get_simulation_details(
         raise
 
 
+_AUTH_RETRY_ATTEMPTS = int(os.environ.get('SAFEBREACH_MCP_AUTH_RETRY_ATTEMPTS', '3'))
+_AUTH_RETRY_BACKOFF_SEC = float(os.environ.get('SAFEBREACH_MCP_AUTH_RETRY_BACKOFF_SEC', '0.5'))
+
+
+class TransientAuthError(Exception):
+    """Raised when a backend API keeps returning HTTP 401 after bounded retries.
+
+    Surfaced as an explicit, typed error so a persistent auth failure is never mistaken
+    for an empty/zero result (the SB-36136 failure mode).
+    """
+
+
+def _get_with_auth_retry(url: str, *, headers: Dict[str, str], timeout: int = 120):
+    """GET ``url``, retrying transient 401s with exponential backoff.
+
+    On HTTP 401: retry up to _AUTH_RETRY_ATTEMPTS with exponential backoff; if it still
+    fails, raise TransientAuthError. Non-401 responses go through check_rbac_response
+    (403 RBAC hint + raise_for_status), preserving existing behaviour.
+    """
+    for attempt in range(_AUTH_RETRY_ATTEMPTS):
+        response = requests.get(url, headers=headers, timeout=timeout)
+        if response.status_code == 401:
+            if attempt < _AUTH_RETRY_ATTEMPTS - 1:
+                sleep_s = _AUTH_RETRY_BACKOFF_SEC * (2 ** attempt)
+                logger.warning("Transient 401 from %s (attempt %d/%d); retrying in %.2fs",
+                               url, attempt + 1, _AUTH_RETRY_ATTEMPTS, sleep_s)
+                time.sleep(sleep_s)
+                continue
+            raise TransientAuthError(
+                f"Authentication failed (HTTP 401) for {url} after {_AUTH_RETRY_ATTEMPTS} attempts. "
+                "Likely a transient auth/RBAC-gateway issue that did not clear on retry. "
+                "Do NOT treat this as an empty or zero result."
+            )
+        check_rbac_response(response)
+        return response
+
+
 def _get_all_security_control_events_from_cache_or_api(test_id: str, simulation_id: str, console: str = "default") -> List[Dict[str, Any]]:
     """
     Get all security control events from cache or API.
@@ -1081,8 +1119,7 @@ def _get_all_security_control_events_from_cache_or_api(test_id: str, simulation_
         headers = {"Content-Type": "application/json", **get_auth_headers_for_console(console)}
         
         logger.info("Fetching security control events from API for %s:%s:%s", console, test_id, simulation_id)
-        response = requests.get(api_url, headers=headers, timeout=120)
-        check_rbac_response(response)
+        response = _get_with_auth_retry(api_url, headers=headers, timeout=120)
         
         response_data = response.json()
         

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -30,6 +30,8 @@ from safebreach_mcp_data.data_functions import (
     _apply_simulation_filters,
     _safe_time_compare,
     _get_all_security_control_events_from_cache_or_api,
+    _get_with_auth_retry,
+    TransientAuthError,
     _apply_security_control_events_filters,
     _get_all_findings_from_cache_or_api,
     _apply_findings_filters,
@@ -912,7 +914,33 @@ class TestDataFunctions:
         # Assertions
         assert "API Error" in str(exc_info.value)
         mock_get.assert_called_once()
-    
+
+    @patch('safebreach_mcp_data.data_functions.time.sleep')
+    @patch('safebreach_mcp_data.data_functions.requests.get')
+    def test_get_with_auth_retry_recovers_from_transient_401(self, mock_get, mock_sleep):
+        """A 401 that clears on retry returns the eventual 200 — no error surfaced."""
+        ok = Mock(); ok.status_code = 200; ok.raise_for_status.return_value = None
+        bad = Mock(); bad.status_code = 401
+        mock_get.side_effect = [bad, ok]
+
+        resp = _get_with_auth_retry("https://x/eventLogs", headers={})
+
+        assert resp is ok
+        assert mock_get.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch('safebreach_mcp_data.data_functions.time.sleep')
+    @patch('safebreach_mcp_data.data_functions.requests.get')
+    def test_get_with_auth_retry_persistent_401_raises_typed(self, mock_get, mock_sleep):
+        """Persistent 401 raises a typed error after N attempts — never silent-empty."""
+        bad = Mock(); bad.status_code = 401
+        mock_get.return_value = bad
+
+        with pytest.raises(TransientAuthError):
+            _get_with_auth_retry("https://x/eventLogs", headers={})
+
+        assert mock_get.call_count == 3
+
     def test_apply_security_control_events_filters_product_name(self, mock_security_control_events_data):
         """Test filtering by product name."""
         # Test exact match


### PR DESCRIPTION
Completes **SAF-32805 acceptance criterion 3** (the 401 retry). Criteria 1 & 2 — filter correctness + empty-match guard — are in **#68**; this is intentionally a separate PR so #68 can merge independently.

## Problem
`get_security_controls_events` hits transient HTTP 401s with no retry; the fetch propagated the 401 as an error, so the agent **abandoned verification mid-analysis** (SB-36136) — a transient auth blip read as "couldn't check," nudging false conclusions.

## Why retry, not refresh
Auth headers come from the **live per-request user credentials** (`get_auth_headers_for_console` → MCP `request_ctx`) — there's **no server-managed token to refresh**. A 401 here is typically transient (RBAC-gateway propagation / auth race), so the only safe recovery is re-issuing after a short backoff; a persistent 401 = genuinely rejected creds.

## Fix
`_get_with_auth_retry(url, headers, timeout)` in `data_functions.py`, used by the security-control-events fetch:
- 401 → retry up to `_AUTH_RETRY_ATTEMPTS` (default 3, env-tunable) with exponential backoff.
- Persistent 401 → raise **`TransientAuthError`** (explicit typed error, never silent/empty).
- Non-401 → unchanged (`check_rbac_response`: 403 RBAC hint + `raise_for_status`).

Kept as a **local helper calling `requests.get`** (not a new shared module) to stay focused on the incident path and avoid disturbing the ~20 other call sites and their tests. Extract to `safebreach_mcp_core` if a second path needs it.

## Tests
- `test_get_with_auth_retry_recovers_from_transient_401` (401→200 retries, returns 200).
- `test_get_with_auth_retry_persistent_401_raises_typed` (all-401 → `TransientAuthError` after N).
- Full data suite green (**477**); the existing security-control-events tests are unaffected (zero churn).

## Acceptance criteria
- ✅ Transient 401s auto-recover.
- ✅ Persistent 401s raise an explicit typed error, never silent-empty.

PRD: `prds/SAF-32805/prd-401-retry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
