### PR TITLE
chore(skill): add uv lock step to mcp-create-release process

### DIFF
--- a/.claude/skills/mcp-create-release/SKILL.md
+++ b/.claude/skills/mcp-create-release/SKILL.md
@@ -67,6 +67,11 @@ version = "{current}" → version = "{next}"
 
 Read back `pyproject.toml` to verify the change took effect.
 
+Then regenerate the lock file to reflect the new version:
+```bash
+uv lock
+```
+
 ## Step 6: Generate Changelog Entries
 
 1. Find the most recent tag:
@@ -144,7 +149,7 @@ Display a summary of everything that will be committed:
 
 - Version bump: `{current}` → `{next}`
 - Branch: `{branch_name}`
-- Files modified: `pyproject.toml`, `CHANGELOG.md`
+- Files modified: `pyproject.toml`, `uv.lock`, `CHANGELOG.md`
 - Changelog entries: (list them)
 
 Ask for final approval via AskUserQuestion:
@@ -153,9 +158,9 @@ Ask for final approval via AskUserQuestion:
 
 ## Step 10: Commit and Push
 
-1. Stage the two modified files:
+1. Stage the modified files:
    ```bash
-   git add pyproject.toml CHANGELOG.md
+   git add pyproject.toml uv.lock CHANGELOG.md
    ```
 2. Commit with HEREDOC:
    ```bash
@@ -221,4 +226,4 @@ Ask for final approval via AskUserQuestion:
 - Merge the PR (user must review and approve)
 - Create git tags or GitHub Releases (GitHub Actions handles this automatically)
 - Handle pre-release or patch versions
-- Modify files beyond `pyproject.toml` and `CHANGELOG.md`
+- Modify files beyond `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`


### PR DESCRIPTION
## Summary

Adds a `uv lock` step to the `mcp-create-release` skill so the version bump keeps `uv.lock` in sync.

## Why

The release skill bumped `pyproject.toml` but never regenerated `uv.lock`. Because the root package (`safebreach-mcp-server`) is an editable install that records its own version in the lock, the version drifted — `main`'s `uv.lock` lagged `pyproject.toml` by a full release (recorded `1.6.0` while `pyproject.toml` was `1.7.0`). The 1.8.0 release (#77) corrected the drift by including the `uv lock` step; this PR persists that step in the skill so it can't recur.

## Changes (SKILL.md only)

- **Step 5** — add `uv lock` after the version bump to regenerate the lock file.
- **Step 9** — list `uv.lock` among the files modified in the batch summary.
- **Step 10** — stage `uv.lock` alongside `pyproject.toml` and `CHANGELOG.md`.
- **Limitations** — note `uv.lock` as an expected modified file.

No `uv.lock` change here — that drift is already resolved on `main` via #77. This is the process fix only.