### PR TITLE
PRD: rename run semantics to evaluate/evaluating and quick_run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,8 +298,8 @@ Caller identity (`get_caller_identity()`): auth token SHA256[:16] for external c
 | `update_studio_attack_draft` | After param validation | After PUT + cache update | — |
 | `run_studio_attack` | After input validation | After POST queue response | — |
 | `set_studio_attack_status` | After pre-check GET | After PUT + cache invalidate | Allow read first |
-| `run_scenario` | Before queue POST | After POST queue response | Skip on dry_run/not_ready |
-| `run_adhoc_scenario` | Before queue POST | After POST queue response | Skip on dry_run |
+| `run_scenario` | Before queue POST | After POST queue response | Skip on evaluate/not_ready |
+| `quick_run` | Before queue POST | After POST queue response | Skip on evaluate |
 | `manage_test` | After input validation | After state change | Note append is best-effort |
 
 Rate limiting environment variables:
@@ -323,7 +323,7 @@ Rate limiting environment variables:
   Ready-to-run = all steps have both targetFilter AND attackerFilter with non-empty criteria values.
   Supports ordering by name, step_count, createdAt, updatedAt (asc/desc). PAGE_SIZE=10 with hint_to_agent.
   Each scenario includes `total_attack_count` (int or None for criteria-based).
-  Conditional `hint_to_agent` when indeterminate counts exist: use `run_scenario` with `dry_run=True`.
+  Conditional `hint_to_agent` when indeterminate counts exist: use `run_scenario` with `evaluate=True`.
 4. `get_scenario_details` ✨ **NEW** - Full scenario/plan payload by ID. Accepts UUID string (OOB) or
   integer-as-string (custom plan). Returns complete payload including all steps with attack filters,
   system/target/attacker filters, phases, actions, edges, plus `source_type` and resolved category names
@@ -396,11 +396,11 @@ Rate limiting environment variables:
   key must be `{"<type>": {"operator": "is", "values": [...], "name": "<type>"}}`. Valid types:
   os, role, simulators, connection. Supports `"default"` key for applying to all missing steps —
   note: "default" only applies to fully-missing steps, not partially-ready ones),
-  `dry_run` (default False — preview without queuing),
+  `evaluate` (default False — evaluate the test without queuing),
   `verbose_failures` (default False — per-attack constraint detail for partial steps).
   **Three-turn workflow**: (1) Call without overrides → diagnostic showing missing filters with
   per-step recommendations (role for network steps, OS for host-level). (2) Call with
-  `step_overrides` + `dry_run=True` → preview with resolved attacks per step, per-step
+  `step_overrides` + `evaluate=True` → preview with resolved attacks per step, per-step
   simulation breakdown (matched target/attacker simulators, matched attacks), and constraint
   failure details for unmatched attacks. (3) Call with `step_overrides` → queue the test.
   **Constraint diagnostics**: 14 constraint reason codes mapped to human-readable descriptions.
@@ -419,16 +419,17 @@ Rate limiting environment variables:
   Note format: `[YYYY-MM-DD HH:MM:SS UTC] Test {action}: {reason}`. Note append is
   best-effort — failure does not block the lifecycle operation. Response includes
   `hint_to_agent` with contextual next-step guidance per action.
-22. `run_adhoc_scenario` ✨ **NEW** 🔒 **Rate-limited** - Execute an ad-hoc scenario from explicit
-  playbook attack IDs. Constructs one step per attack with default all-connected simulator
-  filters. Supports `simulator_overrides` (JSON string mapping attack IDs to specific target/attacker
-  simulator UUIDs) for exact targeting, and `all_connected` global override. Defaults to
-  `dry_run=True` — returns a preview with per-step simulation counts without queuing. The agent
-  MUST present the preview to the user and get confirmation before calling with `dry_run=False`.
-  Partial execution: if some attacks produce 0 simulations, they are skipped (user saw the preview).
+22. `quick_run` ✨ **NEW** 🔒 **Rate-limited** - Quick Run — execute a test from explicit
+  playbook attack IDs without a pre-existing scenario. Constructs one step per attack with default
+  all-connected simulator filters. Supports `simulator_overrides` (JSON string mapping attack IDs
+  to specific target/attacker simulator UUIDs) for exact targeting, and `all_connected` global
+  override. Defaults to `evaluate=True` — evaluates the test with per-step simulation counts
+  without queuing. The agent MUST present the evaluation to the user and get confirmation before
+  calling with `evaluate=False`.
+  Partial execution: if some attacks produce 0 simulations, they are skipped (user saw the evaluation).
   Hard-refuses if ALL attacks produce 0. Parameters: `attack_ids` (required, comma-separated
   integers), `console`, `test_name`, `all_connected` (bool), `simulator_overrides` (JSON string),
-  `dry_run` (bool, default True). Uses the same queue API as `run_scenario`.
+  `evaluate` (bool, default True). Uses the same queue API as `run_scenario`.
   **Simulator UUID discovery**: For rerun workflows, get UUIDs from `get_simulation_details`
   (`attacker_node_id`, `target_node_id`). For discovery workflows, use `get_console_simulators`.
 23. `get_studio_attack_latest_result` ✨ **Enhanced** - Retrieves latest execution results for a Studio

--- a/prds/mcp-semantics-quick-run-evaluate.md
+++ b/prds/mcp-semantics-quick-run-evaluate.md
@@ -1,0 +1,125 @@
+# MCP Semantics: "Evaluating Test" and "Quick Run"
+
+## 1. Overview
+
+Rename two confusing user-facing concepts in the studio MCP tools: the "dry run" preview state becomes "evaluating test" semantics, and the `run_adhoc_scenario` tool becomes `quick_run` to match platform naming.
+
+**Business Problem:** Users see "dry run" when a test is being evaluated, which is confusing, and the "ad-hoc" tool name is inconsistent with the platform's "Quick Run" terminology.
+
+**Key Benefits:**
+- The evaluation preview reads as what it is: evaluating a test before queuing it.
+- Tool naming matches the SafeBreach platform vocabulary ("Quick Run").
+
+**Target Consumer:** MCP agent users running or evaluating tests through the studio MCP tools.
+
+> **Scope decisions:**
+> 1. The rename goes all the way: parameter (`dry_run` -> `evaluate`), response status (`'dry_run'` -> `'evaluating'`), and all wording. Verified safe: the concept never reaches the SafeBreach REST API (both tools return the preview before `_submit_to_queue`), and no known consumer references the parameter, status value, or tool names on the wire — MCP clients discover tools dynamically.
+> 2. New wire-level tool name is `quick_run`.
+> 3. The delete-preview `dry_run` in `manage_test`/`sb_delete_test`/`sb_manage_test` is a SEPARATE confirm-before-destroy mechanism and is NOT touched.
+
+---
+
+## 2. Core Feature Components
+
+### Current State
+- `safebreach_mcp_studio/studio_server.py` registers `run_scenario` with `dry_run: bool = False` and `run_adhoc_scenario` with `dry_run: bool = True`, via `@self.mcp.tool(name=..., annotations=..., description=...)`.
+- Preview responses carry `'status': 'dry_run'` and render Markdown headers "## Dry Run — Simulation Prediction" / "## Ad-hoc Scenario — Dry Run Preview".
+- Ad-hoc internals: `sb_run_adhoc_scenario`, `_build_adhoc_steps`, `_apply_adhoc_overrides` in `studio_functions.py`; default test name `f"Ad-hoc Test ({len(steps)} attacks)"`; rate-limit bucket `"run_adhoc_scenario"`.
+- Cross-package hint in `safebreach_mcp_config/config_types.py` tells the model to use `run_scenario ... dry_run=True`.
+
+### Target State
+- Tool `quick_run` (was `run_adhoc_scenario`) with `evaluate: bool = True` parameter; `run_scenario` with `evaluate: bool = False`.
+- Preview responses carry `'status': 'evaluating'`; headers read "## Evaluating Test — Simulation Prediction" / "## Quick Run — Test Evaluation"; hints say "call again with evaluate=False" to queue the test.
+- Default ad-hoc test name becomes `f"Quick Run ({len(steps)} attacks)"`; rate-limit bucket `"quick_run"`.
+- Internal names follow: `sb_quick_run`, `_build_quick_run_steps`, `_apply_quick_run_overrides`.
+- Docs (CLAUDE.md catalog + gate table) and the config-package hint updated. Delete-preview `dry_run` untouched.
+
+---
+
+## 3. Technical Specifications
+
+### API Changes (MCP tool contract)
+- Tool rename: `run_adhoc_scenario` -> `quick_run` (wire-level `name=` in the FastMCP decorator; `ToolAnnotations` unchanged: `readOnlyHint=False, destructiveHint=True`).
+- Parameter rename on `run_scenario` and `quick_run`: `dry_run` -> `evaluate` (same types/defaults: `False` for `run_scenario`, `True` for `quick_run`).
+- Response status value: `'dry_run'` -> `'evaluating'` in the two run-evaluation preview dicts (NOT in the delete preview).
+
+### Data Model Changes
+- None (no persistence).
+
+### Configuration Changes
+- None.
+
+### Dependencies
+- None. Verified: no upstream REST parameter depends on the old names; rate-limit buckets are free-form call-site strings; no RBAC/allowlist is keyed by tool name.
+
+---
+
+## 4. Definition of Done
+
+- [ ] Evaluation preview presents "evaluating test" wording everywhere the user/model sees it (headers, hints, docstrings, status).
+- [ ] The ad-hoc tool is named `quick_run` and described as "Quick Run" everywhere.
+- [ ] Delete-preview `dry_run` behavior and wording unchanged.
+- [ ] `run_scenario` description's cross-reference and `config_types.py` hint updated.
+- [ ] CLAUDE.md tool catalog and rate-limiting gate table updated.
+- [ ] "Quick Run" wording does not conflate with `run_studio_attack`'s existing "parity with a UI quick-run" phrasing (that description gets clarified if needed).
+- [ ] Unit tests written and passing
+- [ ] Code coverage maintained or improved
+- [ ] Code follows existing repository patterns
+- [ ] No unnecessary changes outside task scope
+
+---
+
+## 5. Implementation Phases
+
+### Phase 1: Rename the evaluation concept (dry_run -> evaluate/evaluating)
+**Scope:** `run_scenario` + `run_adhoc_scenario` evaluation flow only; delete preview excluded.
+
+**Deliverables:**
+- `evaluate` parameter on both tools, `'evaluating'` status, all user/model-facing wording updated.
+
+**Files to modify:**
+- `safebreach_mcp_studio/studio_server.py`: `run_scenario` signature/description/examples, status branch, Markdown header, hint texts; `run_adhoc_scenario` signature/description, status branch, header, hint.
+- `safebreach_mcp_studio/studio_functions.py`: `sb_run_scenario`, `sb_run_adhoc_scenario` signatures, docstrings, preview dicts, hint strings, internal uses.
+- `safebreach_mcp_config/config_types.py`: hint text.
+
+### Phase 2: Rename the tool (run_adhoc_scenario -> quick_run)
+**Scope:** Wire name, descriptions, internals, rate-limit bucket, default test name.
+
+**Files to modify:**
+- `safebreach_mcp_studio/studio_server.py`: `name="quick_run"`, description, inner def, import; `run_scenario` description cross-reference; headers "## Quick Run ...", error text.
+- `safebreach_mcp_studio/studio_functions.py`: `sb_quick_run`, `_build_quick_run_steps`, `_apply_quick_run_overrides`, default test name, rate-limit labels, log messages, section comment.
+
+### Phase 3: Tests and docs
+**Files to modify:**
+- `safebreach_mcp_studio/tests/test_e2e_run_adhoc_scenario.py` -> rename to `test_e2e_quick_run.py`, update tool/function references.
+- `safebreach_mcp_studio/tests/test_e2e_run_scenario.py`, `test_studio_functions.py`, `test_rate_limiting.py`: `evaluate`/`'evaluating'`/`sb_quick_run` updates, test function renames (`test_dry_run*` -> `test_evaluate*`), keeping delete-preview tests (`test_delete_dry_run_*`) unchanged.
+- `CLAUDE.md`: tool catalog entries, gate table.
+- `CHANGELOG.md`: new entry for the rename.
+
+---
+
+## 6. Testing Strategy
+
+### Unit Tests
+- Evaluation preview (`evaluate=True`) returns `'status': 'evaluating'` with prediction fields, without calling the queue API or rate-limit gates.
+- `quick_run` queues a test when `evaluate=False` and the default test name starts with "Quick Run".
+- Rate limiting keys on the `"quick_run"` bucket.
+
+### Edge Cases
+- `manage_test action='delete'` still returns `'status': 'dry_run'` and `dry_run: True` (proves the delete preview was not conflated).
+- Markdown output contains the new headers and no "dry run"/"ad-hoc" strings in the evaluation flow.
+
+### Error Scenarios
+- `quick_run` with attacks that produce 0 simulations returns the updated error wording.
+
+---
+
+## 7. Risks and Mitigation
+
+### Technical Risks
+- **Existing clients calling `run_adhoc_scenario` or passing `dry_run`:** breaking change on the MCP wire contract. Mitigation: MCP clients discover tools dynamically; saved prompts referencing old names will get a tool-not-found — acceptable per the rename's intent; flagged in CHANGELOG.
+- **Conflating the delete preview:** mitigated by explicit exclusion (Phase 1 scope) and regression coverage.
+- **"Quick Run" collision with `run_studio_attack`'s "UI quick-run" phrasing:** clarify that description if it becomes ambiguous.
+
+### Dependencies
+- None.

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -341,7 +341,7 @@ def paginate_scenarios(
         hints.append(
             'Some scenarios have criteria-based attack selection, so their '
             'total_attack_count is unavailable at listing time. Use run_scenario '
-            'with dry_run=True to determine the exact attack count for those scenarios.'
+            'with evaluate=True to determine the exact attack count for those scenarios.'
         )
 
     return {

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2403,7 +2403,7 @@ def _get_scenario_statistics(steps, console, include_constraints=False,
         steps: List of scenario step dicts (with filter fields)
         console: SafeBreach console name
         include_constraints: If True, include per-attack constraint failure reasons
-            (adds latency — use only for dry_run)
+            (adds latency — use only for evaluate)
         verbose_failures: If True, show per-attack constraints even for partial steps
             (default: aggregated summary for partial, per-attack for zero)
 
@@ -2437,7 +2437,7 @@ def _get_scenario_statistics(steps, console, include_constraints=False,
     data = response.json().get('data', {})
     step_stats = data.get('steps', [])
 
-    # Build attack name map for dry_run (resolved attacks + constraint rendering)
+    # Build attack name map for evaluate (resolved attacks + constraint rendering)
     attack_names = _build_attack_name_map(console) if include_constraints else {}
 
     result = []
@@ -2495,7 +2495,7 @@ def _get_scenario_statistics(steps, console, include_constraints=False,
 
 
 # ---------------------------------------------------------------------------
-# run_adhoc_scenario — SAF-31295: Ad-hoc attack execution
+# quick_run — SAF-31295: Quick Run attack execution
 # ---------------------------------------------------------------------------
 
 
@@ -2561,7 +2561,7 @@ def _validate_and_resolve_attack_ids(attack_ids_str, console):
     return parsed_ids, name_map
 
 
-def _build_adhoc_steps(parsed_ids, name_map):
+def _build_quick_run_steps(parsed_ids, name_map):
     """
     Construct one step per attack with default connection filters.
 
@@ -2606,7 +2606,7 @@ def _build_adhoc_steps(parsed_ids, name_map):
     return steps
 
 
-def _apply_adhoc_overrides(steps, overrides, parsed_ids):
+def _apply_quick_run_overrides(steps, overrides, parsed_ids):
     """
     Apply per-attack simulator overrides to constructed steps.
 
@@ -2666,20 +2666,20 @@ def _apply_adhoc_overrides(steps, overrides, parsed_ids):
             step["attackerFilter"] = target_filter
 
 
-def sb_run_adhoc_scenario(
+def sb_quick_run(
     attack_ids: str,
     console: str = "default",
     test_name: str = None,
     all_connected: bool = False,
     simulator_overrides: str = None,
-    dry_run: bool = True,
+    evaluate: bool = True,
 ) -> Dict[str, Any]:
     """
-    Construct and execute an ad-hoc scenario from explicit playbook attack IDs.
+    Construct and execute a Quick Run test from explicit playbook attack IDs.
 
     Creates one step per attack with default all-connected simulator filters.
     Supports per-attack simulator overrides and a global all_connected toggle.
-    Defaults to dry_run=True — returns a preview without queuing.
+    Defaults to evaluate=True — evaluates the test without queuing.
 
     Args:
         attack_ids: Comma-separated playbook attack IDs (integers)
@@ -2687,10 +2687,10 @@ def sb_run_adhoc_scenario(
         test_name: Custom test name (optional, auto-generated if not provided)
         all_connected: Global override — all connected simulators (default: False)
         simulator_overrides: JSON string for per-attack simulator targeting
-        dry_run: If True (default), preview without queuing
+        evaluate: If True (default), evaluate without queuing
 
     Returns:
-        Dict with status='dry_run' (preview) or status='queued' (execution)
+        Dict with status='evaluating' (evaluation) or status='queued' (execution)
 
     Raises:
         ValueError: If attack_ids invalid, not found, or overrides malformed
@@ -2705,23 +2705,23 @@ def sb_run_adhoc_scenario(
 
     # Phase 2: Input validation and step construction
     parsed_ids, name_map = _validate_and_resolve_attack_ids(attack_ids, console)
-    steps = _build_adhoc_steps(parsed_ids, name_map)
+    steps = _build_quick_run_steps(parsed_ids, name_map)
 
     # Phase 3: Simulator overrides
 
     if parsed_overrides and not all_connected:
-        _apply_adhoc_overrides(steps, parsed_overrides, parsed_ids)
+        _apply_quick_run_overrides(steps, parsed_overrides, parsed_ids)
 
     # Phase 4: Statistics pre-flight
     step_stats = _get_scenario_statistics(
-        steps, console, include_constraints=dry_run
+        steps, console, include_constraints=evaluate
     )
     step_counts = [s.get('simulationCount', 0) for s in step_stats]
     total_predicted = sum(step_counts)
     empty_steps = [i + 1 for i, c in enumerate(step_counts) if c == 0]
 
-    # Dry-run: return preview without queuing
-    if dry_run:
+    # Evaluate: return prediction without queuing
+    if evaluate:
         # Build contextual hint based on results
         if total_predicted == 0:
             hint = (
@@ -2734,19 +2734,19 @@ def sb_run_adhoc_scenario(
                 f"{len(empty_steps)} attack(s) will produce 0 simulations. "
                 "You can proceed (they will be skipped), provide "
                 "simulator_overrides for those attacks, or remove them. "
-                "To execute, call again with dry_run=False."
+                "To execute, call again with evaluate=False."
             )
         elif total_predicted > 1000:
             hint = (
                 f"High simulation count ({total_predicted:,}). Consider using "
                 "simulator_overrides to target specific simulators and reduce "
-                "the count. To execute as-is, call again with dry_run=False."
+                "the count. To execute as-is, call again with evaluate=False."
             )
         else:
-            hint = "To execute, call again with dry_run=False."
+            hint = "To execute, call again with evaluate=False."
 
         return {
-            'status': 'dry_run',
+            'status': 'evaluating',
             'attack_ids': parsed_ids,
             'steps': steps,
             'predicted_simulations': total_predicted,
@@ -2760,7 +2760,7 @@ def sb_run_adhoc_scenario(
     # Execution validation
     if total_predicted == 0:
         raise ValueError(
-            f"Ad-hoc scenario would produce 0 simulations across all "
+            f"Quick Run would produce 0 simulations across all "
             f"{len(steps)} attacks. No matching simulators found."
         )
 
@@ -2780,7 +2780,7 @@ def sb_run_adhoc_scenario(
     actions, edges = _build_linear_dag(steps)
 
     # Build queue payload
-    effective_test_name = test_name or f"Ad-hoc Test ({len(steps)} attacks)"
+    effective_test_name = test_name or f"Quick Run ({len(steps)} attacks)"
     payload = {
         "plan": {
             "name": effective_test_name,
@@ -2793,13 +2793,13 @@ def sb_run_adhoc_scenario(
 
     # Rate limiting gates
     caller_id = get_caller_identity()
-    rate_limiter.check_limit(caller_id, "run_adhoc_scenario")
+    rate_limiter.check_limit(caller_id, "quick_run")
 
     # Submit to queue
     api_response = _submit_to_queue(payload, console)
 
     # Record successful action
-    rate_limiter.record_action(caller_id, "run_adhoc_scenario")
+    rate_limiter.record_action(caller_id, "quick_run")
 
     # Extract response data
     data = api_response.get('data', {})
@@ -2832,7 +2832,7 @@ def sb_run_adhoc_scenario(
     }
 
     logger.info(
-        f"Successfully queued ad-hoc scenario "
+        f"Successfully queued Quick Run "
         f"(test_id: {result['test_id']}, attacks: {len(parsed_ids)}, "
         f"steps queued: {result['step_count']})"
     )
@@ -2846,7 +2846,7 @@ def sb_run_scenario(
     test_name: str = None,
     allow_partial_steps: bool = False,
     step_overrides: str = None,
-    dry_run: bool = False,
+    evaluate: bool = False,
     verbose_failures: bool = False,
 ) -> Dict[str, Any]:
     """
@@ -2863,7 +2863,7 @@ def sb_run_scenario(
         allow_partial_steps: If False (default), refuse if any step produces 0 simulations.
         step_overrides: JSON string mapping step numbers (1-indexed) to filter overrides.
             Example: '{"1": {"targetFilter": {"os": {"operator": "is", "values": ["WINDOWS"]}}}}'
-        dry_run: If True, predict simulation counts without actually queuing the test.
+        evaluate: If True, predict simulation counts without actually queuing the test.
 
     Returns:
         If ready (or made ready via overrides): dict with test_id, status='queued', etc.
@@ -2933,9 +2933,9 @@ def sb_run_scenario(
         }
 
     # Statistics pre-flight: predict simulation counts per step
-    # Include constraints for dry_run to diagnose zero-simulation steps
+    # Include constraints for evaluate to diagnose zero-simulation steps
     step_stats = _get_scenario_statistics(scenario['steps'], console,
-                                          include_constraints=dry_run,
+                                          include_constraints=evaluate,
                                           verbose_failures=verbose_failures)
     step_counts = [s['simulationCount'] for s in step_stats]
     total_predicted = sum(step_counts)
@@ -2943,14 +2943,14 @@ def sb_run_scenario(
         i + 1 for i, count in enumerate(step_counts) if count == 0
     ]
 
-    # dry_run: return prediction without queuing (before validation — the point is to preview)
-    if dry_run:
+    # evaluate: return prediction without queuing (before validation — the point is to preview)
+    if evaluate:
         logger.info(
-            f"Dry run for scenario '{scenario.get('name')}' ({scenario_id}): "
+            f"Evaluating test for scenario '{scenario.get('name')}' ({scenario_id}): "
             f"predicted {total_predicted} simulations, empty steps: {empty_steps}"
         )
         return {
-            'status': 'dry_run',
+            'status': 'evaluating',
             'scenario_id': scenario_id,
             'scenario_name': scenario.get('name', ''),
             'source_type': 'custom' if is_custom_plan else 'oob',
@@ -2961,7 +2961,7 @@ def sb_run_scenario(
             'step_count': len(scenario.get('steps', [])),
         }
 
-    # Validate simulation counts (only for actual runs, not dry_run)
+    # Validate simulation counts (only for actual runs, not evaluate)
     if total_predicted == 0:
         step_names = [s.get('name', f'Step {i+1}') for i, s in enumerate(scenario['steps'])]
         raise ValueError(
@@ -3031,7 +3031,7 @@ def sb_run_scenario(
 
         payload = {"plan": plan_body}
 
-    # Rate limiting gate — check before queuing (after dry_run/not_ready early returns)
+    # Rate limiting gate — check before queuing (after evaluate/not_ready early returns)
     caller_id = get_caller_identity()
     rate_limiter.check_limit(caller_id, "run_scenario")
 

--- a/safebreach_mcp_studio/studio_server.py
+++ b/safebreach_mcp_studio/studio_server.py
@@ -26,7 +26,7 @@ from .studio_functions import (
     sb_get_studio_attack_boilerplate,
     sb_set_studio_attack_status,
     sb_run_scenario,
-    sb_run_adhoc_scenario,
+    sb_quick_run,
     sb_manage_test,
 )
 
@@ -1029,7 +1029,7 @@ set_studio_attack_status(attack_id=10000298, new_status="draft", console="demo")
             description="""Executes a ready-to-run SafeBreach scenario on the platform.
 
 Use this when you have an EXISTING scenario ID from get_scenarios. For running specific
-playbook attack IDs without a pre-existing scenario, use run_adhoc_scenario instead.
+playbook attack IDs without a pre-existing scenario, use quick_run instead.
 
 IMPORTANT: This tool triggers REAL attack simulations on simulators. Ensure the correct
 scenario_id before calling. Use get_scenarios (Config Server) to discover available scenarios
@@ -1070,10 +1070,10 @@ Parameters:
   it does NOT merge with partially-ready steps that already have one filter side set.
 
   Format: '{"default": {"targetFilter": {...}, "attackerFilter": {...}}, "8": {"attackerFilter": {...}}}'
-- dry_run (optional, bool, default False): If True, predict simulation counts per step
-  without actually queuing the test. Use this to preview what would happen before committing
-  to a real execution. Shows resolved attacks per step and constraint diagnostics.
-- verbose_failures (optional, bool, default False): When True with dry_run, show per-attack
+- evaluate (optional, bool, default False): If True, evaluate the test — predict simulation
+  counts per step without actually queuing it. Use this to preview what would happen before
+  committing to a real execution. Shows resolved attacks per step and constraint diagnostics.
+- verbose_failures (optional, bool, default False): When True with evaluate, show per-attack
   constraint detail even for steps that produce some simulations (default: aggregated summary
   for partial steps, per-attack for zero steps).
 
@@ -1088,12 +1088,12 @@ info showing missing filters per step (when not ready).
 Example (ready scenario):
 run_scenario(scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5", console="demo")
 
-Example (dry_run preview — no test queued):
-run_scenario(scenario_id="3b8eade5-...", console="demo", dry_run=True)
+Example (evaluate preview — no test queued):
+run_scenario(scenario_id="3b8eade5-...", console="demo", evaluate=True)
 
 Example (3-turn workflow for non-ready scenarios):
   1. run_scenario(scenario_id="abc-123", console="demo")  # returns diagnostic
-  2. run_scenario(scenario_id="abc-123", step_overrides='{"default": {"targetFilter": ...}, "8": {"attackerFilter": ...}}', dry_run=True)  # preview
+  2. run_scenario(scenario_id="abc-123", step_overrides='{"default": {"targetFilter": ...}, "8": {"attackerFilter": ...}}', evaluate=True)  # preview
   3. run_scenario(scenario_id="abc-123", step_overrides='...')  # execute"""
         )
         def run_scenario(
@@ -1102,10 +1102,10 @@ Example (3-turn workflow for non-ready scenarios):
             test_name: str = None,
             allow_partial_steps: bool = False,
             step_overrides: str = None,
-            dry_run: bool = False,
+            evaluate: bool = False,
             verbose_failures: bool = False,
         ) -> str:
-            """Execute a scenario, return diagnostic, or preview with dry_run."""
+            """Execute a scenario, return diagnostic, or preview with evaluate."""
             try:
                 # Single-tenant console auto-resolve
                 from safebreach_mcp_core.environments_metadata import get_console_name, safebreach_envs
@@ -1120,7 +1120,7 @@ Example (3-turn workflow for non-ready scenarios):
                     test_name=test_name,
                     allow_partial_steps=allow_partial_steps,
                     step_overrides=step_overrides,
-                    dry_run=dry_run,
+                    evaluate=evaluate,
                     verbose_failures=verbose_failures,
                 )
 
@@ -1216,15 +1216,15 @@ Example (3-turn workflow for non-ready scenarios):
 
                     return "\n".join(parts)
 
-                # Handle dry_run prediction response
-                if result.get('status') == 'dry_run':
+                # Handle evaluate prediction response
+                if result.get('status') == 'evaluating':
                     predicted_per_step = result.get('predicted_per_step', [])
                     step_stats = result.get('step_stats', [])
                     predicted_total = result.get('predicted_simulations', 0)
                     empty_steps = result.get('empty_steps', [])
 
                     parts = [
-                        "## Dry Run — Simulation Prediction",
+                        "## Evaluating Test — Simulation Prediction",
                         "",
                         f"**Scenario:** {result.get('scenario_name')} "
                         f"(`{result.get('scenario_id')}`, {result.get('source_type')})",
@@ -1334,7 +1334,7 @@ Example (3-turn workflow for non-ready scenarios):
                         elif count == 0 and not stats.get('constraint_summary'):
                             parts.append(
                                 "  - **0 viable pairings** — rerun with "
-                                "`dry_run=True` for constraint details"
+                                "`evaluate=True` for constraint details"
                             )
 
                     if empty_steps:
@@ -1347,7 +1347,7 @@ Example (3-turn workflow for non-ready scenarios):
                     parts.extend([
                         "",
                         "**No test was queued.** To execute, call again "
-                        "without `dry_run=True`.",
+                        "without `evaluate=True`.",
                     ])
 
                     return "\n".join(parts)
@@ -1411,18 +1411,18 @@ Example (3-turn workflow for non-ready scenarios):
                 logger.error(f"Error in run_scenario: {e}")
                 return f"Error running scenario: {str(e)}"
 
-        # ----- run_adhoc_scenario (SAF-31295) -----
+        # ----- quick_run (SAF-31295) -----
 
         @self.mcp.tool(
-            name="run_adhoc_scenario",
+            name="quick_run",
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
-            description="""Execute an ad-hoc scenario from explicit playbook attack IDs.
+            description="""Quick Run — execute a test from explicit playbook attack IDs.
 
 Use this when you have SPECIFIC playbook attack IDs to run without a pre-existing scenario.
 For running an existing OOB or custom scenario by ID, use run_scenario instead.
 
 Constructs one step per attack, predicts simulation counts via the statistics API,
-and presents a dry-run preview before execution. Use get_playbook_attacks to discover
+and evaluates the test before execution. Use get_playbook_attacks to discover
 attack IDs beforehand.
 
 Parameters:
@@ -1438,27 +1438,27 @@ Parameters:
   **How to get simulator UUIDs:**
   - From get_simulation_details: use attacker_node_id and target_node_id fields (rerun workflow)
   - From get_console_simulators: use the simulator id field (discovery workflow)
-- dry_run (optional, bool, default True): Preview without queuing. The agent MUST
-  present the preview to the user and get confirmation before calling with dry_run=False.
+- evaluate (optional, bool, default True): Evaluate the test without queuing. The agent MUST
+  present the evaluation to the user and get confirmation before calling with evaluate=False.
 
-Returns: Markdown summary with predicted simulation counts (dry_run) or test_id (queued).
+Returns: Markdown summary with predicted simulation counts (evaluate) or test_id (queued).
 
-Example (preview):
-  run_adhoc_scenario(attack_ids="8849,217", console="demo")
-Example (execute after preview):
-  run_adhoc_scenario(attack_ids="8849,217", console="demo", dry_run=False)
+Example (evaluate):
+  quick_run(attack_ids="8849,217", console="demo")
+Example (execute after evaluation):
+  quick_run(attack_ids="8849,217", console="demo", evaluate=False)
 Example (rerun with exact simulators from a previous simulation):
-  run_adhoc_scenario(attack_ids="8849", simulator_overrides='{"8849": {"target": ["target-node-id"], "attacker": ["attacker-node-id"]}}', console="demo")"""
+  quick_run(attack_ids="8849", simulator_overrides='{"8849": {"target": ["target-node-id"], "attacker": ["attacker-node-id"]}}', console="demo")"""
         )
-        def run_adhoc_scenario(
+        def quick_run(
             attack_ids: str,
             console: str = "default",
             test_name: str = None,
             all_connected: bool = False,
             simulator_overrides: str = None,
-            dry_run: bool = True,
+            evaluate: bool = True,
         ) -> str:
-            """Execute an ad-hoc scenario from playbook attack IDs."""
+            """Execute a Quick Run test from playbook attack IDs."""
             try:
                 # Single-tenant console auto-resolve
                 from safebreach_mcp_core.environments_metadata import (
@@ -1469,23 +1469,23 @@ Example (rerun with exact simulators from a previous simulation):
                     if console_name != 'default' and console not in safebreach_envs:
                         console = console_name
 
-                result = sb_run_adhoc_scenario(
+                result = sb_quick_run(
                     attack_ids=attack_ids,
                     console=console,
                     test_name=test_name,
                     all_connected=all_connected,
                     simulator_overrides=simulator_overrides,
-                    dry_run=dry_run,
+                    evaluate=evaluate,
                 )
 
-                # Format dry_run response
-                if result.get('status') == 'dry_run':
+                # Format evaluate response
+                if result.get('status') == 'evaluating':
                     predicted_per_step = result.get('predicted_per_step', [])
                     steps = result.get('steps', [])
                     empty_steps = result.get('empty_steps', [])
 
                     parts = [
-                        "## Ad-hoc Scenario — Dry Run Preview",
+                        "## Quick Run — Test Evaluation",
                         "",
                         f"**Attacks:** {len(steps)} attacks, "
                         f"{result.get('predicted_simulations', 0):,} predicted simulations",
@@ -1512,7 +1512,7 @@ Example (rerun with exact simulators from a previous simulation):
                     parts.extend([
                         "",
                         "**No test was queued.** "
-                        + result.get('hint_to_agent', 'To execute, call again with dry_run=False.'),
+                        + result.get('hint_to_agent', 'To execute, call again with evaluate=False.'),
                     ])
 
                     return "\n".join(parts)
@@ -1521,7 +1521,7 @@ Example (rerun with exact simulators from a previous simulation):
                 skipped = result.get('skipped_attacks', [])
 
                 parts = [
-                    "## Ad-hoc Scenario Queued",
+                    "## Quick Run Queued",
                     "",
                     f"**Test ID:** `{result.get('test_id')}`",
                     f"**Test Name:** {result.get('test_name')}",
@@ -1544,11 +1544,11 @@ Example (rerun with exact simulators from a previous simulation):
                 return "\n".join(parts)
 
             except ValueError as e:
-                logger.error(f"Ad-hoc scenario error: {e}")
-                return f"Ad-hoc Scenario Error: {str(e)}"
+                logger.error(f"Quick Run error: {e}")
+                return f"Quick Run Error: {str(e)}"
             except Exception as e:
-                logger.error(f"Error in run_adhoc_scenario: {e}")
-                return f"Error running ad-hoc scenario: {str(e)}"
+                logger.error(f"Error in quick_run: {e}")
+                return f"Error running Quick Run: {str(e)}"
 
         # ----- manage_test (SAF-29969) -----
 

--- a/safebreach_mcp_studio/tests/test_e2e_quick_run.py
+++ b/safebreach_mcp_studio/tests/test_e2e_quick_run.py
@@ -1,8 +1,8 @@
 """
-End-to-End Tests for run_adhoc_scenario (SAF-31295)
+End-to-End Tests for quick_run (SAF-31295)
 
-Tests the ad-hoc scenario execution pipeline using real API calls.
-Pattern: dry_run → verify predictions → queue → cancel.
+Tests the Quick Run execution pipeline using real API calls.
+Pattern: evaluate → verify predictions → queue → cancel.
 
 ZERO MOCKS — all calls hit real SafeBreach APIs.
 
@@ -20,7 +20,7 @@ import pytest
 import os
 import requests
 
-from safebreach_mcp_studio.studio_functions import sb_run_adhoc_scenario
+from safebreach_mcp_studio.studio_functions import sb_quick_run
 from safebreach_mcp_core.secret_utils import get_secret_for_console
 from safebreach_mcp_core.environments_metadata import get_api_base_url, get_api_account_id
 
@@ -120,46 +120,46 @@ def _cleanup_test(test_id, console, test_name, passed, detail=""):
 
 
 # ---------------------------------------------------------------------------
-# E2E Tests — run_adhoc_scenario
+# E2E Tests — quick_run
 # ---------------------------------------------------------------------------
 
 
 @skip_e2e
 @pytest.mark.e2e
-class TestRunAdhocScenarioE2E:
-    """E2E tests for sb_run_adhoc_scenario against a real console."""
+class TestQuickRunE2E:
+    """E2E tests for sb_quick_run against a real console."""
 
-    def test_dry_run_all_attacks(self):
-        """Dry-run with all verified attacks produces predicted_simulations > 0."""
+    def test_evaluate_all_attacks(self):
+        """Evaluate with all verified attacks produces predicted_simulations > 0."""
         attack_ids_str = ",".join(str(a) for a in E2E_ATTACK_IDS)
 
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids=attack_ids_str,
             console=E2E_CONSOLE,
-            dry_run=True,
+            evaluate=True,
         )
 
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert result["predicted_simulations"] > 0
         assert len(result["steps"]) == len(E2E_ATTACK_IDS)
         assert len(result["predicted_per_step"]) == len(E2E_ATTACK_IDS)
         logger.info(
-            f"Dry-run {len(E2E_ATTACK_IDS)} attacks: {result['predicted_simulations']} predicted sims, "
+            f"Evaluate {len(E2E_ATTACK_IDS)} attacks: {result['predicted_simulations']} predicted sims, "
             f"per-step: {result['predicted_per_step']}"
         )
 
-    def test_dry_run_subset_two_attacks(self):
-        """Dry-run with 2 attacks returns correct step count and per-step counts."""
+    def test_evaluate_subset_two_attacks(self):
+        """Evaluate with 2 attacks returns correct step count and per-step counts."""
         subset = E2E_ATTACK_IDS[:2]
         attack_ids_str = ",".join(str(a) for a in subset)
 
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids=attack_ids_str,
             console=E2E_CONSOLE,
-            dry_run=True,
+            evaluate=True,
         )
 
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert len(result["steps"]) == 2
         assert len(result["predicted_per_step"]) == 2
         # Each step should have a non-negative count
@@ -167,7 +167,7 @@ class TestRunAdhocScenarioE2E:
             assert isinstance(count, int)
             assert count >= 0
         logger.info(
-            f"Dry-run 2 attacks: {result['predicted_simulations']} predicted sims, "
+            f"Evaluate 2 attacks: {result['predicted_simulations']} predicted sims, "
             f"per-step: {result['predicted_per_step']}"
         )
 
@@ -179,10 +179,10 @@ class TestRunAdhocScenarioE2E:
         passed = False
 
         try:
-            result = sb_run_adhoc_scenario(
+            result = sb_quick_run(
                 attack_ids=attack_ids_str,
                 console=E2E_CONSOLE,
-                dry_run=False,
+                evaluate=False,
             )
 
             assert result["status"] == "queued"
@@ -191,7 +191,7 @@ class TestRunAdhocScenarioE2E:
             test_id = result["test_id"]
             passed = True
             logger.info(
-                f"Queued ad-hoc scenario: test_id={test_id}, "
+                f"Queued Quick Run: test_id={test_id}, "
                 f"steps={result['step_count']}, "
                 f"predicted={result['predicted_simulations']}"
             )
@@ -208,23 +208,23 @@ class TestRunAdhocScenarioE2E:
         attack_ids_str = f"{E2E_ATTACK_IDS[0]},99999999"
 
         with pytest.raises(ValueError, match="not found"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids=attack_ids_str,
                 console=E2E_CONSOLE,
             )
 
-    def test_dry_run_with_simulator_overrides(self):
-        """Dry-run with pre-verified simulator overrides produces minimal sims."""
+    def test_evaluate_with_simulator_overrides(self):
+        """Evaluate with pre-verified simulator overrides produces minimal sims."""
         attack_ids_str = ",".join(str(a) for a in E2E_ATTACK_IDS)
 
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids=attack_ids_str,
             console=E2E_CONSOLE,
             simulator_overrides=json.dumps(E2E_SIMULATOR_OVERRIDES),
-            dry_run=True,
+            evaluate=True,
         )
 
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert result["predicted_simulations"] > 0
         # Every attack should produce at least 1 simulation
         for i, count in enumerate(result["predicted_per_step"]):
@@ -237,7 +237,7 @@ class TestRunAdhocScenarioE2E:
             f"got {result['predicted_simulations']}"
         )
         logger.info(
-            f"Overrides dry-run: {result['predicted_simulations']} sims, "
+            f"Overrides evaluation: {result['predicted_simulations']} sims, "
             f"per-step: {result['predicted_per_step']}"
         )
 
@@ -248,11 +248,11 @@ class TestRunAdhocScenarioE2E:
         passed = False
 
         try:
-            result = sb_run_adhoc_scenario(
+            result = sb_quick_run(
                 attack_ids=attack_ids_str,
                 console=E2E_CONSOLE,
                 simulator_overrides=json.dumps(E2E_SIMULATOR_OVERRIDES),
-                dry_run=False,
+                evaluate=False,
             )
 
             assert result["status"] == "queued"

--- a/safebreach_mcp_studio/tests/test_e2e_run_scenario.py
+++ b/safebreach_mcp_studio/tests/test_e2e_run_scenario.py
@@ -164,7 +164,7 @@ class TestRunScenarioE2E:
         ready_plan = None
         for p in ready_plans:
             dry = sb_run_scenario(scenario_id=str(p['id']),
-                                 console=E2E_CONSOLE, dry_run=True)
+                                 console=E2E_CONSOLE, evaluate=True)
             if dry.get('predicted_simulations', 0) >= 20 and not dry.get('empty_steps'):
                 ready_plan = p
                 break
@@ -213,10 +213,10 @@ class TestRunScenarioE2E:
         step = result['diagnostic']['missing_steps'][0]
         assert 'recommendation' in step
 
-    def test_dry_run(self):
-        """Slice 4: dry_run for OOB, custom plan, and with overrides — no queuing.
-        Covers: dry_run predictions, source_type, step_overrides, resolved_attacks."""
-        # OOB dry_run
+    def test_evaluate(self):
+        """Slice 4: evaluate for OOB, custom plan, and with overrides — no queuing.
+        Covers: evaluate predictions, source_type, step_overrides, resolved_attacks."""
+        # OOB evaluate
         scenarios = _fetch_all_scenarios(E2E_CONSOLE)
         ready_oob = next((s for s in scenarios
                           if compute_scenario_readiness(s)), None)
@@ -224,8 +224,8 @@ class TestRunScenarioE2E:
 
         result = sb_run_scenario(
             scenario_id=str(ready_oob['id']),
-            console=E2E_CONSOLE, dry_run=True)
-        assert result['status'] == 'dry_run'
+            console=E2E_CONSOLE, evaluate=True)
+        assert result['status'] == 'evaluating'
         assert result['predicted_simulations'] > 0
         assert result['source_type'] == 'oob'
         assert 'test_id' not in result
@@ -234,7 +234,7 @@ class TestRunScenarioE2E:
         if result['step_stats'][0].get('resolved_attacks'):
             assert result['step_stats'][0]['resolved_attacks'][0].get('move_id')
 
-        # Custom plan dry_run
+        # Custom plan evaluate
         plans = _fetch_all_plans(E2E_CONSOLE)
         ready_plan = next((p for p in plans
                            if compute_scenario_readiness(p)), None)
@@ -242,12 +242,12 @@ class TestRunScenarioE2E:
 
         result2 = sb_run_scenario(
             scenario_id=str(ready_plan['id']),
-            console=E2E_CONSOLE, dry_run=True)
-        assert result2['status'] == 'dry_run'
+            console=E2E_CONSOLE, evaluate=True)
+        assert result2['status'] == 'evaluating'
         assert result2['source_type'] == 'custom'
         assert 'test_id' not in result2
 
-        # Augmented dry_run
+        # Augmented evaluate
         not_ready = next((s for s in scenarios
                           if not compute_scenario_readiness(s)), None)
         if not_ready:
@@ -255,8 +255,8 @@ class TestRunScenarioE2E:
             result3 = sb_run_scenario(
                 scenario_id=str(not_ready['id']),
                 console=E2E_CONSOLE,
-                step_overrides=overrides, dry_run=True)
-            assert result3['status'] == 'dry_run'
+                step_overrides=overrides, evaluate=True)
+            assert result3['status'] == 'evaluating'
             assert len(result3['predicted_per_step']) == len(
                 not_ready.get('steps', []))
 

--- a/safebreach_mcp_studio/tests/test_rate_limiting.py
+++ b/safebreach_mcp_studio/tests/test_rate_limiting.py
@@ -303,7 +303,7 @@ MOCK_QUEUE_RESPONSE = {
 
 
 class TestRunScenarioRateLimitingGate:
-    """Verify run_scenario gates: check_limit before queue POST, skip on dry_run."""
+    """Verify run_scenario gates: check_limit before queue POST, skip on evaluate."""
 
     @patch("safebreach_mcp_studio.studio_functions.rate_limiter")
     @patch("safebreach_mcp_studio.studio_functions.get_caller_identity",
@@ -370,11 +370,11 @@ class TestRunScenarioRateLimitingGate:
            return_value="1234567890")
     @patch("safebreach_mcp_studio.studio_functions.get_api_base_url",
            return_value="https://test.safebreach.com")
-    def test_dry_run_does_not_call_gates(
+    def test_evaluate_does_not_call_gates(
         self, _mock_base_url, _mock_account_id,
         mock_get, _mock_stats, _mock_identity, mock_rate_limiter,
     ):
-        """dry_run=True returns prediction without calling check_limit or record_action."""
+        """evaluate=True returns prediction without calling check_limit or record_action."""
         mock_get_resp = MagicMock()
         mock_get_resp.json.return_value = [MOCK_OOB_SCENARIO]
         mock_get_resp.raise_for_status.return_value = None
@@ -383,9 +383,9 @@ class TestRunScenarioRateLimitingGate:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test",
-            dry_run=True,
+            evaluate=True,
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         mock_rate_limiter.check_limit.assert_not_called()
         mock_rate_limiter.record_action.assert_not_called()
 

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -35,7 +35,7 @@ from safebreach_mcp_studio.studio_functions import (
     _fetch_storage_stats,
     _build_linear_dag,
     _submit_to_queue,
-    sb_run_adhoc_scenario,
+    sb_quick_run,
     studio_draft_cache,
     MAIN_FUNCTION_PATTERN,
     _validate_and_build_parameters,
@@ -7227,12 +7227,12 @@ class TestCustomPlanAugmentation:
 
 
 # =====================================================================
-# dry_run Tests (SAF-29967 — Slice 4 extension)
+# evaluate Tests (SAF-29967 — Slice 4 extension)
 # =====================================================================
 
 
-class TestDryRun:
-    """Test dry_run parameter — returns predictions without queuing."""
+class TestEvaluate:
+    """Test evaluate parameter — returns predictions without queuing."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -7247,11 +7247,11 @@ class TestDryRun:
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_account_id')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_dry_run_returns_prediction_without_queuing(
+    def test_evaluate_returns_prediction_without_queuing(
         self, mock_base_url, mock_account_id,
         mock_get, mock_post, mock_stats, mock_oob_scenario
     ):
-        """dry_run=True returns statistics but does NOT call queue API."""
+        """evaluate=True returns statistics but does NOT call queue API."""
         mock_base_url.return_value = "https://test.safebreach.com"
         mock_account_id.return_value = "1234567890"
 
@@ -7263,10 +7263,10 @@ class TestDryRun:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True
+            evaluate=True
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         assert result['predicted_simulations'] == 3874
         assert result['predicted_per_step'] == [1676, 2198]
         assert result['step_stats'] is not None
@@ -7281,11 +7281,11 @@ class TestDryRun:
            return_value=[{'simulationCount': 500, 'matchedTargetSimulators': 5, 'matchedAttackerSimulators': 3, 'matchedAttacks': 10, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}, {'simulationCount': 0, 'matchedTargetSimulators': 0, 'matchedAttackerSimulators': 0, 'matchedAttacks': 0, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}])
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_dry_run_with_empty_steps_reports_them(
+    def test_evaluate_with_empty_steps_reports_them(
         self, mock_base_url, mock_get, mock_stats,
         mock_oob_scenario
     ):
-        """dry_run with some steps producing 0 still returns (no error)."""
+        """evaluate with some steps producing 0 still returns (no error)."""
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -7296,10 +7296,10 @@ class TestDryRun:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True
+            evaluate=True
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         assert result['predicted_simulations'] == 500
         assert result['empty_steps'] == [2]
 
@@ -7307,11 +7307,11 @@ class TestDryRun:
            return_value=[{'simulationCount': 500, 'matchedTargetSimulators': 5, 'matchedAttackerSimulators': 3, 'matchedAttacks': 10, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 15}, {'simulationCount': 300, 'matchedTargetSimulators': 4, 'matchedAttackerSimulators': 2, 'matchedAttacks': 8, 'totalTargetSimulators': 12, 'totalAttackerSimulators': 6, 'totalAttacks': 12}])
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_dry_run_with_overrides(
+    def test_evaluate_with_overrides(
         self, mock_base_url, mock_get, mock_stats,
         mock_scenario_all_missing
     ):
-        """dry_run with step_overrides — augments then predicts."""
+        """evaluate with step_overrides — augments then predicts."""
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -7338,10 +7338,10 @@ class TestDryRun:
             scenario_id="aaaa-bbbb-cccc-dddd",
             console="test-console",
             step_overrides=overrides,
-            dry_run=True
+            evaluate=True
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         assert result['predicted_simulations'] == 800
         assert 'test_id' not in result  # No queue call made
 
@@ -7352,7 +7352,7 @@ class TestDryRun:
 
 
 class TestResolvedAttacks:
-    """Test that dry_run includes resolved attacks per step."""
+    """Test that evaluate includes resolved attacks per step."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -7366,11 +7366,11 @@ class TestResolvedAttacks:
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
     @patch('safebreach_mcp_studio.studio_functions.requests.get')
     @patch('safebreach_mcp_studio.studio_functions.get_api_base_url')
-    def test_dry_run_includes_resolved_attacks(
+    def test_evaluate_includes_resolved_attacks(
         self, mock_base_url, mock_get, mock_stats, mock_names,
         mock_oob_scenario
     ):
-        """dry_run response includes resolved_attacks per step with names."""
+        """evaluate response includes resolved_attacks per step with names."""
         mock_base_url.return_value = "https://test.safebreach.com"
 
         mock_get_response = MagicMock()
@@ -7397,10 +7397,10 @@ class TestResolvedAttacks:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True
+            evaluate=True
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         step_stats = result.get('step_stats', [])
         assert len(step_stats) == 2
 
@@ -7447,7 +7447,7 @@ class TestResolvedAttacks:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True
+            evaluate=True
         )
 
         resolved = result['step_stats'][0].get('resolved_attacks', [])
@@ -7509,11 +7509,11 @@ class TestVerboseFailures:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True,
+            evaluate=True,
             verbose_failures=True,
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         # Step 1 (partial) should have constraint_summary (per-attack), not aggregated
         step1 = result['step_stats'][0]
         assert 'constraint_summary' in step1
@@ -7561,11 +7561,11 @@ class TestVerboseFailures:
         result = sb_run_scenario(
             scenario_id="3b8eade5-9285-43b8-b3e7-6350420983a5",
             console="test-console",
-            dry_run=True,
+            evaluate=True,
             verbose_failures=False,
         )
 
-        assert result['status'] == 'dry_run'
+        assert result['status'] == 'evaluating'
         step1 = result['step_stats'][0]
         # Should have aggregated, not per-attack
         assert 'constraint_summary_aggregated' in step1
@@ -9170,8 +9170,8 @@ DEFAULT_CONNECTION_FILTER = {
 }
 
 
-class TestAdhocScenarioInputParsing:
-    """Test input parsing for sb_run_adhoc_scenario."""
+class TestQuickRunInputParsing:
+    """Test input parsing for sb_quick_run."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9190,10 +9190,10 @@ class TestAdhocScenarioInputParsing:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(3)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217,1071", console="test"
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert len(result["steps"]) == 3
 
     @patch('safebreach_mcp_studio.studio_functions._get_scenario_statistics')
@@ -9206,21 +9206,21 @@ class TestAdhocScenarioInputParsing:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(2)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids=" 8849 , 217 ", console="test"
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert len(result["steps"]) == 2
 
     def test_empty_string_raises_valueerror(self):
         """Empty string raises ValueError."""
         with pytest.raises(ValueError, match="attack_ids.*required"):
-            sb_run_adhoc_scenario(attack_ids="", console="test")
+            sb_quick_run(attack_ids="", console="test")
 
     def test_none_raises_valueerror(self):
         """None raises ValueError."""
         with pytest.raises(ValueError, match="attack_ids.*required"):
-            sb_run_adhoc_scenario(attack_ids=None, console="test")
+            sb_quick_run(attack_ids=None, console="test")
 
     @patch(
         'safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api',
@@ -9229,7 +9229,7 @@ class TestAdhocScenarioInputParsing:
     def test_non_integer_raises_valueerror(self, mock_playbook):
         """'8849,abc,217' raises ValueError for non-integer."""
         with pytest.raises(ValueError, match="invalid"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids="8849,abc,217", console="test"
             )
 
@@ -9243,13 +9243,13 @@ class TestAdhocScenarioInputParsing:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(2)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,,217", console="test"
         )
         assert len(result["steps"]) == 2
 
 
-class TestAdhocScenarioAttackValidation:
+class TestQuickRunAttackValidation:
     """Test attack ID validation against playbook cache."""
 
     @pytest.fixture(autouse=True)
@@ -9269,10 +9269,10 @@ class TestAdhocScenarioAttackValidation:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(2)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217", console="test"
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
 
     @patch(
         'safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api',
@@ -9281,7 +9281,7 @@ class TestAdhocScenarioAttackValidation:
     def test_some_invalid_ids_raises_valueerror(self, mock_playbook):
         """Some invalid IDs raises ValueError listing the invalid ones."""
         with pytest.raises(ValueError, match="99999"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids="8849,99999,88888", console="test"
             )
 
@@ -9292,7 +9292,7 @@ class TestAdhocScenarioAttackValidation:
     def test_all_invalid_ids_raises_valueerror(self, mock_playbook):
         """All invalid IDs raises ValueError listing all."""
         with pytest.raises(ValueError, match="not found"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids="99999,88888", console="test"
             )
 
@@ -9304,15 +9304,15 @@ class TestAdhocScenarioAttackValidation:
     def test_playbook_cache_failure_graceful(self, mock_playbook, mock_stats):
         """Playbook cache failure degrades gracefully — names unavailable."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         # Should still work — just without attack name resolution
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert len(result["steps"]) == 1
 
 
-class TestAdhocScenarioStepConstruction:
+class TestQuickRunStepConstruction:
     """Test one-step-per-attack construction."""
 
     @pytest.fixture(autouse=True)
@@ -9332,7 +9332,7 @@ class TestAdhocScenarioStepConstruction:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(3)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217,1071", console="test"
         )
         steps = result["steps"]
@@ -9352,7 +9352,7 @@ class TestAdhocScenarioStepConstruction:
         mock_stats.return_value = [
             {"simulationCount": 10} for _ in range(2)
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217", console="test"
         )
         steps = result["steps"]
@@ -9367,7 +9367,7 @@ class TestAdhocScenarioStepConstruction:
     def test_step_names_fallback_without_cache(self, mock_playbook, mock_stats):
         """Step names fall back to 'Attack {id}' when cache unavailable."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         steps = result["steps"]
@@ -9381,7 +9381,7 @@ class TestAdhocScenarioStepConstruction:
     def test_steps_have_uuid(self, mock_playbook, mock_stats):
         """Each step has a non-empty uuid."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         step = result["steps"][0]
@@ -9399,7 +9399,7 @@ class TestAdhocScenarioStepConstruction:
     ):
         """Default targetFilter is connection: all_connected."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         step = result["steps"][0]
@@ -9415,7 +9415,7 @@ class TestAdhocScenarioStepConstruction:
     ):
         """Default attackerFilter is connection: all_connected."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         step = result["steps"][0]
@@ -9429,7 +9429,7 @@ class TestAdhocScenarioStepConstruction:
     def test_steps_have_empty_system_filter(self, mock_playbook, mock_stats):
         """Each step has systemFilter: {}."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         assert result["steps"][0]["systemFilter"] == {}
@@ -9442,7 +9442,7 @@ class TestAdhocScenarioStepConstruction:
     def test_attacks_filter_structure(self, mock_playbook, mock_stats):
         """attacksFilter has correct playbook filter structure."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test"
         )
         af = result["steps"][0]["attacksFilter"]["playbook"]
@@ -9456,8 +9456,8 @@ class TestAdhocScenarioStepConstruction:
 # ---------------------------------------------------------------------------
 
 
-class TestAdhocScenarioSimulatorOverrides:
-    """Test simulator_overrides for sb_run_adhoc_scenario."""
+class TestQuickRunSimulatorOverrides:
+    """Test simulator_overrides for sb_quick_run."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9480,7 +9480,7 @@ class TestAdhocScenarioSimulatorOverrides:
                 "attacker": ["sim-uuid-3"],
             }
         })
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217", console="test",
             simulator_overrides=overrides,
         )
@@ -9515,7 +9515,7 @@ class TestAdhocScenarioSimulatorOverrides:
         overrides = json.dumps({
             "8849": {"target": ["sim-uuid-1"]},
         })
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test",
             simulator_overrides=overrides,
         )
@@ -9544,7 +9544,7 @@ class TestAdhocScenarioSimulatorOverrides:
                 "attacker": ["sim-attacker"],
             },
         })
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test",
             simulator_overrides=overrides,
         )
@@ -9564,7 +9564,7 @@ class TestAdhocScenarioSimulatorOverrides:
             "8849": {"target": ["sim-a"]},
             "1071": {"target": ["sim-b"], "attacker": ["sim-c"]},
         })
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217,1071", console="test",
             simulator_overrides=overrides,
         )
@@ -9588,7 +9588,7 @@ class TestAdhocScenarioSimulatorOverrides:
             "99999": {"target": ["sim-x"]},
         })
         with pytest.raises(ValueError, match="99999"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids="8849", console="test",
                 simulator_overrides=overrides,
             )
@@ -9596,7 +9596,7 @@ class TestAdhocScenarioSimulatorOverrides:
     def test_invalid_json_raises(self):
         """Invalid JSON string raises ValueError (fail-fast, before attack validation)."""
         with pytest.raises(ValueError, match="[Ii]nvalid.*JSON"):
-            sb_run_adhoc_scenario(
+            sb_quick_run(
                 attack_ids="8849", console="test",
                 simulator_overrides="not-valid-json{",
             )
@@ -9610,7 +9610,7 @@ class TestAdhocScenarioSimulatorOverrides:
         """Override filter uses simulators key with operator/values/name."""
         mock_stats.return_value = [{"simulationCount": 10}]
         overrides = json.dumps({"8849": {"target": ["uuid-1"]}})
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test",
             simulator_overrides=overrides,
         )
@@ -9621,8 +9621,8 @@ class TestAdhocScenarioSimulatorOverrides:
         assert tf["simulators"]["values"] == ["uuid-1"]
 
 
-class TestAdhocScenarioAllConnected:
-    """Test all_connected override for sb_run_adhoc_scenario."""
+class TestQuickRunAllConnected:
+    """Test all_connected override for sb_quick_run."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9639,7 +9639,7 @@ class TestAdhocScenarioAllConnected:
     def test_all_connected_keeps_default_filters(self, mock_playbook, mock_stats):
         """all_connected=True — steps already have connection filter (no change)."""
         mock_stats.return_value = [{"simulationCount": 10} for _ in range(2)]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217", console="test",
             all_connected=True,
         )
@@ -9660,7 +9660,7 @@ class TestAdhocScenarioAllConnected:
         overrides = json.dumps({
             "8849": {"target": ["sim-uuid-1"], "attacker": ["sim-uuid-2"]},
         })
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test",
             all_connected=True,
             simulator_overrides=overrides,
@@ -9682,7 +9682,7 @@ class TestAdhocScenarioAllConnected:
         """all_connected=False (default) allows simulator_overrides to apply."""
         mock_stats.return_value = [{"simulationCount": 10}]
         overrides = json.dumps({"8849": {"target": ["sim-uuid-1"]}})
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849", console="test",
             all_connected=False,
             simulator_overrides=overrides,
@@ -9692,14 +9692,14 @@ class TestAdhocScenarioAllConnected:
 
 
 # ---------------------------------------------------------------------------
-# Phase 4 (SAF-31295): Statistics, dry-run & execution
+# Phase 4 (SAF-31295): Statistics, evaluate & execution
 # ---------------------------------------------------------------------------
 
 # Standard mock for queue API response
-MOCK_QUEUE_RESPONSE_ADHOC = {
+MOCK_QUEUE_RESPONSE_QUICK_RUN = {
     "data": {
         "planRunId": "1779200000000.1",
-        "name": "Ad-hoc Test",
+        "name": "Quick Run Test",
         "steps": [
             {"stepRunId": "1779200000000.2"},
             {"stepRunId": "1779200000000.3"},
@@ -9708,8 +9708,8 @@ MOCK_QUEUE_RESPONSE_ADHOC = {
 }
 
 
-class TestAdhocScenarioDryRun:
-    """Test dry_run=True (default) behavior."""
+class TestQuickRunEvaluate:
+    """Test evaluate=True (default) behavior."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9724,20 +9724,20 @@ class TestAdhocScenarioDryRun:
         'safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api',
         return_value=MOCK_PLAYBOOK_ATTACKS,
     )
-    def test_dry_run_calls_statistics_not_queue(
+    def test_evaluate_calls_statistics_not_queue(
         self, mock_playbook, mock_stats, mock_queue
     ):
-        """dry_run=True: statistics called, queue NOT called."""
+        """evaluate=True: statistics called, queue NOT called."""
         mock_stats.return_value = [
             {"simulationCount": 10},
             {"simulationCount": 5},
         ]
-        result = sb_run_adhoc_scenario(
-            attack_ids="8849,217", console="test", dry_run=True,
+        result = sb_quick_run(
+            attack_ids="8849,217", console="test", evaluate=True,
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         mock_stats.assert_called_once()
-        # dry_run should pass include_constraints=True for diagnostic detail
+        # evaluate should pass include_constraints=True for diagnostic detail
         assert mock_stats.call_args[1].get("include_constraints") is True
         mock_queue.assert_not_called()
 
@@ -9747,18 +9747,18 @@ class TestAdhocScenarioDryRun:
         'safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api',
         return_value=MOCK_PLAYBOOK_ATTACKS,
     )
-    def test_dry_run_response_structure(
+    def test_evaluate_response_structure(
         self, mock_playbook, mock_stats, mock_queue
     ):
-        """dry_run response has status, steps, predicted counts, empty_steps."""
+        """evaluate response has status, steps, predicted counts, empty_steps."""
         mock_stats.return_value = [
             {"simulationCount": 10},
             {"simulationCount": 0},
         ]
-        result = sb_run_adhoc_scenario(
+        result = sb_quick_run(
             attack_ids="8849,217", console="test",
         )
-        assert result["status"] == "dry_run"
+        assert result["status"] == "evaluating"
         assert result["predicted_simulations"] == 10
         assert result["predicted_per_step"] == [10, 0]
         assert 2 in result["empty_steps"]  # step 2 (1-indexed) has 0 sims
@@ -9771,20 +9771,20 @@ class TestAdhocScenarioDryRun:
         'safebreach_mcp_playbook.playbook_functions._get_all_attacks_from_cache_or_api',
         return_value=MOCK_PLAYBOOK_ATTACKS,
     )
-    def test_dry_run_does_not_trigger_rate_limiting(
+    def test_evaluate_does_not_trigger_rate_limiting(
         self, mock_playbook, mock_stats, mock_queue, mock_limiter
     ):
-        """dry_run=True: rate limiter NOT called."""
+        """evaluate=True: rate limiter NOT called."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        sb_run_adhoc_scenario(
-            attack_ids="8849", console="test", dry_run=True,
+        sb_quick_run(
+            attack_ids="8849", console="test", evaluate=True,
         )
         mock_limiter.check_limit.assert_not_called()
         mock_limiter.record_action.assert_not_called()
 
 
-class TestAdhocScenarioExecution:
-    """Test dry_run=False (execution) behavior."""
+class TestQuickRunExecution:
+    """Test evaluate=False (execution) behavior."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9803,14 +9803,14 @@ class TestAdhocScenarioExecution:
     def test_execution_calls_queue(
         self, mock_playbook, mock_stats, mock_queue, mock_limiter
     ):
-        """dry_run=False: statistics + queue both called, returns queued status."""
+        """evaluate=False: statistics + queue both called, returns queued status."""
         mock_stats.return_value = [
             {"simulationCount": 10},
             {"simulationCount": 5},
         ]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        result = sb_run_adhoc_scenario(
-            attack_ids="8849,217", console="test", dry_run=False,
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        result = sb_quick_run(
+            attack_ids="8849,217", console="test", evaluate=False,
         )
         assert result["status"] == "queued"
         assert result["test_id"] == "1779200000000.1"
@@ -9834,9 +9834,9 @@ class TestAdhocScenarioExecution:
             {"simulationCount": 10},
             {"simulationCount": 5},
         ]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        result = sb_run_adhoc_scenario(
-            attack_ids="8849,217", console="test", dry_run=False,
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        result = sb_quick_run(
+            attack_ids="8849,217", console="test", evaluate=False,
         )
         assert result["step_run_ids"] == [
             "1779200000000.2", "1779200000000.3"
@@ -9857,8 +9857,8 @@ class TestAdhocScenarioExecution:
             {"simulationCount": 0},
         ]
         with pytest.raises(ValueError, match="0 simulations"):
-            sb_run_adhoc_scenario(
-                attack_ids="8849,217", console="test", dry_run=False,
+            sb_quick_run(
+                attack_ids="8849,217", console="test", evaluate=False,
             )
         mock_queue.assert_not_called()
 
@@ -9881,15 +9881,15 @@ class TestAdhocScenarioExecution:
         mock_queue.return_value = {
             "data": {
                 "planRunId": "test.1",
-                "name": "Ad-hoc Test",
+                "name": "Quick Run Test",
                 "steps": [
                     {"stepRunId": "test.2"},
                     {"stepRunId": "test.3"},
                 ],
             }
         }
-        result = sb_run_adhoc_scenario(
-            attack_ids="8849,217,1071", console="test", dry_run=False,
+        result = sb_quick_run(
+            attack_ids="8849,217,1071", console="test", evaluate=False,
         )
         assert result["status"] == "queued"
         # Verify the queue payload has only 2 steps (0-sim step removed)
@@ -9921,8 +9921,8 @@ class TestAdhocScenarioExecution:
                 "steps": [{"stepRunId": "t.2"}, {"stepRunId": "t.3"}],
             }
         }
-        sb_run_adhoc_scenario(
-            attack_ids="8849,217,1071", console="test", dry_run=False,
+        sb_quick_run(
+            attack_ids="8849,217,1071", console="test", evaluate=False,
         )
         queue_payload = mock_queue.call_args[0][0]
         # DAG should have actions and edges for 2 steps
@@ -9933,8 +9933,8 @@ class TestAdhocScenarioExecution:
         assert len(multi) == 2
 
 
-class TestAdhocScenarioRateLimiting:
-    """Test rate limiting gates for sb_run_adhoc_scenario."""
+class TestQuickRunRateLimiting:
+    """Test rate limiting gates for sb_quick_run."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -9955,14 +9955,14 @@ class TestAdhocScenarioRateLimiting:
     ):
         """check_limit called BEFORE queue POST."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        sb_run_adhoc_scenario(
-            attack_ids="8849", console="test", dry_run=False,
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        sb_quick_run(
+            attack_ids="8849", console="test", evaluate=False,
         )
         mock_limiter.check_limit.assert_called_once()
         # check_limit must be called with caller_id and tool name
         call_args = mock_limiter.check_limit.call_args
-        assert call_args[0][1] == "run_adhoc_scenario"
+        assert call_args[0][1] == "quick_run"
 
     @patch('safebreach_mcp_studio.studio_functions.rate_limiter')
     @patch('safebreach_mcp_studio.studio_functions._submit_to_queue')
@@ -9976,13 +9976,13 @@ class TestAdhocScenarioRateLimiting:
     ):
         """record_action called AFTER successful queue POST."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        sb_run_adhoc_scenario(
-            attack_ids="8849", console="test", dry_run=False,
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        sb_quick_run(
+            attack_ids="8849", console="test", evaluate=False,
         )
         mock_limiter.record_action.assert_called_once()
         call_args = mock_limiter.record_action.call_args
-        assert call_args[0][1] == "run_adhoc_scenario"
+        assert call_args[0][1] == "quick_run"
 
     @patch('safebreach_mcp_studio.studio_functions.rate_limiter')
     @patch('safebreach_mcp_studio.studio_functions._submit_to_queue')
@@ -9998,14 +9998,14 @@ class TestAdhocScenarioRateLimiting:
         mock_stats.return_value = [{"simulationCount": 10}]
         mock_queue.side_effect = requests.exceptions.ConnectionError("fail")
         with pytest.raises(requests.exceptions.RequestException):
-            sb_run_adhoc_scenario(
-                attack_ids="8849", console="test", dry_run=False,
+            sb_quick_run(
+                attack_ids="8849", console="test", evaluate=False,
             )
         mock_limiter.check_limit.assert_called_once()
         mock_limiter.record_action.assert_not_called()
 
 
-class TestAdhocScenarioTestName:
+class TestQuickRunTestName:
     """Test test_name parameter handling."""
 
     @pytest.fixture(autouse=True)
@@ -10027,10 +10027,10 @@ class TestAdhocScenarioTestName:
     ):
         """Custom test_name appears in queue payload."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        sb_run_adhoc_scenario(
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        sb_quick_run(
             attack_ids="8849", console="test",
-            test_name="My Custom Test", dry_run=False,
+            test_name="My Custom Test", evaluate=False,
         )
         payload = mock_queue.call_args[0][0]
         assert payload["plan"]["name"] == "My Custom Test"
@@ -10045,23 +10045,23 @@ class TestAdhocScenarioTestName:
     def test_default_test_name_auto_generated(
         self, mock_playbook, mock_stats, mock_queue, mock_limiter
     ):
-        """No test_name → auto-generated default containing 'Ad-hoc'."""
+        """No test_name → auto-generated default containing 'Quick Run'."""
         mock_stats.return_value = [{"simulationCount": 10}]
-        mock_queue.return_value = MOCK_QUEUE_RESPONSE_ADHOC
-        sb_run_adhoc_scenario(
-            attack_ids="8849", console="test", dry_run=False,
+        mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
+        sb_quick_run(
+            attack_ids="8849", console="test", evaluate=False,
         )
         payload = mock_queue.call_args[0][0]
-        assert "Ad-hoc" in payload["plan"]["name"] or "ad-hoc" in payload["plan"]["name"].lower()
+        assert "Quick Run" in payload["plan"]["name"]
 
 
 # ---------------------------------------------------------------------------
-# Phase 5 (SAF-31295): MCP tool wrapper — run_adhoc_scenario
+# Phase 5 (SAF-31295): MCP tool wrapper — quick_run
 # ---------------------------------------------------------------------------
 
 
-class TestAdhocScenarioMCPWrapper:
-    """Test the run_adhoc_scenario MCP tool wrapper (Markdown formatting)."""
+class TestQuickRunMCPWrapper:
+    """Test the quick_run MCP tool wrapper (Markdown formatting)."""
 
     @pytest.fixture(autouse=True)
     def set_auth_context(self):
@@ -10071,29 +10071,29 @@ class TestAdhocScenarioMCPWrapper:
         _user_auth_artifacts.reset(token)
 
     def _get_wrapper(self):
-        """Get the run_adhoc_scenario wrapper function from the server."""
+        """Get the quick_run wrapper function from the server."""
         from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
         server = SafeBreachStudioServer()
         # Find the registered tool by name
         for tool in server.mcp._tool_manager._tools.values():
-            if tool.name == "run_adhoc_scenario":
+            if tool.name == "quick_run":
                 return tool.fn
-        raise AssertionError("run_adhoc_scenario tool not registered")
+        raise AssertionError("quick_run tool not registered")
 
     def test_tool_is_registered(self):
-        """Tool is registered with name run_adhoc_scenario."""
+        """Tool is registered with name quick_run."""
         from safebreach_mcp_studio.studio_server import SafeBreachStudioServer
         server = SafeBreachStudioServer()
         tool_names = [
             t.name for t in server.mcp._tool_manager._tools.values()
         ]
-        assert "run_adhoc_scenario" in tool_names
+        assert "quick_run" in tool_names
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
-    def test_dry_run_markdown_contains_preview_header(self, mock_fn):
-        """Dry-run Markdown contains 'Dry Run Preview'."""
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
+    def test_evaluate_markdown_contains_preview_header(self, mock_fn):
+        """Evaluate Markdown contains 'Quick Run — Test Evaluation'."""
         mock_fn.return_value = {
-            'status': 'dry_run',
+            'status': 'evaluating',
             'attack_ids': [8849, 217],
             'steps': [
                 {"name": "Attack 8849", "attacksFilter": {"playbook": {"values": [8849]}}},
@@ -10107,16 +10107,16 @@ class TestAdhocScenarioMCPWrapper:
         }
         wrapper = self._get_wrapper()
         result = wrapper(attack_ids="8849,217", console="test")
-        assert "Dry Run" in result
-        assert "Preview" in result
+        assert "Quick Run" in result
+        assert "Test Evaluation" in result
         assert "15" in result  # total predicted
         assert "No test was queued" in result or "no test" in result.lower()
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
-    def test_dry_run_markdown_flags_zero_sim(self, mock_fn):
-        """Dry-run Markdown flags 0-sim attacks."""
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
+    def test_evaluate_markdown_flags_zero_sim(self, mock_fn):
+        """Evaluate Markdown flags 0-sim attacks."""
         mock_fn.return_value = {
-            'status': 'dry_run',
+            'status': 'evaluating',
             'attack_ids': [8849, 217],
             'steps': [
                 {"name": "Attack 8849", "attacksFilter": {"playbook": {"values": [8849]}}},
@@ -10134,13 +10134,13 @@ class TestAdhocScenarioMCPWrapper:
         # Should mention the 0-sim attack
         assert "217" in result or "0 sim" in result.lower()
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
     def test_queued_markdown_contains_test_id(self, mock_fn):
         """Queued Markdown contains test_id and queued header."""
         mock_fn.return_value = {
             'status': 'queued',
             'test_id': '1779200000000.1',
-            'test_name': 'Ad-hoc Test',
+            'test_name': 'Quick Run Test',
             'attack_ids': [8849],
             'step_count': 1,
             'step_run_ids': ['1779200000000.2'],
@@ -10155,13 +10155,13 @@ class TestAdhocScenarioMCPWrapper:
             ),
         }
         wrapper = self._get_wrapper()
-        result = wrapper(attack_ids="8849", console="test", dry_run=False)
+        result = wrapper(attack_ids="8849", console="test", evaluate=False)
         assert "Queued" in result or "queued" in result
         assert "1779200000000.1" in result
         assert "get_test_details" in result
         assert "manage_test" in result
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
     def test_queued_markdown_shows_skipped_attacks(self, mock_fn):
         """Partial execution Markdown lists skipped attacks."""
         mock_fn.return_value = {
@@ -10179,12 +10179,12 @@ class TestAdhocScenarioMCPWrapper:
         }
         wrapper = self._get_wrapper()
         result = wrapper(
-            attack_ids="8849,217,1071", console="test", dry_run=False,
+            attack_ids="8849,217,1071", console="test", evaluate=False,
         )
         assert "217" in result
         assert "skipped" in result.lower() or "0 sim" in result.lower()
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
     def test_valueerror_returns_error_message(self, mock_fn):
         """ValueError returns error-prefixed message."""
         mock_fn.side_effect = ValueError("attack_ids is required")
@@ -10193,7 +10193,7 @@ class TestAdhocScenarioMCPWrapper:
         assert "Error" in result
         assert "attack_ids is required" in result
 
-    @patch('safebreach_mcp_studio.studio_server.sb_run_adhoc_scenario')
+    @patch('safebreach_mcp_studio.studio_server.sb_quick_run')
     def test_exception_returns_error_message(self, mock_fn):
         """Generic exception returns error message."""
         mock_fn.side_effect = RuntimeError("unexpected failure")


### PR DESCRIPTION
## Summary
- Adds the PRD for renaming the studio MCP run semantics: the confusing "dry run" preview becomes "evaluating test" semantics (`evaluate` parameter, `'evaluating'` status), and the `run_adhoc_scenario` tool becomes `quick_run` to match platform naming.
- PRD only for now — implementation follows on this branch after review.
- The delete-preview `dry_run` in `manage_test` is a separate confirm-before-destroy mechanism and stays out of scope.