### PR TITLE
chore(playbook): unregister tag write tools pending backend support (SAF-34168)

### DIFF
--- a/prds/SAF-34168-comment-out-tag-write-tools/context.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/context.md
@@ -1,0 +1,274 @@
+# Ticket Context: SAF-34168
+
+## Status
+Phase 6: PRD Created — see `prd.md` in this folder
+
+## Decisions Taken During Planning
+- **Approach (confirmed with reporter)**: comment out the six tool registrations **and** the six
+  write-function imports at `playbook_server.py:17-28` **and** the two wrapper test classes
+  (`TestWriteToolWrappers`, `TestBulkWrappers`). Nothing deleted; re-enable = uncomment three blocks.
+- **`TestPlaybookTagWriteE2E` needs an *unconditional* skip.** Discovered during planning that its
+  existing `@skip_e2e` decorator is inert by default: `SKIP_E2E_TESTS` is read as
+  `os.environ.get('SKIP_E2E_TESTS', 'false')` at `test_e2e.py:39`, so the default is *run*, not skip.
+  (The decorator's reason string reads backwards relative to that default, and differs from
+  `safebreach_mcp_data/tests/test_drift_tools.py:3300`, which defaults to `"true"`.)
+- **Verified expected end state**: the two wrapper classes collect exactly 6 and 5 cases; deselecting
+  both from the unit run yields **236 passed, 0 failed** (from the 247 baseline).
+
+## Mode
+Improving (ticket created 2026-07-28, then prepared)
+
+## Original Ticket
+- **Summary**: MCP: Comment out playbook attack tag write tools (add / remove / rename, incl. bulk)
+- **Type**: Task
+- **Status**: To Do
+- **Parent Epic**: SAF-29873 — MCP and BG Actions and Guardrails
+- **Sprint**: Saf sprint 94 (active)
+- **Team / Offering**: Core / All
+- **Assignee**: Dan Almog
+- **Description (as created)**: Comment out the six tag write tool registrations in
+  `safebreach_mcp_playbook/playbook_server.py`; keep the two read-only tag tools; do not delete the
+  underlying `sb_*` implementations so the tools can be re-enabled later.
+
+## Task Scope
+Withdraw the playbook attack **tag write** surface from the SafeBreach MCP playbook server so that
+only read-only tag tools remain exposed to clients, without deleting the implementation work
+delivered under SAF-29870.
+
+## Repositories Under Investigation
+- `/Users/dan/dev/repos/safebreach-mcp` (single repo; owns all affected code)
+
+---
+
+## Investigation Findings
+
+### Repository: safebreach-mcp
+
+#### 1. Tool inventory — playbook server registers 10 tools, all unconditionally
+
+All tools are registered inside `SafeBreachPlaybookServer._register_tools()`
+(`safebreach_mcp_playbook/playbook_server.py:44`), called from `__init__`
+(`playbook_server.py:35-42`). There is **no conditional registration** — no `if` guard, no
+environment-variable gate, no role check around any tool.
+
+Registered tool names in `origin/main`:
+
+| Tool | Kind | server.py lines |
+|------|------|-----------------|
+| `get_playbook_attacks` | read | 47-167 |
+| `get_playbook_attack_details` | read | 169-286 |
+| `get_playbook_attacks_by_tags` | read (tag) | 288-348 |
+| `add_playbook_attack_tag` | **write** | 350-364 |
+| `remove_playbook_attack_tag` | **write** | 366-380 |
+| `rename_playbook_attack_tag` | **write** | 382-400 |
+| `get_playbook_attack_tags` | read (tag) | 402-419 |
+| `bulk_add_playbook_attack_tags` | **write** | 421-437 |
+| `bulk_remove_playbook_attack_tags` | **write** | 439-454 |
+| `bulk_rename_playbook_attack_tag` | **write** | 456-478 |
+
+The six **write** tools are exactly the ones in scope. The two read-only tag tools
+(`get_playbook_attacks_by_tags`, `get_playbook_attack_tags`) stay.
+
+#### 2. The backend endpoints the write tools depend on
+
+All six write tools funnel into two config-service endpoints:
+
+| Scope | URL | Built by |
+|-------|-----|----------|
+| Single attack | `{config}/api/content/v3/accounts/{account_id}/moves/{attack_id}/tags` | `_build_move_tags_request` (`playbook_functions.py:345-354`) |
+| Bulk | `{config}/api/content/v3/accounts/{account_id}/moves/tags` | `_bulk_tags_request` (`playbook_functions.py:571-577`) |
+
+These are the calls that stop being supported when the backend removes tag mutation, and they are
+the reason the MCP tools have to be withdrawn in step.
+
+The two **read** tag tools are on a different path, which is why they can stay exposed:
+- `sb_get_playbook_attack_tags` (`playbook_functions.py:490`) resolves tags from the cached
+  playbook-attacks listing via `_get_all_attacks_from_cache_or_api`, then
+  `_extract_custom_tag_values` — no call to either write endpoint.
+- `sb_get_playbook_attacks_by_tags` (`:292`) filters that same cached listing.
+
+There is no feature flag or conditional-registration mechanism in the playbook server (see finding 1),
+so commenting out the registrations is the available lever rather than a config toggle.
+
+#### 3. Underlying implementations (to be preserved)
+
+`safebreach_mcp_playbook/playbook_functions.py`:
+
+| Function | Line | Note |
+|----------|------|------|
+| `sb_add_playbook_attack_tag` | 357 | write |
+| `sb_remove_playbook_attack_tag` | 399 | write |
+| `sb_rename_playbook_attack_tag` | 441 | write |
+| `sb_get_playbook_attack_tags` | 490 | read — keep exposed |
+| `sb_bulk_add_playbook_attack_tags` | 620 | write |
+| `sb_bulk_remove_playbook_attack_tags` | 641 | write |
+| `sb_bulk_rename_playbook_attack_tag` | 664 | write |
+| `sb_get_playbook_attacks_by_tags` | 292 | read — keep exposed |
+| `_build_move_tags_request` (helper) | 345 | shared by single-attack writes |
+| `_parse_bulk_tag_values` (helper) | 554 | bulk only |
+| `_bulk_tags_request` (helper) | 571 | bulk only |
+
+Each write function calls `rate_limiter.check_limit(...)` / `record_action(...)` keyed on its own
+tool name (`playbook_functions.py:382/388`, `424/430`, `472/478`, `631/637`, `652/660`, `681/688`).
+
+#### 4. The import block is a hidden coupling
+
+`playbook_server.py:17-28` imports all ten `sb_*` functions at module level, including the six
+write functions. Two consequences:
+
+- If the tool registrations are commented out but the imports are kept, the imports become unused.
+  This is cosmetically dead but **harmless for CI** (see finding 6).
+- If the imports are *also* commented out, the wrapper-delegation tests break in a second,
+  different way: they patch the module attribute
+  `safebreach_mcp_playbook.playbook_server.sb_add_playbook_attack_tag`
+  (`test_tag_write_tools.py:284`, `:296`, `:305`; `test_bulk_tag_tools.py:208`, `:217`), which
+  raises `AttributeError` if the name no longer exists on the module.
+
+So the import decision and the test decision are coupled and must be made together.
+
+#### 5. Tests affected
+
+**Will fail** — these resolve the tool out of the registry via
+`server.mcp._tool_manager._tools[name]`, which raises `KeyError` once registration is removed:
+
+| File | Class | Tests |
+|------|-------|-------|
+| `tests/test_tag_write_tools.py` | `TestWriteToolWrappers` (line 269) | `test_registered_and_write_annotations` (parametrized ×3), `test_add_wrapper_delegates_and_markdown`, `test_rename_wrapper_delegates`, `test_wrapper_error_path` → **6 test cases** |
+| `tests/test_bulk_tag_tools.py` | `TestBulkWrappers` (line 193) | `test_registered_write_annotations` (parametrized ×3), `test_add_wrapper_delegates`, `test_wrapper_error_path` → **5 test cases** |
+
+**Unaffected** — these call the `sb_*` functions directly and keep passing as long as the functions
+survive:
+- `test_tag_write_tools.py`: `TestAddPlaybookAttackTag` (67), `TestRemovePlaybookAttackTag` (149),
+  `TestRenamePlaybookAttackTag` (206)
+- `test_bulk_tag_tools.py`: `TestBulkAdd` (64), `TestBulkRemove` (141), `TestBulkRename` (164)
+- `test_tag_tools.py`: read-path tests, plus `test_tool_registered` (220) and
+  `test_tool_registered_read_only` (295) — these cover the two **read** tag tools, which stay
+- `test_playbook_server.py`: asserts only that the server object and `.mcp` exist; it explicitly
+  does not assert on individual tool names (lines 12-33) → unaffected
+
+**Live E2E** — `origin/main`'s `tests/test_e2e.py` contains `TestPlaybookTagWriteE2E` (line 751)
+with `test_get_tags_on_attack_e2e`, `test_add_read_remove_tag_roundtrip_e2e`,
+`test_rename_tag_roundtrip_e2e`, `test_bulk_tag_value_cap_enforced_e2e`,
+`test_add_empty_tag_rejected_e2e`. These drive the `sb_*` functions against a live console rather
+than the MCP tool registry, so they will keep passing — but they would be exercising a surface no
+longer offered to clients. Needs an explicit decision (skip/mark vs. leave).
+
+#### 6. Repo has no lint or unit-test CI gate
+
+`.github/workflows/` contains only `release.yml` and `security-scan.yml` (TruffleHog secret scan).
+There is no ruff/flake8/pylint configuration in `pyproject.toml` (sections present: `project`,
+`optional-dependencies`, `scripts`, `tool.setuptools`, `tool.uv`, `tool.pytest.ini_options`) and no
+`.flake8` / `ruff.toml`. Therefore unused imports will not fail anything automatically, and the
+test suite must be run locally to catch the 11 failing cases.
+
+**Measured baseline on `origin/main`** (the base of this ticket's branch):
+
+| Invocation | Result |
+|------------|--------|
+| `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` | **247 passed, 0 failed** |
+| `pytest safebreach_mcp_playbook/` (full, incl. E2E) | 251 passed, 25 failed, 4 errors, 1 skipped |
+
+Every one of the 25 failures and 4 errors is in `test_e2e.py` and is caused by missing live-console
+credentials (`ValueError: Failed to fetch playbook attacks: Environment variable 'demo-...'`), not by
+anything related to this ticket. **E2E must be excluded from this ticket's pass/fail gate**, and
+those pre-existing failures must not be mistaken for regressions or "fixed" here.
+
+#### 7. Branch / base state — SAF-29870 is already merged to `main`
+
+- `origin/main` HEAD: `17c0b52`; `ad38a43` is **"SAF-29870: MCP AI-Agent tag actions (CRUD +
+  retrieval + bulk) (#76)"** — squash-merged.
+- `origin/main` already registers all ten tools including the six writes, and already contains
+  `tests/test_tag_write_tools.py` and `tests/test_bulk_tag_tools.py`.
+- The local branch `feature/SAF-29870-mcp-actions-ai-agent-tags` is **12 ahead / 3 behind**
+  `origin/main`, but a direct tree diff shows the playbook module differs from `main` in
+  `tests/test_e2e.py` only (`main` has 201 lines the branch lacks — the `TestPlaybookTagWriteE2E`
+  class). The branch is effectively superseded by the squash merge.
+- **Implication**: SAF-34168 must branch from `origin/main`, not from the SAF-29870 branch.
+  Branching off the stale feature branch would silently drop `main`'s E2E tag-write tests.
+
+#### 8. Documentation
+
+`CLAUDE.md:224` documents the playbook server's tools as only `get_playbook_attacks` and
+`get_playbook_attack_details`. It never listed the tag tools, so it is already stale and requires
+no change for this ticket — though it is a pre-existing gap worth noting.
+
+#### Working-tree note
+The checkout currently has uncommitted `uv.lock` modifications and an untracked `.idea/` directory.
+Unrelated to this ticket; must not be swept into its commits.
+
+---
+
+## Problem Analysis
+
+### Problem Description
+**Driver (from the reporter, not derivable from this repo):** there is a backend bug in how tags are
+treated for **cloned moves**. To contain it, the ability to change tags is being **removed on the
+backend for now**.
+
+SAF-29870 delivered a tag-mutation surface on the MCP playbook server: six write tools (add / remove /
+rename a custom tag on a playbook attack, plus three bulk variants). Those tools call the two
+config-service move-tags endpoints documented in finding 2. Since the backend capability they depend
+on is going away, the tools have to be withdrawn in step with the backend change — left in place they
+either fail against the changed backend, or keep exercising the broken cloned-move tag path.
+
+This is **not** an MCP-side defect. Nothing in the MCP implementation is being fixed; the surface is
+being parked. That is why the ticket asks for comment-out rather than deletion: the six `sb_*`
+functions, their helpers, and their direct unit tests stay in place so the tools can be restored once
+the cloned-move tag handling is corrected backend-side.
+
+The two read-only tag tools resolve tags from the cached attacks listing rather than the write
+endpoints (finding 2), so they are unaffected and stay exposed.
+
+### Impact Assessment
+- **MCP clients**: the playbook server's advertised tool list drops from 10 to 4 tools. Any client,
+  prompt, or skill that calls one of the six names starts failing with an unknown-tool error rather
+  than a graceful message.
+- **`playbook_server.py`**: six `@self.mcp.tool` blocks (~100 lines across lines 350-400 and
+  421-478) commented out; the module-level import block at lines 17-28 must be decided on jointly
+  with the tests.
+- **`playbook_functions.py`**: unchanged. All seven `sb_*` tag functions and the three helpers
+  remain, keeping the change cheap to revert.
+- **Test suite**: 11 test cases across two files fail as written and need to be commented out,
+  skipped, or deleted in step with the registrations.
+- **Rate limiter**: the per-tool-name limits for the six tools become unreachable but harmless; no
+  change required.
+- **Docs**: no change required (`CLAUDE.md` never listed these tools).
+
+### Risks & Edge Cases
+- **Import/patch coupling** (highest-value detail): commenting out the registrations *and* the
+  imports breaks the delegation tests differently (`AttributeError` on `patch`) than commenting out
+  registrations alone (`KeyError` on the registry lookup). Deciding one without the other produces
+  a confusing red suite.
+- **Wrong base branch**: branching from the local `feature/SAF-29870-...` branch instead of
+  `origin/main` would lose `main`'s `TestPlaybookTagWriteE2E` coverage and reintroduce a stale
+  `test_e2e.py`.
+- **Comment-out only removes the tools from MCP discovery**: the parked `sb_*` code paths remain
+  importable and callable in-process. That is acceptable here because the real block is backend-side —
+  the endpoints themselves stop supporting tag mutation. The MCP change stops clients calling
+  something that no longer works; it is not itself the enforcement point.
+- **Ordering relative to the backend change**: if MCP and backend land far apart there is a window
+  where either the tools are gone while the backend still accepts writes (harmless), or the tools are
+  still advertised while the backend rejects them (harmful — agents get opaque failures). The second
+  direction is the one to avoid.
+- **Commented-out code decays**: ~100 lines of dormant registration plus dormant tests will drift
+  from the live code. The re-enable trigger is the backend cloned-move fix landing.
+- **Live E2E writes**: `TestPlaybookTagWriteE2E` mutates tags on a real console through the preserved
+  `sb_*` functions. Once the backend removes tag mutation it will fail regardless of the MCP change,
+  so it should be skip-marked here.
+- **Partial withdrawal is a trap**: leaving any one of the six registered (e.g. forgetting a bulk
+  variant) leaves a tool advertised that will fail against the changed backend, while appearing done.
+  The acceptance criteria must enumerate all six by name.
+- **Read-tool assumption**: "keep the read tools" rests on them reading the attacks listing rather
+  than the write endpoints (finding 2). If the cloned-move bug also corrupts the tag values *as read*,
+  that assumption needs revisiting — see open question 2.
+
+### Open Questions
+1. Is the backend removing the two move-tags endpoints entirely (404), or keeping them and rejecting
+   writes? Determines how the parked `sb_*` functions fail if ever called, and how
+   `TestPlaybookTagWriteE2E` should be marked.
+2. Do the read-only tag tools stay correct under the cloned-move bug? They surface tags from the
+   attacks listing, not the write endpoints — confirm the cloned-move handling does not also make
+   *read* values wrong or misleading.
+3. Should the module-level imports of the six write functions be commented out too, or kept so the
+   dormant tests can be re-enabled unchanged?
+4. Should this ship before, with, or after the backend change?

--- a/prds/SAF-34168-comment-out-tag-write-tools/prd.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/prd.md
@@ -25,7 +25,8 @@ The two read-only tag tools are unaffected and stay exposed.
 
 | Field | Value |
 |-------|-------|
-| Status | Ready for implementation |
+| Status | Phases A–C implemented (uncommitted); Phase D (PR) pending |
+| Last Updated | 2026-07-28 |
 | Prior artifacts | `context.md`, `summary.md` in this folder (from `preparing-ticket`) |
 | Investigation | Complete — reused from `context.md`, not re-run |
 | Approach decision | Confirmed with the reporter: comment out registrations **+** imports **+** the two wrapper test classes |
@@ -125,25 +126,34 @@ has none, so whichever name ends the list must not leave a dangling comma before
 
 ### 3.4 `safebreach_mcp_playbook/tests/test_e2e.py` (867 lines)
 
-`TestPlaybookTagWriteE2E` (class at line **751**) writes real tags to a live console through the two
-endpoints the backend is removing. It must be explicitly skipped.
+`TestPlaybookTagWriteE2E` (class at line **751**) holds **9** live tests. Only some of them touch the
+endpoints the backend is removing, so the skip is applied **per-test, not to the class**:
 
-**Important**: the class already carries `@skip_e2e` (line 749) and `@pytest.mark.e2e` (line 750), but
-`skip_e2e` is **inert by default** — `SKIP_E2E_TESTS` is read at line 39 as
-`os.environ.get('SKIP_E2E_TESTS', 'false')`, so the default is *run*, not skip. (The decorator's own
-reason string, "set SKIP_E2E_TESTS=false to enable", reads backwards relative to that default. Also
-inconsistent with `safebreach_mcp_data/tests/test_drift_tools.py:3300`, which defaults to `"true"`.
-Out of scope here — just don't be misled by it.)
+| Group | Tests | Hits withdrawn endpoints? | Action |
+|-------|-------|---------------------------|--------|
+| Mutating | `test_add_read_remove_tag_roundtrip_e2e`, `test_rename_tag_roundtrip_e2e`, `test_bulk_add_remove_roundtrip_e2e`, `test_bulk_rename_roundtrip_e2e` | **Yes** — write real tags | **Skip these 4** |
+| Read-only | `test_get_tags_on_attack_e2e` | No — reads the cached attacks listing | **Leave** — covers `get_playbook_attack_tags`, a tool this ticket keeps |
+| Validation | `test_bulk_attack_id_cap_enforced_e2e` (847), `test_bulk_tag_value_cap_enforced_e2e` (853), `test_add_empty_tag_rejected_e2e` (859), `test_rename_noop_rejected_e2e` (864) | No — each asserts a `ValueError` raised *before any API call* | **Leave** — still covers the parked `sb_*` input validation, unchanged by this ticket |
 
-Therefore add an **unconditional** class-level skip, e.g.
-`@pytest.mark.skip(reason="playbook tag write tools withdrawn; backend tag mutation removed")`.
-Per house rules the reason string must **not** contain a ticket ID — ticket context belongs in the
-commit/PR, not in code.
+A blanket class-level skip would wrongly disable the read-only test for a tool being kept, plus four
+validation tests whose own banner (line 845) reads "no live writes; always run". Hence per-test.
 
-The 5 affected tests: `test_get_tags_on_attack_e2e`, `test_add_read_remove_tag_roundtrip_e2e`,
-`test_rename_tag_roundtrip_e2e`, `test_bulk_tag_value_cap_enforced_e2e`,
-`test_add_empty_tag_rejected_e2e` (plus `test_bulk_add_remove_roundtrip_e2e`,
-`test_bulk_rename_roundtrip_e2e`).
+**Why the existing decorator is not the lever**: the class already carries `@skip_e2e` (749) and
+`@pytest.mark.e2e` (750), but `skip_e2e` is **inert by default** — `SKIP_E2E_TESTS` is read at line 39
+as `os.environ.get('SKIP_E2E_TESTS', 'false')`, so the default is *run*, not skip. (Its reason string,
+"set SKIP_E2E_TESTS=false to enable", reads backwards relative to that default, and differs from
+`safebreach_mcp_data/tests/test_drift_tools.py:3300`, which defaults to `"true"`. Out of scope — just
+don't be misled.)
+
+Apply `@pytest.mark.skip(reason=...)` to each of the 4 mutating tests. Per house rules the reason
+string must **not** contain a ticket ID — ticket context belongs in the commit/PR, not in code.
+
+**Note on redundancy**: the 4 mutating tests all consume the `writable_move_ids` fixture, which GETs
+the tags endpoint and `pytest.skip()`s when no move has a writable `/content/v3` store. If the backend
+*removes* the endpoints (404), that fixture would skip these 4 on its own and no code change would be
+needed. If the backend *keeps* them and only rejects writes, the fixture still yields IDs and the tests
+would fail. The explicit skip is correct under **either** outcome, which is why it is applied rather
+than relying on the fixture (see Open Question 1).
 
 ### 3.5 Explicitly NOT touched
 
@@ -186,23 +196,28 @@ The two **read** tag tools never touch either endpoint, which is why they stay e
 
 ## Section 6: Definition of Done
 
-- [ ] All six write tool registrations commented out in `playbook_server.py`, across both
-      non-contiguous regions (350-400 and 421-478).
-- [ ] The six write-function imports commented out in the `playbook_server.py:17-28` block, with no
-      dangling comma.
-- [ ] Advertised playbook tool list is exactly four tools: `get_playbook_attacks`,
+- [x] All six write tool registrations commented out in `playbook_server.py`, across both
+      non-contiguous regions.
+- [x] The six write-function imports commented out in the `playbook_server.py` import block, with no
+      dangling comma — verified by `python -c "import safebreach_mcp_playbook.playbook_server"`.
+- [x] Advertised playbook tool list is exactly four tools: `get_playbook_attacks`,
       `get_playbook_attack_details`, `get_playbook_attacks_by_tags`, `get_playbook_attack_tags`.
-- [ ] `TestWriteToolWrappers` and `TestBulkWrappers` commented out, along with the now-unused
-      `SafeBreachPlaybookServer` import at line 22 of each test file.
-- [ ] `TestPlaybookTagWriteE2E` carries an unconditional skip whose reason contains no ticket ID.
-- [ ] `playbook_functions.py` shows **zero** diff.
-- [ ] `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` reports
-      **236 passed, 0 failed** (247 baseline − 11 removed cases).
-- [ ] Read-path tag tests in `test_tag_tools.py` still pass, including `test_tool_registered` (220)
-      and `test_tool_registered_read_only` (295).
-- [ ] Work is on `feature/SAF-34168-withdraw-tag-write-tools`, based on `origin/main`.
+      Verified by enumerating the registry — 4 tools, exactly these.
+- [x] `TestWriteToolWrappers` and `TestBulkWrappers` commented out, along with the now-unused
+      `SafeBreachPlaybookServer` import in each test file.
+- [x] The 4 **mutating** tests in `TestPlaybookTagWriteE2E` carry `@pytest.mark.skip`, reason contains
+      no ticket ID. *(Revised from a class-level skip — see 3.4. A blanket skip would have disabled the
+      read-only test for a kept tool plus 4 validation tests that never call the backend.)*
+- [x] `playbook_functions.py` shows **zero** diff — verified with `git diff --quiet`.
+- [x] `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` reports
+      **246 passed, 0 failed**. *(Revised from 236: the 247 baseline − 11 removed wrapper cases = 236,
+      plus the 10 new `TestExposedTagTools` cases = 246.)*
+- [x] Read-path tag tests in `test_tag_tools.py` still pass, including `test_tool_registered` and
+      `test_tool_registered_read_only`.
+- [x] Full repo unit suite (`-m "not e2e"` across all modules) passes: **1439 passed, 0 failed**.
+- [x] Work is on `feature/SAF-34168-withdraw-tag-write-tools`, based on `origin/main`.
 - [ ] PR description records: which blocks were commented (not deleted), that imports were commented
-      alongside, and that the E2E class was skipped.
+      alongside, and that the 4 mutating E2E tests were skipped. *(Phase D — pending)*
 
 ---
 
@@ -222,11 +237,27 @@ are pre-existing on `main` and **must not** be treated as regressions.
 
 ### 7.2 Expected after the change
 
-| Invocation | Expected |
-|------------|----------|
-| Unit-only (E2E ignored) | **236 passed, 0 failed** |
-| `test_tag_tools.py` (read paths) | unchanged, all pass |
-| `test_playbook_server.py` | unchanged — it asserts only that the server and `.mcp` exist, never individual tool names |
+| Invocation | Expected | Actual |
+|------------|----------|--------|
+| Unit-only (E2E ignored) | **246 passed, 0 failed** | ✅ 246 passed |
+| Full repo unit suite, `-m "not e2e"` | no failures | ✅ 1439 passed |
+| `test_tag_tools.py` (read paths) | unchanged, all pass | ✅ |
+| `test_playbook_server.py` | **gains** `TestExposedTagTools` (10 cases) — see below | ✅ |
+
+246 = 247 baseline − 11 removed wrapper cases + 10 new `TestExposedTagTools` cases.
+
+`test_playbook_server.py` previously asserted only that the server and `.mcp` exist, with a comment
+claiming tool registration "can't easily be tested" — which the wrapper tests disproved. The new
+`TestExposedTagTools` class replaces that gap with the real invariant, and is what makes this change
+durable rather than a one-off edit:
+
+- `test_tag_write_tool_not_registered` (parametrized ×6) — none of the withdrawn write tools is advertised.
+- `test_expected_tool_registered` (parametrized ×4) — all four surviving tools, including **both** tag
+  read tools, are still advertised. This is the guard against the non-contiguous-region hazard (Risk 1).
+
+Deliberately **not** a strict set-equality assertion: equality would break the moment an unrelated
+playbook tool is added, while presence+absence covers both real risks (over-deletion and partial
+withdrawal) without that brittleness.
 
 ### 7.3 Verification steps
 
@@ -254,6 +285,21 @@ being commented rather than left behind.
 ---
 
 ## Section 8: Implementation Phases
+
+### Phase Status Tracking
+
+| Phase | Name | Status | Completed | Commit | Notes |
+|-------|------|--------|-----------|--------|-------|
+| A | Server registrations + imports | ✅ Complete | 2026-07-28 | uncommitted | Registry verified at exactly 4 tools; import smoke check passes |
+| B | Unit tests (wrapper classes) | ✅ Complete | 2026-07-28 | uncommitted | Both wrapper classes + the unused import in each file commented |
+| C | E2E skip | ✅ Complete | 2026-07-28 | uncommitted | Narrowed during implementation to the 4 **mutating** tests (see 3.4) |
+| D | PR | ⏳ Pending | — | — | Requires explicit approval to commit/push |
+
+Status icons: ✅ Complete · 🔄 In Progress · ⏳ Pending · ❌ Blocked
+
+> **Atomicity constraint**: Phases A and B **must land in the same change**. Phase A alone removes the
+> six registrations while `TestWriteToolWrappers` / `TestBulkWrappers` still resolve those tools from
+> the registry, leaving 11 knowingly-failing tests. Do not commit A without B.
 
 ### Phase A — Server registrations + imports
 1. Comment out the six `@self.mcp.tool` blocks: 350-364, 366-380, 382-400, then 421-437, 439-454,
@@ -331,4 +377,5 @@ from 10 to 4. Unit suite goes 247 → 236 passed.
 
 | Date | Change |
 |------|--------|
-| 2026-07-28 | PRD created. Investigation reused from `context.md` (no re-run). Approach confirmed with reporter: comment out registrations + imports + both wrapper test classes. Discovered during planning that `skip_e2e` is inert by default (`SKIP_E2E_TESTS` defaults to `'false'` at `test_e2e.py:39`), so an unconditional skip is required on `TestPlaybookTagWriteE2E`. |
+| 2026-07-28 | PRD created. Investigation reused from `context.md` (no re-run). Approach confirmed with reporter: comment out registrations + imports + both wrapper test classes. Discovered during planning that `skip_e2e` is inert by default (`SKIP_E2E_TESTS` defaults to `'false'` at `test_e2e.py:39`), so an explicit skip is required. |
+| 2026-07-28 | Phases A–C implemented via TDD. Two revisions found during implementation: **(1)** `TestPlaybookTagWriteE2E` holds **9** tests, not the 5 first recorded, and only **4** of them mutate tags — the skip was narrowed from the class to those 4, since a blanket skip would have disabled the read-only test for `get_playbook_attack_tags` (a tool this ticket keeps) plus 4 validation tests that raise before any API call. **(2)** Expected unit count revised 236 → 246 to account for the 10 new `TestExposedTagTools` cases added as the TDD red step. |

--- a/prds/SAF-34168-comment-out-tag-write-tools/prd.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/prd.md
@@ -261,6 +261,36 @@ Deliberately **not** a strict set-equality assertion: equality would break the m
 playbook tool is added, while presence+absence covers both real risks (over-deletion and partial
 withdrawal) without that brittleness.
 
+### 7.2b Live E2E verification — DONE (2026-07-28)
+
+Ran `pytest safebreach_mcp_playbook/tests/test_e2e.py -v -rs` against a live internal dev console,
+wired via `SAFEBREACH_ENVS_FILE` + `E2E_CONSOLE`. Console name, URL, account id and instance id are
+deliberately **not** recorded here — this repo is public and `E2E_TESTING.md` requires real
+environment details to stay in private local files. They are in the Jira ticket instead.
+
+**Result: 29 passed, 5 skipped, 0 failed** (309s).
+
+The two outcomes this ticket needed:
+
+| Test | Result | Why it matters |
+|------|--------|----------------|
+| `test_get_tags_on_attack_e2e` | ✅ **PASSED** | The read tool this ticket keeps, exercised against a real console — the one thing unit tests cannot cover |
+| The 4 mutating tag tests | ⏭️ **SKIPPED**, reason `tag mutation unsupported backend-side; write tools withdrawn` | Confirms the per-test skip landed on exactly the intended 4, and did **not** disable the class |
+
+Also passing live: all 4 validation tests (`test_bulk_attack_id_cap_enforced_e2e`,
+`test_bulk_tag_value_cap_enforced_e2e`, `test_add_empty_tag_rejected_e2e`,
+`test_rename_noop_rejected_e2e`) — confirming the Section 3.4 analysis that they raise before any API
+call and therefore did not need skipping.
+
+5th skip is unrelated and pre-existing: `test_cache_behavior_real_api` (`SB_MCP_CACHE_PLAYBOOK` unset).
+
+Console note: the env was stopped and had to be started before the run. Its DNS resolves to the
+instance's **private** address, so it is VPN-reachable only — a bare `curl` from outside the VPN
+returns nothing and can be mistaken for a dead environment.
+
+**Still not covered by this run**: whether a *deployed* build advertises only the 4 tools to clients
+through mcp-proxy. That needs `deploy-mcp-server-under-test`, not a pytest run.
+
 ### 7.3 Verification steps
 
 1. **Tool-list assertion** (the criterion that actually matters). Instantiate the server and confirm

--- a/prds/SAF-34168-comment-out-tag-write-tools/prd.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/prd.md
@@ -1,0 +1,334 @@
+# MCP: Comment Out Playbook Attack Tag Write Tools — SAF-34168
+
+## Section 1: Overview
+
+**Ticket**: SAF-34168 (Task) — parent epic SAF-29873 "MCP and BG Actions and Guardrails"
+**Sprint**: Saf sprint 94
+**Repo**: `safebreach-mcp`
+**Branch**: `feature/SAF-34168-withdraw-tag-write-tools` (cut from `origin/main`)
+
+### Driver
+
+There is a **backend bug in how tags are treated for cloned moves**. As a result, the ability to
+change tags is being **removed on the backend for now**.
+
+The MCP playbook server exposes six tag *write* tools that call the backend move-tags endpoints.
+Since the backend capability they depend on is going away, those tools must be withdrawn in step with
+the backend change. This is **not** an MCP-side defect — the MCP implementation is being *parked*,
+not fixed, so it can be restored once the cloned-move tag handling is corrected backend-side.
+
+The two read-only tag tools are unaffected and stay exposed.
+
+---
+
+## Section 1.5: Document Status
+
+| Field | Value |
+|-------|-------|
+| Status | Ready for implementation |
+| Prior artifacts | `context.md`, `summary.md` in this folder (from `preparing-ticket`) |
+| Investigation | Complete — reused from `context.md`, not re-run |
+| Approach decision | Confirmed with the reporter: comment out registrations **+** imports **+** the two wrapper test classes |
+| Code written | None — this document plans only |
+
+---
+
+## Section 2: Solution Description
+
+Comment out (do **not** delete) three blocks, so that re-enablement after the backend fix is
+"uncomment three blocks and revert one skip":
+
+1. The **six write tool registrations** in `playbook_server.py`.
+2. The **six write-function imports** in the module-level import block of `playbook_server.py`.
+3. The **two wrapper test classes** that resolve those tools out of the MCP tool registry.
+
+Plus one behavioural change:
+
+4. An **explicit skip** on the live tag-write E2E class, because it exercises the endpoints the
+   backend is removing.
+
+`playbook_functions.py` is **not touched at all**. Every `sb_*` tag function, every helper, and every
+unit test that calls those functions directly stays in place and keeps passing. That is what makes
+this cheap to reverse.
+
+### Why comment out rather than flag-gate
+
+There is no feature flag or conditional-registration mechanism anywhere in
+`SafeBreachPlaybookServer._register_tools()` (`playbook_server.py:44`) — all tools are registered
+unconditionally. Introducing a gating mechanism would be new machinery for a temporary withdrawal, so
+commenting out is the available and proportionate lever.
+
+---
+
+## Section 3: Affected Components
+
+### 3.1 `safebreach_mcp_playbook/playbook_server.py`
+
+**Registrations to comment out** (each is a complete `@self.mcp.tool(...)` decorator plus its wrapper
+function):
+
+| # | Tool | Lines | Annotation today |
+|---|------|-------|------------------|
+| 1 | `add_playbook_attack_tag` | 350-364 | `readOnlyHint=False, destructiveHint=False` |
+| 2 | `remove_playbook_attack_tag` | 366-380 | `readOnlyHint=False, destructiveHint=True` |
+| 3 | `rename_playbook_attack_tag` | 382-400 | `readOnlyHint=False, destructiveHint=False` |
+| 4 | `bulk_add_playbook_attack_tags` | 421-437 | `readOnlyHint=False, destructiveHint=False` |
+| 5 | `bulk_remove_playbook_attack_tags` | 439-454 | `readOnlyHint=False, destructiveHint=True` |
+| 6 | `bulk_rename_playbook_attack_tag` | 456-478 | `readOnlyHint=False, destructiveHint=False` |
+
+Note the ordering: `get_playbook_attack_tags` (402-419) sits **between** the single-attack writes and
+the bulk writes. It must be left registered — the two commented regions are therefore
+**non-contiguous** (350-400 and 421-478), which is the easiest thing to get wrong here.
+
+**Imports to comment out** — inside the `from .playbook_functions import (...)` block at lines 17-28:
+
+```
+    sb_get_playbook_attacks,              # keep
+    sb_get_playbook_attack_details,       # keep
+    sb_get_playbook_attacks_by_tags,      # keep
+    sb_add_playbook_attack_tag,           # comment out
+    sb_remove_playbook_attack_tag,        # comment out
+    sb_rename_playbook_attack_tag,        # comment out
+    sb_get_playbook_attack_tags,          # keep
+    sb_bulk_add_playbook_attack_tags,     # comment out
+    sb_bulk_remove_playbook_attack_tags,  # comment out
+    sb_bulk_rename_playbook_attack_tag    # comment out
+```
+
+Mind the trailing comma on the last surviving entry — `sb_bulk_rename_playbook_attack_tag` currently
+has none, so whichever name ends the list must not leave a dangling comma before `)`.
+
+`ToolAnnotations` (line 15) stays imported — the surviving read tools still use it.
+
+### 3.2 `safebreach_mcp_playbook/tests/test_tag_write_tools.py` (311 lines)
+
+- Comment out `TestWriteToolWrappers` — class at line **269**, runs to **end of file (311)**. Include
+  its banner comment block at lines 266-268.
+- Comment out the now-unused import at line **22**
+  (`from safebreach_mcp_playbook.playbook_server import SafeBreachPlaybookServer`) — it is referenced
+  only at line 271, inside the class being commented out.
+- **Leave untouched**: `TestAddPlaybookAttackTag` (67), `TestRemovePlaybookAttackTag` (149),
+  `TestRenamePlaybookAttackTag` (206). These call the `sb_*` functions directly and must keep passing.
+
+**Removes 6 test cases**: `test_registered_and_write_annotations` (parametrized ×3),
+`test_add_wrapper_delegates_and_markdown`, `test_rename_wrapper_delegates`, `test_wrapper_error_path`.
+
+### 3.3 `safebreach_mcp_playbook/tests/test_bulk_tag_tools.py` (223 lines)
+
+- Comment out `TestBulkWrappers` — class at line **193**, runs to **end of file (223)**. Include its
+  banner comment block at lines 190-192.
+- Comment out the now-unused import at line **22** (same symbol, referenced only at line 195).
+- **Leave untouched**: `TestBulkAdd` (64), `TestBulkRemove` (141), `TestBulkRename` (164).
+
+**Removes 5 test cases**: `test_registered_write_annotations` (parametrized ×3),
+`test_add_wrapper_delegates`, `test_wrapper_error_path`.
+
+### 3.4 `safebreach_mcp_playbook/tests/test_e2e.py` (867 lines)
+
+`TestPlaybookTagWriteE2E` (class at line **751**) writes real tags to a live console through the two
+endpoints the backend is removing. It must be explicitly skipped.
+
+**Important**: the class already carries `@skip_e2e` (line 749) and `@pytest.mark.e2e` (line 750), but
+`skip_e2e` is **inert by default** — `SKIP_E2E_TESTS` is read at line 39 as
+`os.environ.get('SKIP_E2E_TESTS', 'false')`, so the default is *run*, not skip. (The decorator's own
+reason string, "set SKIP_E2E_TESTS=false to enable", reads backwards relative to that default. Also
+inconsistent with `safebreach_mcp_data/tests/test_drift_tools.py:3300`, which defaults to `"true"`.
+Out of scope here — just don't be misled by it.)
+
+Therefore add an **unconditional** class-level skip, e.g.
+`@pytest.mark.skip(reason="playbook tag write tools withdrawn; backend tag mutation removed")`.
+Per house rules the reason string must **not** contain a ticket ID — ticket context belongs in the
+commit/PR, not in code.
+
+The 5 affected tests: `test_get_tags_on_attack_e2e`, `test_add_read_remove_tag_roundtrip_e2e`,
+`test_rename_tag_roundtrip_e2e`, `test_bulk_tag_value_cap_enforced_e2e`,
+`test_add_empty_tag_rejected_e2e` (plus `test_bulk_add_remove_roundtrip_e2e`,
+`test_bulk_rename_roundtrip_e2e`).
+
+### 3.5 Explicitly NOT touched
+
+| File / area | Reason |
+|-------------|--------|
+| `playbook_functions.py` | All `sb_*` tag functions + helpers `_build_move_tags_request` (345), `_parse_bulk_tag_values` (554), `_bulk_tags_request` (571) stay. Parked for re-enable. |
+| Rate limiter | Per-tool-name entries (`playbook_functions.py:382/388`, `424/430`, `472/478`, `631/637`, `652/660`, `681/688`) become unreachable but are harmless. |
+| `CLAUDE.md` | Line 224 lists only `get_playbook_attacks` / `get_playbook_attack_details` — it never documented the tag tools, so nothing to update. |
+| `playbook_types.py` | Tag transformation helpers serve the surviving read path. |
+
+---
+
+## Section 4: Backend Dependency
+
+All six write tools funnel into two config-service endpoints:
+
+| Scope | URL | Built by |
+|-------|-----|----------|
+| Single attack | `{config}/api/content/v3/accounts/{account_id}/moves/{attack_id}/tags` | `_build_move_tags_request` (`playbook_functions.py:345-354`) |
+| Bulk | `{config}/api/content/v3/accounts/{account_id}/moves/tags` | `_bulk_tags_request` (`playbook_functions.py:571-577`) |
+
+The two **read** tag tools never touch either endpoint, which is why they stay exposed:
+
+- `sb_get_playbook_attack_tags` (`:490`) resolves tags from the cached playbook-attacks listing via
+  `_get_all_attacks_from_cache_or_api`, then `_extract_custom_tag_values`.
+- `sb_get_playbook_attacks_by_tags` (`:292`) filters that same cached listing.
+
+---
+
+## Section 5: Out of Scope
+
+- Fixing the cloned-move tag bug (backend work, tracked separately).
+- Introducing a feature flag or RBAC-gated registration mechanism.
+- Deleting any `sb_*` function, helper, or direct-call unit test.
+- Repairing the 25 pre-existing `test_e2e.py` credential failures.
+- Reconciling the inconsistent `SKIP_E2E_TESTS` defaults across the repo.
+- Updating `CLAUDE.md` (never documented these tools).
+
+---
+
+## Section 6: Definition of Done
+
+- [ ] All six write tool registrations commented out in `playbook_server.py`, across both
+      non-contiguous regions (350-400 and 421-478).
+- [ ] The six write-function imports commented out in the `playbook_server.py:17-28` block, with no
+      dangling comma.
+- [ ] Advertised playbook tool list is exactly four tools: `get_playbook_attacks`,
+      `get_playbook_attack_details`, `get_playbook_attacks_by_tags`, `get_playbook_attack_tags`.
+- [ ] `TestWriteToolWrappers` and `TestBulkWrappers` commented out, along with the now-unused
+      `SafeBreachPlaybookServer` import at line 22 of each test file.
+- [ ] `TestPlaybookTagWriteE2E` carries an unconditional skip whose reason contains no ticket ID.
+- [ ] `playbook_functions.py` shows **zero** diff.
+- [ ] `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` reports
+      **236 passed, 0 failed** (247 baseline − 11 removed cases).
+- [ ] Read-path tag tests in `test_tag_tools.py` still pass, including `test_tool_registered` (220)
+      and `test_tool_registered_read_only` (295).
+- [ ] Work is on `feature/SAF-34168-withdraw-tag-write-tools`, based on `origin/main`.
+- [ ] PR description records: which blocks were commented (not deleted), that imports were commented
+      alongside, and that the E2E class was skipped.
+
+---
+
+## Section 7: Testing Strategy
+
+### 7.1 Baseline (measured on `origin/main`, this branch's base)
+
+| Invocation | Result |
+|------------|--------|
+| `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` | **247 passed, 0 failed** |
+| `pytest safebreach_mcp_playbook/` (full, incl. E2E) | 251 passed, 25 failed, 4 errors, 1 skipped |
+| The three tag test files alone | 95 passed |
+
+Every failure and error in the full run lives in `test_e2e.py` and is caused by missing live-console
+credentials (`ValueError: Failed to fetch playbook attacks: Environment variable 'demo-...'`). These
+are pre-existing on `main` and **must not** be treated as regressions.
+
+### 7.2 Expected after the change
+
+| Invocation | Expected |
+|------------|----------|
+| Unit-only (E2E ignored) | **236 passed, 0 failed** |
+| `test_tag_tools.py` (read paths) | unchanged, all pass |
+| `test_playbook_server.py` | unchanged — it asserts only that the server and `.mcp` exist, never individual tool names |
+
+### 7.3 Verification steps
+
+1. **Tool-list assertion** (the criterion that actually matters). Instantiate the server and confirm
+   the registry holds exactly the four surviving names:
+   ```python
+   sorted(SafeBreachPlaybookServer().mcp._tool_manager._tools.keys())
+   ```
+   Must contain none of the six withdrawn names. This is the same registry accessor the deleted
+   wrapper tests used, so it is known to work.
+2. **Unit suite**: `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py`
+   → 236 passed, 0 failed.
+3. **Collection check**: `pytest safebreach_mcp_playbook/tests/test_e2e.py --collect-only -q` to
+   confirm the tag-write class is skipped rather than erroring at import.
+4. **Import sanity**: `python -c "import safebreach_mcp_playbook.playbook_server"` — catches a
+   malformed import block (dangling comma / orphaned parenthesis), the most likely mechanical slip.
+
+### 7.4 No CI safety net
+
+`.github/workflows/` contains only `release.yml` and `security-scan.yml` (TruffleHog). There is no
+lint or unit-test workflow, and no ruff/flake8/pylint config in `pyproject.toml`. The suite must be
+run locally; unused imports would not be caught automatically, which is part of why the imports are
+being commented rather than left behind.
+
+---
+
+## Section 8: Implementation Phases
+
+### Phase A — Server registrations + imports
+1. Comment out the six `@self.mcp.tool` blocks: 350-364, 366-380, 382-400, then 421-437, 439-454,
+   456-478. Leave `get_playbook_attack_tags` (402-419) registered between the two regions.
+2. Comment out the six write-function names in the `playbook_server.py:17-28` import block; fix comma
+   placement on the last surviving name.
+3. Run `python -c "import safebreach_mcp_playbook.playbook_server"`.
+4. Assert the registry holds exactly four tools (Section 7.3 step 1).
+
+### Phase B — Unit tests
+1. Comment out `TestWriteToolWrappers` (`test_tag_write_tools.py` 266-311) and the unused
+   `SafeBreachPlaybookServer` import at line 22.
+2. Comment out `TestBulkWrappers` (`test_bulk_tag_tools.py` 190-223) and the unused import at line 22.
+3. Run `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` → expect
+   **236 passed**.
+
+### Phase C — E2E skip
+1. Add an unconditional `@pytest.mark.skip(...)` to `TestPlaybookTagWriteE2E` (line 751), above or
+   below the existing `@skip_e2e` / `@pytest.mark.e2e` decorators. Reason string must carry no ticket ID.
+2. Run `pytest safebreach_mcp_playbook/tests/test_e2e.py --collect-only -q` and confirm the class is
+   collected-and-skipped, not erroring.
+
+### Phase D — PR
+1. Commit the three commented blocks plus the E2E skip.
+2. PR description: the backend cloned-move tag bug as the driver, the parked-not-deleted intent, the
+   import decision, the E2E skip, and the 247 → 236 count change.
+
+---
+
+## Section 9: Risks and Assumptions
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| 1 | **Non-contiguous regions.** `get_playbook_attack_tags` (402-419) sits between the single and bulk write blocks; a careless range comment-out kills a read tool that must survive. | Section 7.3 step 1 asserts the exact four-tool list. |
+| 2 | **Malformed import block.** Commenting names inside a parenthesised import easily leaves a dangling comma or orphaned paren. | Explicit `import` smoke check (Phase A step 3). |
+| 3 | **Partial withdrawal.** Missing one of the six — easiest with the three bulk variants — leaves a tool advertised that will fail against the changed backend, while looking done. | All six enumerated by name in the DoD and the tool-list assertion. |
+| 4 | **Import/patch coupling.** Commenting registrations alone fails the wrapper tests with `KeyError`; also commenting imports fails them with `AttributeError`. Doing one without the other yields a confusing red suite. | Resolved by decision: all three blocks go together, in Phases A and B of the same change. |
+| 5 | **Ordering vs the backend change.** If MCP lands *after* the backend, the tools stay advertised while the backend rejects calls — agents get opaque failures. The reverse (tools gone, backend still working) is harmless. | Open question 3; prefer shipping at or before the backend change. |
+| 6 | **Comment-out is not enforcement.** The parked `sb_*` functions remain importable and callable in-process. | Acceptable: the real block is backend-side. The MCP change stops clients calling something that no longer works. |
+| 7 | **Dormant-code decay.** ~100 commented lines plus two commented test classes will drift from live code. | Re-enable trigger is the backend cloned-move fix landing. |
+| 8 | **Read-tool assumption.** "Keep the read tools" rests on them reading the attacks listing rather than the write endpoints (Section 4). If the cloned-move bug also corrupts tag values *as read*, scope needs revisiting. | Open question 2. |
+
+### Assumptions
+- The backend change removes only tag *mutation*; tag *reads* via the attacks listing stay correct.
+- The six `sb_*` functions are expected back, so parking beats deleting.
+- No consumer (skill, prompt, saved workflow) hard-depends on the six tool names. Not verified outside
+  this repo.
+
+---
+
+## Section 10: Open Questions
+
+1. Is the backend removing the two move-tags endpoints entirely (404), or keeping them and rejecting
+   writes? Determines how the parked `sb_*` functions fail if ever called.
+2. Do the read-only tag tools stay correct under the cloned-move bug? They surface tags from the
+   attacks listing, not the write endpoints.
+3. Should this ship before, with, or after the backend change?
+
+---
+
+## Section 11: Executive Summary
+
+A backend bug in cloned-move tag handling is causing tag mutation to be removed backend-side. Six MCP
+playbook tag write tools depend on the two endpoints being withdrawn, so they are commented out — not
+deleted — along with their module-level imports and the two test classes that assert their
+registration. One live E2E class gets an unconditional skip. `playbook_functions.py` is untouched, so
+re-enabling after the backend fix means uncommenting three blocks and reverting one skip.
+
+Scope: **1 source file, 3 test files, 0 changes to business logic.** Advertised playbook tools drop
+from 10 to 4. Unit suite goes 247 → 236 passed.
+
+---
+
+## Section 12: Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-07-28 | PRD created. Investigation reused from `context.md` (no re-run). Approach confirmed with reporter: comment out registrations + imports + both wrapper test classes. Discovered during planning that `skip_e2e` is inert by default (`SKIP_E2E_TESTS` defaults to `'false'` at `test_e2e.py:39`), so an unconditional skip is required on `TestPlaybookTagWriteE2E`. |

--- a/prds/SAF-34168-comment-out-tag-write-tools/prd.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/prd.md
@@ -25,7 +25,7 @@ The two read-only tag tools are unaffected and stay exposed.
 
 | Field | Value |
 |-------|-------|
-| Status | Phases A–C implemented (uncommitted); Phase D (PR) pending |
+| Status | All phases complete — PR #80 open, awaiting review |
 | Last Updated | 2026-07-28 |
 | Prior artifacts | `context.md`, `summary.md` in this folder (from `preparing-ticket`) |
 | Investigation | Complete — reused from `context.md`, not re-run |
@@ -216,8 +216,10 @@ The two **read** tag tools never touch either endpoint, which is why they stay e
       `test_tool_registered_read_only`.
 - [x] Full repo unit suite (`-m "not e2e"` across all modules) passes: **1439 passed, 0 failed**.
 - [x] Work is on `feature/SAF-34168-withdraw-tag-write-tools`, based on `origin/main`.
-- [ ] PR description records: which blocks were commented (not deleted), that imports were commented
-      alongside, and that the 4 mutating E2E tests were skipped. *(Phase D — pending)*
+- [x] PR description records: which blocks were commented (not deleted), that imports were commented
+      alongside, and that the 4 mutating E2E tests were skipped —
+      [PR #80](https://github.com/SafeBreach/safebreach-mcp/pull/80). Also flags the breaking change
+      (10 → 4 advertised tools) and carries the three open questions for the reviewer.
 
 ---
 
@@ -290,10 +292,10 @@ being commented rather than left behind.
 
 | Phase | Name | Status | Completed | Commit | Notes |
 |-------|------|--------|-----------|--------|-------|
-| A | Server registrations + imports | ✅ Complete | 2026-07-28 | uncommitted | Registry verified at exactly 4 tools; import smoke check passes |
-| B | Unit tests (wrapper classes) | ✅ Complete | 2026-07-28 | uncommitted | Both wrapper classes + the unused import in each file commented |
-| C | E2E skip | ✅ Complete | 2026-07-28 | uncommitted | Narrowed during implementation to the 4 **mutating** tests (see 3.4) |
-| D | PR | ⏳ Pending | — | — | Requires explicit approval to commit/push |
+| A | Server registrations + imports | ✅ Complete | 2026-07-28 | `81fc1a3` | Registry verified at exactly 4 tools; import smoke check passes |
+| B | Unit tests (wrapper classes) | ✅ Complete | 2026-07-28 | `81fc1a3` | Both wrapper classes + the unused import in each file commented |
+| C | E2E skip | ✅ Complete | 2026-07-28 | `81fc1a3` | Narrowed during implementation to the 4 **mutating** tests (see 3.4) |
+| D | PR | ✅ Complete | 2026-07-28 | `81fc1a3` | [PR #80](https://github.com/SafeBreach/safebreach-mcp/pull/80) — open against `main` |
 
 Status icons: ✅ Complete · 🔄 In Progress · ⏳ Pending · ❌ Blocked
 

--- a/prds/SAF-34168-comment-out-tag-write-tools/summary.md
+++ b/prds/SAF-34168-comment-out-tag-write-tools/summary.md
@@ -1,0 +1,254 @@
+# Ticket Summary: SAF-34168
+
+## Overview
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: `safebreach-mcp`
+
+---
+
+## Current State
+**Summary**: MCP: Comment out playbook attack tag write tools (add / remove / rename, incl. bulk)
+
+**Issues Identified in the ticket as created**:
+- It states *what* to comment out but not *why*. The driver, supplied by the reporter, is a
+  **backend bug in how tags are treated for cloned moves**; the ability to change tags is being
+  **removed on the backend for now**. The MCP write tools call those backend endpoints, so they are
+  withdrawn in step with the backend change. This is not an MCP-side defect.
+- It does not identify the 11 test cases that fail as a direct result, nor which tests are safe.
+
+- It does not flag the import/patch coupling in `playbook_server.py:17-28`, which is the one detail
+  most likely to cause a confusing red suite mid-implementation.
+- It does not name the base branch, even though the obvious candidate (the local
+  `feature/SAF-29870-...` branch) is the wrong one.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+- The playbook server registers **10 tools unconditionally** in
+  `SafeBreachPlaybookServer._register_tools()` (`safebreach_mcp_playbook/playbook_server.py:44`).
+  No `if` guard, env-var gate, or role check exists around any of them.
+- The **six write tools** in scope: `add_playbook_attack_tag` (350-364),
+  `remove_playbook_attack_tag` (366-380), `rename_playbook_attack_tag` (382-400),
+  `bulk_add_playbook_attack_tags` (421-437), `bulk_remove_playbook_attack_tags` (439-454),
+  `bulk_rename_playbook_attack_tag` (456-478).
+- The **two read-only tag tools to keep**: `get_playbook_attacks_by_tags` (288-348) and
+  `get_playbook_attack_tags` (402-419).
+- **The backend endpoints being withdrawn.** All six write tools funnel into two config-service
+  endpoints: single-attack writes to
+  `{config}/api/content/v3/accounts/{account_id}/moves/{attack_id}/tags`
+  (`_build_move_tags_request`, `playbook_functions.py:345-354`), and bulk writes to
+  `{config}/api/content/v3/accounts/{account_id}/moves/tags`
+  (`_bulk_tags_request`, `playbook_functions.py:571-577`). These are the calls that stop being
+  supported.
+- **The read tools are on a different path**, which is why they stay:
+  `sb_get_playbook_attack_tags` (`:490`) resolves tags from the cached attacks listing via
+  `_get_all_attacks_from_cache_or_api`, and `sb_get_playbook_attacks_by_tags` (`:292`) filters that
+  same listing. Neither touches the two write endpoints.
+- Implementations to preserve live in `playbook_functions.py`: `sb_add_playbook_attack_tag` (357),
+  `sb_remove_playbook_attack_tag` (399), `sb_rename_playbook_attack_tag` (441),
+  `sb_bulk_add_playbook_attack_tags` (620), `sb_bulk_remove_playbook_attack_tags` (641),
+  `sb_bulk_rename_playbook_attack_tag` (664), plus helpers `_build_move_tags_request` (345),
+  `_parse_bulk_tag_values` (554), `_bulk_tags_request` (571).
+- **Import coupling**: `playbook_server.py:17-28` imports all six write functions at module level.
+  The wrapper tests `patch` those module attributes, so commenting the imports breaks them with
+  `AttributeError`, while commenting only the registrations breaks them with `KeyError`.
+- **11 test cases fail** once registration is removed: `TestWriteToolWrappers` in
+  `tests/test_tag_write_tools.py:269` (6 cases) and `TestBulkWrappers` in
+  `tests/test_bulk_tag_tools.py:193` (5 cases). All other tag tests call `sb_*` directly and are
+  unaffected; `test_playbook_server.py` asserts nothing about individual tool names.
+- **No CI gate**: `.github/workflows/` has only `release.yml` and `security-scan.yml` (TruffleHog).
+  No ruff/flake8/pylint config anywhere, so unused imports fail nothing and the suite must be run
+  locally.
+- **Measured baseline on `origin/main`** (this branch's base): unit tests
+  (`pytest safebreach_mcp_playbook/ --ignore=.../test_e2e.py`) = **247 passed, 0 failed**. The full
+  suite including E2E = 251 passed / 25 failed / 4 errors / 1 skipped, where **every** failure and
+  error is in `test_e2e.py` and caused by missing live-console credentials. E2E must therefore be
+  excluded from this ticket's gate.
+- **Base branch**: SAF-29870 is already squash-merged to `main` as `ad38a43` (PR #76). `origin/main`
+  registers all ten tools. The local `feature/SAF-29870-...` branch is 12 ahead / 3 behind and
+  differs from `main` in the playbook module only in `tests/test_e2e.py`, where `main` has 201 lines
+  the branch lacks (`TestPlaybookTagWriteE2E`, line 751). **Branch from `origin/main`.**
+- **Docs**: `CLAUDE.md:224` never listed the tag tools — already stale, no change needed here.
+
+**Relevant files**:
+- `safebreach_mcp_playbook/playbook_server.py` (registrations + imports) — the only file that must change
+- `safebreach_mcp_playbook/tests/test_tag_write_tools.py` (`TestWriteToolWrappers`)
+- `safebreach_mcp_playbook/tests/test_bulk_tag_tools.py` (`TestBulkWrappers`)
+- `safebreach_mcp_playbook/tests/test_e2e.py` (`TestPlaybookTagWriteE2E`, on `main`)
+- `safebreach_mcp_playbook/playbook_functions.py` (unchanged — preserved)
+
+---
+
+## Problem Analysis
+
+### Problem Description
+There is a backend bug in how tags are treated for **cloned moves**. Because of it, the ability to
+change tags is being **removed on the backend for now**.
+
+The MCP playbook server's six tag write tools call the backend move-tags endpoints:
+
+* single-attack writes → `{config}/api/content/v3/accounts/{account_id}/moves/{attack_id}/tags`
+  (`_build_move_tags_request`, `playbook_functions.py:345-354`)
+* bulk writes → `{config}/api/content/v3/accounts/{account_id}/moves/tags`
+  (`_bulk_tags_request`, `playbook_functions.py:571-577`)
+
+Since the capability those tools depend on is going away, the tools must be withdrawn in step with
+the backend change — otherwise the MCP server keeps advertising six tools that will fail, or that
+keep exercising the broken cloned-move tag path.
+
+The two read-only tag tools do **not** touch either endpoint: `sb_get_playbook_attack_tags` (`:490`)
+resolves tags from the cached attacks listing via `_get_all_attacks_from_cache_or_api`, and
+`sb_get_playbook_attacks_by_tags` (`:292`) filters that same listing. They stay exposed.
+
+The implementation is parked rather than deleted so it can be restored once the cloned-move tag
+handling is fixed backend-side.
+
+### Impact Assessment
+- **MCP clients**: playbook server tool count drops 10 → 4. Calls to any of the six names fail as
+  unknown tools.
+- **`playbook_server.py`**: ~100 lines of registration commented out; import block at 17-28 decided
+  jointly with the tests.
+- **`playbook_functions.py`**: unchanged, keeping the revert cheap.
+- **Tests**: 11 cases must be commented out / skipped in the same change.
+- **Rate limiter / docs**: no changes required.
+
+### Risks & Edge Cases
+- **Import/patch coupling**: commenting registrations *and* imports fails the delegation tests
+  differently (`AttributeError`) than commenting registrations alone (`KeyError`). Handle both together.
+- **Wrong base branch**: branching off the local `feature/SAF-29870-...` branch loses `main`'s
+  `TestPlaybookTagWriteE2E` coverage.
+- **Comment-out only removes the tools from MCP discovery** — the parked `sb_*` functions stay
+  importable and callable in-process. That is acceptable here because the actual block is
+  backend-side: the endpoints themselves stop supporting tag mutation. The MCP change keeps clients
+  from calling something that no longer works; it is not itself the enforcement point.
+- **Dead-code decay**: ~100 dormant lines plus dormant tests will drift from the live code. The
+  re-enable trigger is the backend cloned-move fix landing.
+- **Live E2E writes**: `TestPlaybookTagWriteE2E` mutates tags on a real console through the preserved
+  functions. Once the backend removes tag mutation it will fail regardless of this change, so it
+  should be skip-marked here.
+- **Partial withdrawal**: missing any one of the six (easy with the bulk variants) leaves a tool
+  advertised that will fail against the changed backend, while looking complete — hence all six are
+  enumerated in the criteria.
+- **Timing/ordering with the backend**: if the MCP change ships well before or after the backend
+  change, there is a window where either the tools are gone while the backend still works, or the
+  tools remain while the backend rejects them. The latter is the harmful direction.
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+MCP: Comment out playbook attack tag write tools (add/remove/rename + bulk) following backend removal
+of tag mutation
+
+### Description
+
+**Background**
+
+There is a **backend bug in how tags are treated for cloned moves**. As a result, the ability to
+change tags is being **removed on the backend for now**.
+
+The MCP playbook server exposes six tag *write* tools that call the backend move-tags endpoints.
+Since the backend capability they depend on is going away, those tools must be withdrawn in step
+with the backend change. This is not an MCP-side defect — the implementation is parked, not fixed,
+and is preserved so it can be restored once the cloned-move tag handling is corrected backend-side.
+
+The two read-only tag tools are unaffected and stay exposed.
+
+**Technical Context**
+
+* All tools are registered unconditionally in `SafeBreachPlaybookServer._register_tools()`
+  (`safebreach_mcp_playbook/playbook_server.py:44`) — no flag or role check exists to toggle.
+* Write tools to withdraw: `add_playbook_attack_tag` (350-364), `remove_playbook_attack_tag`
+  (366-380), `rename_playbook_attack_tag` (382-400), `bulk_add_playbook_attack_tags` (421-437),
+  `bulk_remove_playbook_attack_tags` (439-454), `bulk_rename_playbook_attack_tag` (456-478).
+* Read-only tag tools that must keep working: `get_playbook_attacks_by_tags` (288-348),
+  `get_playbook_attack_tags` (402-419).
+* `playbook_functions.py` is unchanged: `sb_add_playbook_attack_tag` (357),
+  `sb_remove_playbook_attack_tag` (399), `sb_rename_playbook_attack_tag` (441),
+  `sb_bulk_*` (620 / 641 / 664) and helpers (345 / 554 / 571) all stay.
+* `playbook_server.py:17-28` imports the six write functions at module level, and the wrapper tests
+  `patch` those module attributes — so the import decision and the test decision must be made together.
+* Rate limiting is per-tool-name (`playbook_functions.py:382/388`, `424/430`, `472/478`, `631/637`,
+  `652/660`, `681/688`); those entries become unreachable but need no change.
+* Base branch is `origin/main` — SAF-29870 is already squash-merged there (`ad38a43`, PR #76). The
+  local `feature/SAF-29870-...` branch is stale and lacks `main`'s `TestPlaybookTagWriteE2E`.
+* Repo has no lint or unit-test CI gate (`.github/workflows/` = `release.yml` +
+  `security-scan.yml`), so the suite must be run locally.
+
+**Problem Description**
+
+* A backend bug in how tags are treated for **cloned moves** is being addressed by removing the
+  ability to change tags on the backend for now.
+* The MCP playbook server advertises six tag write tools that call the two backend move-tags
+  endpoints, so they depend on a capability that is going away.
+* Left in place, those tools either fail against the changed backend or keep exercising the broken
+  cloned-move tag path.
+* There is no feature flag or conditional-registration mechanism in the playbook server to switch
+  them off, so commenting out the registrations is the available lever.
+* The implementation must be parked rather than deleted, since it is expected back once the
+  cloned-move tag handling is fixed backend-side.
+
+**Affected Areas**
+
+* `safebreach-mcp` — `safebreach_mcp_playbook/playbook_server.py` (registrations at 350-400 and
+  421-478; imports at 17-28)
+* `safebreach-mcp` — `safebreach_mcp_playbook/tests/test_tag_write_tools.py`
+  (`TestWriteToolWrappers`, 6 cases)
+* `safebreach-mcp` — `safebreach_mcp_playbook/tests/test_bulk_tag_tools.py` (`TestBulkWrappers`,
+  5 cases)
+* `safebreach-mcp` — `safebreach_mcp_playbook/tests/test_e2e.py` (`TestPlaybookTagWriteE2E`)
+* `safebreach-mcp` — `safebreach_mcp_playbook/playbook_functions.py` (**unchanged**, preserved)
+
+### Acceptance Criteria
+
+- [ ] All six write tool registrations are commented out in `playbook_server.py`:
+      `add_playbook_attack_tag`, `remove_playbook_attack_tag`, `rename_playbook_attack_tag`,
+      `bulk_add_playbook_attack_tags`, `bulk_remove_playbook_attack_tags`,
+      `bulk_rename_playbook_attack_tag`.
+- [ ] The playbook server's advertised tool list contains exactly four tools:
+      `get_playbook_attacks`, `get_playbook_attack_details`, `get_playbook_attacks_by_tags`,
+      `get_playbook_attack_tags`.
+- [ ] `get_playbook_attacks_by_tags` and `get_playbook_attack_tags` still work, verified by the
+      existing read-path tests in `tests/test_tag_tools.py`.
+- [ ] All `sb_*` tag functions and helpers in `playbook_functions.py` are left in place and untouched,
+      so the change is a pure re-enable.
+- [ ] The 11 registration-dependent test cases (`TestWriteToolWrappers`,
+      `TestBulkWrappers`) are commented out or skip-marked in the same change, with the reason and
+      this ticket referenced in the commit/PR — not in a code comment.
+- [ ] The module-level imports of the six write functions are handled consistently with the test
+      decision, and the resulting state is explicitly recorded in the PR description.
+- [ ] `pytest safebreach_mcp_playbook/ --ignore=safebreach_mcp_playbook/tests/test_e2e.py` passes
+      locally with no failures and no errors. Baseline on `origin/main` is **247 passed**; the
+      expected end state is 247 minus however many of the 11 registration-dependent cases are
+      removed outright (skip-marking keeps the count and reports them as skipped).
+- [ ] `test_e2e.py` is **excluded** from the pass/fail gate: on `origin/main` it already reports
+      25 failed / 4 errors / 1 skipped purely from missing live-console credentials. Do not treat
+      those as regressions, and do not attempt to "fix" them under this ticket.
+- [ ] Work is based on `origin/main`, not on `feature/SAF-29870-mcp-actions-ai-agent-tags`.
+- [ ] `TestPlaybookTagWriteE2E` is skip-marked — it writes tags through the endpoints the backend is
+      removing, so it will fail against a live console once the backend change lands regardless of
+      the MCP change.
+
+### Suggested Labels/Components
+- Component: (none set on this project's tasks)
+- Labels: `CTEM-dev` (matches SAF-29870, the story this withdraws from)
+
+---
+
+## Open Questions for the Reviewer
+
+1. **Is the backend removing the two move-tags endpoints entirely (404), or keeping them and
+   rejecting writes?** Determines how the parked `sb_*` functions fail if ever called, and how
+   `TestPlaybookTagWriteE2E` should be marked.
+2. **Do the read-only tag tools stay correct under the cloned-move bug?** They surface tags from the
+   attacks listing rather than the write endpoints. Confirm the cloned-move handling does not also
+   make *read* values wrong or misleading — if it does, the read tools need a caveat too, and this
+   ticket's "keep the read tools" scope would need revisiting.
+3. **Imports at `playbook_server.py:17-28`** — comment out alongside the registrations, or keep so
+   the dormant tests can be re-enabled unchanged?
+4. **Ordering relative to the backend change** — should this ship before, with, or after it? The
+   harmful direction is the tools remaining live while the backend already rejects the calls.

--- a/safebreach_mcp_playbook/playbook_server.py
+++ b/safebreach_mcp_playbook/playbook_server.py
@@ -18,13 +18,15 @@ from .playbook_functions import (
     sb_get_playbook_attacks,
     sb_get_playbook_attack_details,
     sb_get_playbook_attacks_by_tags,
-    sb_add_playbook_attack_tag,
-    sb_remove_playbook_attack_tag,
-    sb_rename_playbook_attack_tag,
     sb_get_playbook_attack_tags,
-    sb_bulk_add_playbook_attack_tags,
-    sb_bulk_remove_playbook_attack_tags,
-    sb_bulk_rename_playbook_attack_tag
+    # Tag write functions are not imported while tag mutation is unsupported backend-side.
+    # Restore alongside the tool registrations below.
+    # sb_add_playbook_attack_tag,
+    # sb_remove_playbook_attack_tag,
+    # sb_rename_playbook_attack_tag,
+    # sb_bulk_add_playbook_attack_tags,
+    # sb_bulk_remove_playbook_attack_tags,
+    # sb_bulk_rename_playbook_attack_tag,
 )
 
 logger = logging.getLogger(__name__)
@@ -347,57 +349,60 @@ Results are paginated with 10 items per page; each attack includes its normalize
                 logger.error(f"Error in get_playbook_attacks_by_tags: {e}")
                 return f"Error getting playbook attacks by tags: {str(e)}"
 
-        @self.mcp.tool(
-            name="add_playbook_attack_tag",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
-            description="""Adds a custom tag to a single SafeBreach playbook attack.
-This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
-Parameters: console (required), attack_id (required, the playbook attack/move ID), tag_value (required, a single tag)."""
-        )
-        def add_playbook_attack_tag(console: str = "default", attack_id: int = None, tag_value: str = None) -> str:
-            """Add a custom tag to a single playbook attack."""
-            try:
-                result = sb_add_playbook_attack_tag(console=console, attack_id=attack_id, tag_value=tag_value)
-                return f"✅ Added tag '{result['tag_value']}' to playbook attack {result['attack_id']}."
-            except Exception as e:
-                logger.error(f"Error in add_playbook_attack_tag: {e}")
-                return f"Error adding tag to playbook attack: {str(e)}"
-
-        @self.mcp.tool(
-            name="remove_playbook_attack_tag",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
-            description="""Removes a custom tag from a single SafeBreach playbook attack.
-This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
-Parameters: console (required), attack_id (required, the playbook attack/move ID), tag_value (required, a single tag)."""
-        )
-        def remove_playbook_attack_tag(console: str = "default", attack_id: int = None, tag_value: str = None) -> str:
-            """Remove a custom tag from a single playbook attack."""
-            try:
-                result = sb_remove_playbook_attack_tag(console=console, attack_id=attack_id, tag_value=tag_value)
-                return f"✅ Removed tag '{result['tag_value']}' from playbook attack {result['attack_id']}."
-            except Exception as e:
-                logger.error(f"Error in remove_playbook_attack_tag: {e}")
-                return f"Error removing tag from playbook attack: {str(e)}"
-
-        @self.mcp.tool(
-            name="rename_playbook_attack_tag",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
-            description="""Renames a custom tag on a single SafeBreach playbook attack.
-This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
-Parameters: console (required), attack_id (required, the playbook attack/move ID), old_value (required), new_value (required)."""
-        )
-        def rename_playbook_attack_tag(console: str = "default", attack_id: int = None,
-                                       old_value: str = None, new_value: str = None) -> str:
-            """Rename a custom tag on a single playbook attack."""
-            try:
-                result = sb_rename_playbook_attack_tag(
-                    console=console, attack_id=attack_id, old_value=old_value, new_value=new_value
-                )
-                return (f"✅ Renamed tag '{result['old_value']}' to '{result['new_value']}' "
-                        f"on playbook attack {result['attack_id']}.")
-            except Exception as e:
-                logger.error(f"Error in rename_playbook_attack_tag: {e}")
-                return f"Error renaming tag on playbook attack: {str(e)}"
+        # Tag write tools are not registered while tag mutation is unsupported backend-side.
+        # Their implementations remain in playbook_functions.py; uncomment to restore.
+        #
+        # @self.mcp.tool(
+        #     name="add_playbook_attack_tag",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+        #     description="""Adds a custom tag to a single SafeBreach playbook attack.
+        # This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
+        # Parameters: console (required), attack_id (required, the playbook attack/move ID), tag_value (required, a single tag)."""
+        # )
+        # def add_playbook_attack_tag(console: str = "default", attack_id: int = None, tag_value: str = None) -> str:
+        #     """Add a custom tag to a single playbook attack."""
+        #     try:
+        #         result = sb_add_playbook_attack_tag(console=console, attack_id=attack_id, tag_value=tag_value)
+        #         return f"✅ Added tag '{result['tag_value']}' to playbook attack {result['attack_id']}."
+        #     except Exception as e:
+        #         logger.error(f"Error in add_playbook_attack_tag: {e}")
+        #         return f"Error adding tag to playbook attack: {str(e)}"
+        #
+        # @self.mcp.tool(
+        #     name="remove_playbook_attack_tag",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+        #     description="""Removes a custom tag from a single SafeBreach playbook attack.
+        # This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
+        # Parameters: console (required), attack_id (required, the playbook attack/move ID), tag_value (required, a single tag)."""
+        # )
+        # def remove_playbook_attack_tag(console: str = "default", attack_id: int = None, tag_value: str = None) -> str:
+        #     """Remove a custom tag from a single playbook attack."""
+        #     try:
+        #         result = sb_remove_playbook_attack_tag(console=console, attack_id=attack_id, tag_value=tag_value)
+        #         return f"✅ Removed tag '{result['tag_value']}' from playbook attack {result['attack_id']}."
+        #     except Exception as e:
+        #         logger.error(f"Error in remove_playbook_attack_tag: {e}")
+        #         return f"Error removing tag from playbook attack: {str(e)}"
+        #
+        # @self.mcp.tool(
+        #     name="rename_playbook_attack_tag",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+        #     description="""Renames a custom tag on a single SafeBreach playbook attack.
+        # This is a WRITE action (rate-limited, hidden unless AI-agent actions are enabled).
+        # Parameters: console (required), attack_id (required, the playbook attack/move ID), old_value (required), new_value (required)."""
+        # )
+        # def rename_playbook_attack_tag(console: str = "default", attack_id: int = None,
+        #                                old_value: str = None, new_value: str = None) -> str:
+        #     """Rename a custom tag on a single playbook attack."""
+        #     try:
+        #         result = sb_rename_playbook_attack_tag(
+        #             console=console, attack_id=attack_id, old_value=old_value, new_value=new_value
+        #         )
+        #         return (f"✅ Renamed tag '{result['old_value']}' to '{result['new_value']}' "
+        #                 f"on playbook attack {result['attack_id']}.")
+        #     except Exception as e:
+        #         logger.error(f"Error in rename_playbook_attack_tag: {e}")
+        #         return f"Error renaming tag on playbook attack: {str(e)}"
 
         @self.mcp.tool(
             name="get_playbook_attack_tags",
@@ -418,59 +423,62 @@ Parameters: console (required), attack_id (required, the playbook attack/move ID
                 logger.error(f"Error in get_playbook_attack_tags: {e}")
                 return f"Error getting tags for playbook attack: {str(e)}"
 
-        @self.mcp.tool(
-            name="bulk_add_playbook_attack_tags",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
-            description="""Adds one or more custom tags to one or more playbook attacks (BULK write, rate-limited).
-Covers: one tag on many attacks, many tags on one attack, and many tags on many attacks.
-Guardrails: capped per call (max attacks/tags) to protect the console.
-Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), tag_values (required, comma-separated tags)."""
-        )
-        def bulk_add_playbook_attack_tags(console: str = "default", attack_ids: str = None, tag_values: str = None) -> str:
-            """Bulk-add custom tags to playbook attacks."""
-            try:
-                r = sb_bulk_add_playbook_attack_tags(console=console, attack_ids=attack_ids, tag_values=tag_values)
-                return (f"✅ Bulk add: {r.get('succeeded')} succeeded, {r.get('failed_count')} failed "
-                        f"across {len(r['attack_ids'])} attack(s). {r.get('hint_to_agent','')}")
-            except Exception as e:
-                logger.error(f"Error in bulk_add_playbook_attack_tags: {e}")
-                return f"Error bulk-adding tags: {str(e)}"
-
-        @self.mcp.tool(
-            name="bulk_remove_playbook_attack_tags",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
-            description="""Removes one or more custom tags from one or more playbook attacks (BULK write, rate-limited).
-Guardrails: capped per call (max attacks/tags) to protect the console.
-Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), tag_values (required, comma-separated tags)."""
-        )
-        def bulk_remove_playbook_attack_tags(console: str = "default", attack_ids: str = None, tag_values: str = None) -> str:
-            """Bulk-remove custom tags from playbook attacks."""
-            try:
-                r = sb_bulk_remove_playbook_attack_tags(console=console, attack_ids=attack_ids, tag_values=tag_values)
-                return (f"✅ Bulk remove: {r.get('succeeded')} succeeded, {r.get('failed_count')} failed "
-                        f"across {len(r['attack_ids'])} attack(s). {r.get('hint_to_agent','')}")
-            except Exception as e:
-                logger.error(f"Error in bulk_remove_playbook_attack_tags: {e}")
-                return f"Error bulk-removing tags: {str(e)}"
-
-        @self.mcp.tool(
-            name="bulk_rename_playbook_attack_tag",
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
-            description="""Renames a custom tag (old_value -> new_value) across one or more playbook attacks (BULK write, rate-limited).
-Guardrails: capped per call (max attacks) to protect the console.
-Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), old_value (required), new_value (required)."""
-        )
-        def bulk_rename_playbook_attack_tag(console: str = "default", attack_ids: str = None,
-                                            old_value: str = None, new_value: str = None) -> str:
-            """Bulk-rename a custom tag across playbook attacks."""
-            try:
-                r = sb_bulk_rename_playbook_attack_tag(console=console, attack_ids=attack_ids,
-                                                       old_value=old_value, new_value=new_value)
-                return (f"✅ Bulk rename '{old_value}'→'{new_value}': {r.get('succeeded')} succeeded, "
-                        f"{r.get('failed_count')} failed across {len(r['attack_ids'])} attack(s).")
-            except Exception as e:
-                logger.error(f"Error in bulk_rename_playbook_attack_tag: {e}")
-                return f"Error bulk-renaming tag: {str(e)}"
+        # Bulk tag write tools are not registered while tag mutation is unsupported backend-side.
+        # Their implementations remain in playbook_functions.py; uncomment to restore.
+        #
+        # @self.mcp.tool(
+        #     name="bulk_add_playbook_attack_tags",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+        #     description="""Adds one or more custom tags to one or more playbook attacks (BULK write, rate-limited).
+        # Covers: one tag on many attacks, many tags on one attack, and many tags on many attacks.
+        # Guardrails: capped per call (max attacks/tags) to protect the console.
+        # Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), tag_values (required, comma-separated tags)."""
+        # )
+        # def bulk_add_playbook_attack_tags(console: str = "default", attack_ids: str = None, tag_values: str = None) -> str:
+        #     """Bulk-add custom tags to playbook attacks."""
+        #     try:
+        #         r = sb_bulk_add_playbook_attack_tags(console=console, attack_ids=attack_ids, tag_values=tag_values)
+        #         return (f"✅ Bulk add: {r.get('succeeded')} succeeded, {r.get('failed_count')} failed "
+        #                 f"across {len(r['attack_ids'])} attack(s). {r.get('hint_to_agent','')}")
+        #     except Exception as e:
+        #         logger.error(f"Error in bulk_add_playbook_attack_tags: {e}")
+        #         return f"Error bulk-adding tags: {str(e)}"
+        #
+        # @self.mcp.tool(
+        #     name="bulk_remove_playbook_attack_tags",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+        #     description="""Removes one or more custom tags from one or more playbook attacks (BULK write, rate-limited).
+        # Guardrails: capped per call (max attacks/tags) to protect the console.
+        # Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), tag_values (required, comma-separated tags)."""
+        # )
+        # def bulk_remove_playbook_attack_tags(console: str = "default", attack_ids: str = None, tag_values: str = None) -> str:
+        #     """Bulk-remove custom tags from playbook attacks."""
+        #     try:
+        #         r = sb_bulk_remove_playbook_attack_tags(console=console, attack_ids=attack_ids, tag_values=tag_values)
+        #         return (f"✅ Bulk remove: {r.get('succeeded')} succeeded, {r.get('failed_count')} failed "
+        #                 f"across {len(r['attack_ids'])} attack(s). {r.get('hint_to_agent','')}")
+        #     except Exception as e:
+        #         logger.error(f"Error in bulk_remove_playbook_attack_tags: {e}")
+        #         return f"Error bulk-removing tags: {str(e)}"
+        #
+        # @self.mcp.tool(
+        #     name="bulk_rename_playbook_attack_tag",
+        #     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+        #     description="""Renames a custom tag (old_value -> new_value) across one or more playbook attacks (BULK write, rate-limited).
+        # Guardrails: capped per call (max attacks) to protect the console.
+        # Parameters: console (required), attack_ids (required, comma-separated attack/move IDs), old_value (required), new_value (required)."""
+        # )
+        # def bulk_rename_playbook_attack_tag(console: str = "default", attack_ids: str = None,
+        #                                     old_value: str = None, new_value: str = None) -> str:
+        #     """Bulk-rename a custom tag across playbook attacks."""
+        #     try:
+        #         r = sb_bulk_rename_playbook_attack_tag(console=console, attack_ids=attack_ids,
+        #                                                old_value=old_value, new_value=new_value)
+        #         return (f"✅ Bulk rename '{old_value}'→'{new_value}': {r.get('succeeded')} succeeded, "
+        #                 f"{r.get('failed_count')} failed across {len(r['attack_ids'])} attack(s).")
+        #     except Exception as e:
+        #         logger.error(f"Error in bulk_rename_playbook_attack_tag: {e}")
+        #         return f"Error bulk-renaming tag: {str(e)}"
 
 
 def parse_external_config(server_type: str) -> bool:

--- a/safebreach_mcp_playbook/tests/test_bulk_tag_tools.py
+++ b/safebreach_mcp_playbook/tests/test_bulk_tag_tools.py
@@ -19,7 +19,7 @@ from safebreach_mcp_playbook.playbook_functions import (
     MAX_BULK_ATTACK_IDS,
     MAX_BULK_TAG_VALUES,
 )
-from safebreach_mcp_playbook.playbook_server import SafeBreachPlaybookServer
+# from safebreach_mcp_playbook.playbook_server import SafeBreachPlaybookServer
 
 MOD = "safebreach_mcp_playbook.playbook_functions"
 BASE_URL = "https://test.safebreach.com"
@@ -187,37 +187,40 @@ class TestBulkRename:
         infra.rate_limiter.check_limit.assert_called_once_with("test-caller", "bulk_rename_playbook_attack_tag")
 
 
-# =========================================================================== #
-# server wrappers — annotations + delegation
-# =========================================================================== #
-class TestBulkWrappers:
-    def _tool(self, name):
-        server = SafeBreachPlaybookServer()
-        return server.mcp._tool_manager._tools[name]
-
-    @pytest.mark.parametrize("name,destructive", [
-        ("bulk_add_playbook_attack_tags", False),
-        ("bulk_remove_playbook_attack_tags", True),
-        ("bulk_rename_playbook_attack_tag", False),
-    ])
-    def test_registered_write_annotations(self, name, destructive):
-        tool = self._tool(name)
-        assert tool.annotations.readOnlyHint is False
-        assert tool.annotations.destructiveHint is destructive
-
-    @patch("safebreach_mcp_playbook.playbook_server.sb_bulk_add_playbook_attack_tags")
-    def test_add_wrapper_delegates(self, mock_sb):
-        mock_sb.return_value = {"attack_ids": [1, 2], "succeeded": 2, "failed_count": 0, "hint_to_agent": "ok"}
-        tool = self._tool("bulk_add_playbook_attack_tags")
-        out = tool.fn(console="c", attack_ids="1,2", tag_values="x")
-        assert mock_sb.call_args.kwargs["attack_ids"] == "1,2"
-        assert mock_sb.call_args.kwargs["tag_values"] == "x"
-        assert isinstance(out, str)
-
-    @patch("safebreach_mcp_playbook.playbook_server.sb_bulk_add_playbook_attack_tags")
-    def test_wrapper_error_path(self, mock_sb):
-        mock_sb.side_effect = ValueError("too many")
-        tool = self._tool("bulk_add_playbook_attack_tags")
-        out = tool.fn(console="c", attack_ids="1", tag_values="x")
-        assert isinstance(out, str)
-        assert out.startswith("Error")
+# Wrapper tests are disabled: the tag write tools are no longer registered on the
+# playbook server while tag mutation is unsupported backend-side. Restore together
+# with the tool registrations.
+# # =========================================================================== #
+# # server wrappers — annotations + delegation
+# # =========================================================================== #
+# class TestBulkWrappers:
+#     def _tool(self, name):
+#         server = SafeBreachPlaybookServer()
+#         return server.mcp._tool_manager._tools[name]
+#
+#     @pytest.mark.parametrize("name,destructive", [
+#         ("bulk_add_playbook_attack_tags", False),
+#         ("bulk_remove_playbook_attack_tags", True),
+#         ("bulk_rename_playbook_attack_tag", False),
+#     ])
+#     def test_registered_write_annotations(self, name, destructive):
+#         tool = self._tool(name)
+#         assert tool.annotations.readOnlyHint is False
+#         assert tool.annotations.destructiveHint is destructive
+#
+#     @patch("safebreach_mcp_playbook.playbook_server.sb_bulk_add_playbook_attack_tags")
+#     def test_add_wrapper_delegates(self, mock_sb):
+#         mock_sb.return_value = {"attack_ids": [1, 2], "succeeded": 2, "failed_count": 0, "hint_to_agent": "ok"}
+#         tool = self._tool("bulk_add_playbook_attack_tags")
+#         out = tool.fn(console="c", attack_ids="1,2", tag_values="x")
+#         assert mock_sb.call_args.kwargs["attack_ids"] == "1,2"
+#         assert mock_sb.call_args.kwargs["tag_values"] == "x"
+#         assert isinstance(out, str)
+#
+#     @patch("safebreach_mcp_playbook.playbook_server.sb_bulk_add_playbook_attack_tags")
+#     def test_wrapper_error_path(self, mock_sb):
+#         mock_sb.side_effect = ValueError("too many")
+#         tool = self._tool("bulk_add_playbook_attack_tags")
+#         out = tool.fn(console="c", attack_ids="1", tag_values="x")
+#         assert isinstance(out, str)
+#         assert out.startswith("Error")

--- a/safebreach_mcp_playbook/tests/test_e2e.py
+++ b/safebreach_mcp_playbook/tests/test_e2e.py
@@ -773,6 +773,9 @@ class TestPlaybookTagWriteE2E:
 
     # ---- req 1: single add / remove / rename round-trips (self-cleaning) ------------------- #
 
+    @pytest.mark.skip(
+        reason="tag mutation unsupported backend-side; write tools withdrawn"
+    )
     def test_add_read_remove_tag_roundtrip_e2e(self, writable_move_ids):
         """Add a tag → verify via get-tags → remove it → verify removal (state restored)."""
         attack_id = writable_move_ids[0]
@@ -785,6 +788,9 @@ class TestPlaybookTagWriteE2E:
             sb_remove_playbook_attack_tag(console=E2E_CONSOLE, attack_id=attack_id, tag_value=tag)
         assert tag not in _current_tags(E2E_CONSOLE, attack_id)
 
+    @pytest.mark.skip(
+        reason="tag mutation unsupported backend-side; write tools withdrawn"
+    )
     def test_rename_tag_roundtrip_e2e(self, writable_move_ids):
         """Add old tag → rename to new → verify swap → remove new (state restored)."""
         attack_id = writable_move_ids[0]
@@ -804,6 +810,9 @@ class TestPlaybookTagWriteE2E:
 
     # ---- req 4: bulk (many tags on many attacks) round-trips (self-cleaning) --------------- #
 
+    @pytest.mark.skip(
+        reason="tag mutation unsupported backend-side; write tools withdrawn"
+    )
     def test_bulk_add_remove_roundtrip_e2e(self, writable_move_ids):
         """Bulk-add N tags on N attacks → verify each → bulk-remove → verify removal."""
         tag_a = _unique_tag("bulkA")
@@ -823,6 +832,9 @@ class TestPlaybookTagWriteE2E:
             current = _current_tags(E2E_CONSOLE, attack_id)
             assert tag_a not in current and tag_b not in current
 
+    @pytest.mark.skip(
+        reason="tag mutation unsupported backend-side; write tools withdrawn"
+    )
     def test_bulk_rename_roundtrip_e2e(self, writable_move_ids):
         """Bulk-add a tag on N attacks → bulk-rename it → verify swap → bulk-remove (restored)."""
         old_tag = _unique_tag("bulkOld")

--- a/safebreach_mcp_playbook/tests/test_playbook_server.py
+++ b/safebreach_mcp_playbook/tests/test_playbook_server.py
@@ -32,6 +32,43 @@ class TestSafeBreachPlaybookServer:
         assert server.mcp is not None
 
 
+class TestExposedTagTools:
+    """Guard the tag surface the playbook server advertises.
+
+    Tag mutation is unsupported backend-side, so the write tools must not be registered.
+    The read-only tag tools must stay registered.
+    """
+
+    WITHDRAWN_WRITE_TOOLS = [
+        "add_playbook_attack_tag",
+        "remove_playbook_attack_tag",
+        "rename_playbook_attack_tag",
+        "bulk_add_playbook_attack_tags",
+        "bulk_remove_playbook_attack_tags",
+        "bulk_rename_playbook_attack_tag",
+    ]
+
+    EXPECTED_TOOLS = [
+        "get_playbook_attacks",
+        "get_playbook_attack_details",
+        "get_playbook_attacks_by_tags",
+        "get_playbook_attack_tags",
+    ]
+
+    def _registered_tool_names(self):
+        return set(SafeBreachPlaybookServer().mcp._tool_manager._tools.keys())
+
+    @pytest.mark.parametrize("tool_name", WITHDRAWN_WRITE_TOOLS)
+    def test_tag_write_tool_not_registered(self, tool_name):
+        """No tag write tool is advertised to MCP clients."""
+        assert tool_name not in self._registered_tool_names()
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOLS)
+    def test_expected_tool_registered(self, tool_name):
+        """The read-only tools, including both tag read tools, stay advertised."""
+        assert tool_name in self._registered_tool_names()
+
+
 class TestParseExternalConfig:
     """Test the parse_external_config function."""
     

--- a/safebreach_mcp_playbook/tests/test_tag_write_tools.py
+++ b/safebreach_mcp_playbook/tests/test_tag_write_tools.py
@@ -19,7 +19,7 @@ from safebreach_mcp_playbook.playbook_functions import (
     sb_rename_playbook_attack_tag,
     clear_playbook_cache,
 )
-from safebreach_mcp_playbook.playbook_server import SafeBreachPlaybookServer
+# from safebreach_mcp_playbook.playbook_server import SafeBreachPlaybookServer
 
 MOD = "safebreach_mcp_playbook.playbook_functions"
 BASE_URL = "https://test.safebreach.com"
@@ -263,49 +263,52 @@ class TestRenamePlaybookAttackTag:
         assert result["hint_to_agent"]
 
 
-# =========================================================================== #
-# Server wrappers — annotations + delegation + error path
-# =========================================================================== #
-class TestWriteToolWrappers:
-    def _tool(self, name):
-        server = SafeBreachPlaybookServer()
-        return server, server.mcp._tool_manager._tools[name]
-
-    @pytest.mark.parametrize("name,expected_destructive", [
-        ("add_playbook_attack_tag", False),
-        ("remove_playbook_attack_tag", True),   # remove deletes data → destructive (matches manage_test)
-        ("rename_playbook_attack_tag", False),  # update semantics, like update_studio_attack_draft
-    ])
-    def test_registered_and_write_annotations(self, name, expected_destructive):
-        _, tool = self._tool(name)
-        assert tool.annotations.readOnlyHint is False
-        assert tool.annotations.destructiveHint is expected_destructive
-
-    @patch("safebreach_mcp_playbook.playbook_server.sb_add_playbook_attack_tag")
-    def test_add_wrapper_delegates_and_markdown(self, mock_sb):
-        mock_sb.return_value = {"attack_id": 1027, "tag_value": "mytag", "action": "added",
-                                "hint_to_agent": "ok"}
-        _, tool = self._tool("add_playbook_attack_tag")
-        out = tool.fn(console="x", attack_id=1027, tag_value="mytag")
-        assert mock_sb.call_args.kwargs["attack_id"] == 1027
-        assert mock_sb.call_args.kwargs["tag_value"] == "mytag"
-        assert isinstance(out, str)
-        assert "mytag" in out
-
-    @patch("safebreach_mcp_playbook.playbook_server.sb_rename_playbook_attack_tag")
-    def test_rename_wrapper_delegates(self, mock_sb):
-        mock_sb.return_value = {"attack_id": 1027, "old_value": "old", "new_value": "new",
-                                "action": "renamed", "hint_to_agent": "ok"}
-        _, tool = self._tool("rename_playbook_attack_tag")
-        out = tool.fn(console="x", attack_id=1027, old_value="old", new_value="new")
-        assert mock_sb.call_args.kwargs["old_value"] == "old"
-        assert mock_sb.call_args.kwargs["new_value"] == "new"
-        assert isinstance(out, str)
-
-    @patch("safebreach_mcp_playbook.playbook_server.sb_add_playbook_attack_tag")
-    def test_wrapper_error_path(self, mock_sb):
-        mock_sb.side_effect = ValueError("bad")
-        _, tool = self._tool("add_playbook_attack_tag")
-        out = tool.fn(console="x", attack_id=1027, tag_value="mytag")
-        assert isinstance(out, str)
-        assert out.startswith("Error")
+# Wrapper tests are disabled: the tag write tools are no longer registered on the
+# playbook server while tag mutation is unsupported backend-side. Restore together
+# with the tool registrations.
+# # =========================================================================== #
+# # Server wrappers — annotations + delegation + error path
+# # =========================================================================== #
+# class TestWriteToolWrappers:
+#     def _tool(self, name):
+#         server = SafeBreachPlaybookServer()
+#         return server, server.mcp._tool_manager._tools[name]
+#
+#     @pytest.mark.parametrize("name,expected_destructive", [
+#         ("add_playbook_attack_tag", False),
+#         ("remove_playbook_attack_tag", True),   # remove deletes data → destructive (matches manage_test)
+#         ("rename_playbook_attack_tag", False),  # update semantics, like update_studio_attack_draft
+#     ])
+#     def test_registered_and_write_annotations(self, name, expected_destructive):
+#         _, tool = self._tool(name)
+#         assert tool.annotations.readOnlyHint is False
+#         assert tool.annotations.destructiveHint is expected_destructive
+#
+#     @patch("safebreach_mcp_playbook.playbook_server.sb_add_playbook_attack_tag")
+#     def test_add_wrapper_delegates_and_markdown(self, mock_sb):
+#         mock_sb.return_value = {"attack_id": 1027, "tag_value": "mytag", "action": "added",
+#                                 "hint_to_agent": "ok"}
+#         _, tool = self._tool("add_playbook_attack_tag")
+#         out = tool.fn(console="x", attack_id=1027, tag_value="mytag")
+#         assert mock_sb.call_args.kwargs["attack_id"] == 1027
+#         assert mock_sb.call_args.kwargs["tag_value"] == "mytag"
+#         assert isinstance(out, str)
+#         assert "mytag" in out
+#
+#     @patch("safebreach_mcp_playbook.playbook_server.sb_rename_playbook_attack_tag")
+#     def test_rename_wrapper_delegates(self, mock_sb):
+#         mock_sb.return_value = {"attack_id": 1027, "old_value": "old", "new_value": "new",
+#                                 "action": "renamed", "hint_to_agent": "ok"}
+#         _, tool = self._tool("rename_playbook_attack_tag")
+#         out = tool.fn(console="x", attack_id=1027, old_value="old", new_value="new")
+#         assert mock_sb.call_args.kwargs["old_value"] == "old"
+#         assert mock_sb.call_args.kwargs["new_value"] == "new"
+#         assert isinstance(out, str)
+#
+#     @patch("safebreach_mcp_playbook.playbook_server.sb_add_playbook_attack_tag")
+#     def test_wrapper_error_path(self, mock_sb):
+#         mock_sb.side_effect = ValueError("bad")
+#         _, tool = self._tool("add_playbook_attack_tag")
+#         out = tool.fn(console="x", attack_id=1027, tag_value="mytag")
+#         assert isinstance(out, str)
+#         assert out.startswith("Error")


### PR DESCRIPTION
## Why

Tag mutation is unsupported backend-side for now, because of a bug in how tags are treated for **cloned moves**. The six playbook tag write tools call the backend move-tags endpoints, so they are withdrawn from the MCP tool surface in step with that change.

This is **not** an MCP-side defect. The implementation is being *parked*, not fixed, so it can be restored once the cloned-move tag handling is corrected backend-side.

Jira: [SAF-34168](https://safebreach.atlassian.net/browse/SAF-34168)

## What changed

Everything is **commented out, not deleted**. Re-enabling is uncommenting three blocks plus reverting four decorators.

| Area | Change |
|---|---|
| `playbook_server.py` | The six `@self.mcp.tool` registrations, across **two non-contiguous regions** — `get_playbook_attack_tags` sits between them and stays registered |
| `playbook_server.py` | The six write-function names in the module-level import block |
| `test_tag_write_tools.py` | `TestWriteToolWrappers` + the `SafeBreachPlaybookServer` import it was the only consumer of |
| `test_bulk_tag_tools.py` | `TestBulkWrappers` + the same now-unused import |
| `test_e2e.py` | `@pytest.mark.skip` on the **4 mutating** tests in `TestPlaybookTagWriteE2E` |
| `test_playbook_server.py` | **New** `TestExposedTagTools` locking the tool surface in |

Withdrawn: `add_playbook_attack_tag`, `remove_playbook_attack_tag`, `rename_playbook_attack_tag`, `bulk_add_playbook_attack_tags`, `bulk_remove_playbook_attack_tags`, `bulk_rename_playbook_attack_tag`.

Still exposed: `get_playbook_attacks`, `get_playbook_attack_details`, `get_playbook_attacks_by_tags`, `get_playbook_attack_tags`.

**`playbook_functions.py` has zero diff.** Every `sb_*` tag function, helper, and direct-call unit test remains and still passes.

## ⚠️ Breaking change

Advertised playbook tools drop from **10 to 4**. Any MCP client calling a withdrawn tool name will get an unknown-tool error.

## Notes for reviewers

**Why comment out rather than flag-gate.** There is no feature flag or conditional-registration mechanism in `_register_tools()` — all tools register unconditionally. Adding gating machinery for a temporary withdrawal seemed disproportionate.

**Why the new test asserts presence/absence, not set equality.** `TestExposedTagTools` checks that the six write tools are absent and the four survivors present, rather than asserting the registry equals exactly those four. Set equality would break the moment an unrelated playbook tool is added, while presence/absence still covers both real risks: over-deletion (the non-contiguous regions) and partial withdrawal (missing one bulk variant). It replaces a test that previously asserted only that the server object exists, with a comment claiming registration "can't easily be tested".

**Why the E2E skip is per-test, not per-class.** `TestPlaybookTagWriteE2E` holds 9 tests, but only 4 mutate tags. The others are a read-only test for `get_playbook_attack_tags` (a tool this PR keeps) and 4 validation tests that raise before any API call — their own banner reads "no live writes; always run". A class-level skip would have disabled all 5 unnecessarily.

**Heads-up on `@skip_e2e`.** It is inert by default: `SKIP_E2E_TESTS` is read as `os.environ.get('SKIP_E2E_TESTS', 'false')`, so the default is *run*, not skip — and its reason string ("set SKIP_E2E_TESTS=false to enable") reads backwards relative to that. It also differs from `safebreach_mcp_data/tests/test_drift_tools.py`, which defaults to skip. Left alone as out of scope, but it is why an explicit skip was needed here.

## Verification

| Check | Result |
|---|---|
| Playbook unit suite (E2E ignored) | **246 passed, 0 failed** |
| Full repo unit suite, `-m "not e2e"` | **1439 passed, 0 failed** |
| Registered playbook tools | exactly the 4 expected |
| `import safebreach_mcp_playbook.playbook_server` | OK (guards the edited import block) |
| `git diff` on `playbook_functions.py` | zero |

246 = 247 baseline − 11 removed wrapper cases + 10 new `TestExposedTagTools` cases.

Pre-existing and untouched: `test_e2e.py` reports 25 failures / 4 errors on `main` from missing live-console credentials. Out of scope.

## Open questions

1. Is the backend removing the two move-tags endpoints entirely (404), or keeping them and rejecting writes? Determines how the parked `sb_*` functions fail if ever called.
2. Do the read-only tag tools stay correct under the cloned-move bug? They read the cached attacks listing, not the write endpoints — but if the bug also corrupts tag values *as read*, keeping them needs revisiting.
3. Should this merge before, with, or after the backend change? The harmful ordering is the tools staying live while the backend already rejects the calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cfaeYj3HTojAnLqGfiFiv
