### PR TITLE
Release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.10.0 — 2026-07-30
+
+### Added
+
+- `get_tests` now includes tests waiting in the orchestrator execution queue: a fresh
+  (never-cached) queue snapshot is merged on every call that could match non-terminal tests.
+  Queued entries carry `status='queued'`, `queue_position` (1-based), and `queued_time`
+  (submission time), are pinned to the top of the first page (newest submission first), and
+  the response includes `queued_tests_count`
+- New `'queued'` value for the `get_tests` `status_filter` — slotted-but-still-preparing
+  (PENDING) tests are normalized to `'queued'` as well; `status_filter` values are now
+  explicitly validated with a clear error listing allowed options
+- `get_tests` warns via `hint_to_agent` when the orchestrator queue is paused (queued tests
+  will not start until the queue is resumed)
+
+### Fixed
+
+- Capped the `mcp` SDK dependency below 2.0 (`mcp>=1.10.0,<2.0.0`) — mcp 2.x removed
+  `mcp.server.fastmcp`, which crashed all servers on first import for fresh standalone installs
+
 ## 1.9.0 — 2026-07-29
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.9.0"
+version = "1.10.0"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "safebreach-mcp-server"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 1.10.0

## 1.10.0 — 2026-07-30

### Added

- `get_tests` now includes tests waiting in the orchestrator execution queue: a fresh
  (never-cached) queue snapshot is merged on every call that could match non-terminal tests.
  Queued entries carry `status='queued'`, `queue_position` (1-based), and `queued_time`
  (submission time), are pinned to the top of the first page (newest submission first), and
  the response includes `queued_tests_count`
- New `'queued'` value for the `get_tests` `status_filter` — slotted-but-still-preparing
  (PENDING) tests are normalized to `'queued'` as well; `status_filter` values are now
  explicitly validated with a clear error listing allowed options
- `get_tests` warns via `hint_to_agent` when the orchestrator queue is paused (queued tests
  will not start until the queue is resumed)

### Fixed

- Capped the `mcp` SDK dependency below 2.0 (`mcp>=1.10.0,<2.0.0`) — mcp 2.x removed
  `mcp.server.fastmcp`, which crashed all servers on first import for fresh standalone installs

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.10.0`
3. Create a GitHub Release with the changelog notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)