### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.9.0 — 2026-07-29
+
+### Changed
+
+- The playbook MCP server no longer exposes the tag write tools — add, remove and rename a
+  custom tag on a playbook attack, plus the three bulk variants. Tag mutation is unsupported
+  backend-side, so these are withdrawn until that support returns. The playbook server now
+  advertises four tools instead of ten.
+- The read-only tag tools, `get_playbook_attack_tags` and `get_playbook_attacks_by_tags`, are
+  unaffected and remain available.
+- Release tooling now regenerates `uv.lock` when bumping the version.
+
 ## 1.8.0 — 2026-07-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.8.0"
+version = "1.9.0"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "safebreach-mcp-server"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 1.9.0

### Changed

- The playbook MCP server no longer exposes the tag write tools — add, remove and rename a
  custom tag on a playbook attack, plus the three bulk variants. Tag mutation is unsupported
  backend-side, so these are withdrawn until that support returns. The playbook server now
  advertises four tools instead of ten.
- The read-only tag tools, `get_playbook_attack_tags` and `get_playbook_attacks_by_tags`, are
  unaffected and remain available.
- Release tooling now regenerates `uv.lock` when bumping the version.

---

### Note on the version choice

The tool withdrawal is a **breaking change for MCP clients** calling any of the six removed tool
names — strict semver would argue for `2.0.0`. `1.9.0` was chosen deliberately, for consistency with
`1.8.0` (which shipped these same tools as a minor bump) and because the withdrawal is expected to be
temporary, pending backend support for tag mutation returning.

### Pre-flight checks

The release workflow's gates were dry-run locally before opening this PR:

| Gate | Result |
|---|---|
| Version extraction from `pyproject.toml` | `1.9.0` |
| `^## 1.9.0` present in `CHANGELOG.md` | pass |
| Release-notes extraction (`awk` between headings) | pass, renders the section above |
| Date separator is em-dash `—` (U+2014), not `--` | pass |
| Tag `1.9.0` does not already exist | pass |
| `uv.lock` regenerated | `safebreach-mcp-server v1.8.0 -> v1.9.0` |

### What ships in this release

Everything from SAF-34168, merged in #80. Verified on `main` before cutting this branch: the playbook
server advertises exactly four tools — `get_playbook_attacks`, `get_playbook_attack_details`,
`get_playbook_attacks_by_tags`, `get_playbook_attack_tags`.

Test evidence on that commit: 246 playbook unit tests and 1439 repo unit tests pass, plus a live E2E
run (29 passed / 5 skipped / 0 failed) confirming the retained read tool works against a real console
and the withdrawn write paths skip as intended.

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.9.0`
3. Create a GitHub Release with the changelog notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cfaeYj3HTojAnLqGfiFiv
