### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.0 — 2026-07-08
+
+### Fixed
+
+- Concurrency limiter no longer lets one caller starve every MCP server at once: the per-caller limit bucket is now
+  namespaced per server, so heavy load (or a tool-refresh fan-out) on one server no longer rate-limits the others. The
+  long-lived streamable-HTTP GET stream is also no longer counted against the limit.
+
 ## 1.6.0 — 2026-07-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.6.0"
+version = "1.7.0"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Release 1.7.0

### Fixed

- Concurrency limiter no longer lets one caller starve every MCP server at once: the per-caller limit bucket is now
  namespaced per server, so heavy load (or a tool-refresh fan-out) on one server no longer rate-limits the others. The
  long-lived streamable-HTTP GET stream is also no longer counted against the limit. (SAF-33239)

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.7.0`
3. Create a GitHub Release with the changelog notes