### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.0 — 2026-07-07
+
+### Added
+
+- `get_test_drifts` can now compare any two arbitrary/non-consecutive test runs via `baseline_test_id`,
+  with configurable join options (`include_baseline_only`, `include_current_only`, `include_no_results`).
+  Each drift carries inline attack identity, and run-exclusive simulations are summarized per attack. (SAF-33124)
+- `get_test_details` now surfaces the security-event correlation phase in test status. (SAF-32063)
+
+### Changed
+
+- `get_test_drifts`: `total_drifts` now counts genuine status transitions only (run-exclusive simulations
+  no longer inflate the headline), and no-result/internal_fail transitions are included by default. (SAF-33124)
+- Per-agent concurrency limiting is now keyed per-JWT instead of per shared mcp-session-id. (SAF-31903)
+- Scenario guidance now steers agents to run non-ready scenarios via `step_overrides` / `ready_to_run_filter`
+  rather than concluding none are runnable. (SAF-32210)
+
+### Fixed
+
+- Corrected stale running-test simulation counts in `get_test_details`. (SAF-32018)
+- Fixed playbook attack id/name simulation filters (wrong key and int/str type mismatch). (SAF-32805)
+
 ## 1.5.0 — 2026-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-agent concurrency limiting is now keyed per-JWT instead of per shared mcp-session-id. (SAF-31903)
 - Scenario guidance now steers agents to run non-ready scenarios via `step_overrides` / `ready_to_run_filter`
   rather than concluding none are runnable. (SAF-32210)
+- Renamed run semantics for clarity: the `dry_run` parameter is now `evaluate` (previewed runs report an
+  `evaluating` status), and the `run_adhoc_scenario` tool is now `quick_run`.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.5.0"
+version = "1.6.0"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "safebreach-mcp-server"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 1.6.0

### Added

- `get_test_drifts` can now compare any two arbitrary/non-consecutive test runs via `baseline_test_id`, with configurable join options (`include_baseline_only`, `include_current_only`, `include_no_results`). Each drift carries inline attack identity, and run-exclusive simulations are summarized per attack. (SAF-33124)
- `get_test_details` now surfaces the security-event correlation phase in test status. (SAF-32063)

### Changed

- `get_test_drifts`: `total_drifts` now counts genuine status transitions only (run-exclusive simulations no longer inflate the headline), and no-result/internal_fail transitions are included by default. (SAF-33124)
- Per-agent concurrency limiting is now keyed per-JWT instead of per shared mcp-session-id. (SAF-31903)
- Scenario guidance now steers agents to run non-ready scenarios via `step_overrides` / `ready_to_run_filter` rather than concluding none are runnable. (SAF-32210)
- Renamed run semantics for clarity: the `dry_run` parameter is now `evaluate` (previewed runs report an `evaluating` status), and the `run_adhoc_scenario` tool is now `quick_run`. (PR #71)

### Fixed

- Corrected stale running-test simulation counts in `get_test_details`. (SAF-32018)
- Fixed playbook attack id/name simulation filters (wrong key and int/str type mismatch). (SAF-32805)

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.6.0`
3. Create a GitHub Release with the changelog notes