### PR TITLE
fix(data): restore 'paused' as a valid get_tests status_filter (SAF-34457)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,7 +493,7 @@ The `get_console_simulators`, `get_tests`, and `get_test_simulations` functions 
 **Enhanced Test History Filtering (`get_tests`):**
 - **Test Type**: Filter by "validate" (BAS tests) or "propagate" (ALM tests)
 - **Time Windows**: Filter by start/end dates (epoch timestamps or ISO 8601 strings, e.g., '2026-03-01T00:00:00Z')
-- **Status**: Filter by "completed", "canceled", "failed", "running", "queued" (SAF-33511: "queued"
+- **Status**: Filter by "completed", "canceled", "failed", "running", "paused", "queued" (SAF-33511: "queued"
   covers tests waiting in the orchestrator execution queue — merged live from the orchestrator
   queue API on every call, never cached — plus slotted-but-preparing tests; queued entries are
   pinned to the top of the first page with `queue_position` and `queued_time` fields, and the

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ The MCP server exposes the following tools for SafeBreach operations:
      - `test_type` (string, optional) - Filter by "validate" (BAS), "propagate" (ALM), or None for all
      - `start_date` (int, optional) - Filter tests with end_time >= start_date (Unix timestamp)
      - `end_date` (int, optional) - Filter tests with end_time <= end_date (Unix timestamp)
-     - `status_filter` (string, optional) - Filter by "completed", "canceled", "failed", "running", "queued", or None for all. "queued" returns tests waiting in the orchestrator execution queue (merged live on every call — never cached); queued entries are pinned to the top of the first page and carry `queue_position` and `queued_time` instead of start/end times (so `start_date`/`end_date` filters exclude them)
+     - `status_filter` (string, optional) - Filter by "completed", "canceled", "failed", "running", "paused", "queued", or None for all. "queued" returns tests waiting in the orchestrator execution queue (merged live on every call — never cached); queued entries are pinned to the top of the first page and carry `queue_position` and `queued_time` instead of start/end times (so `start_date`/`end_date` filters exclude them)
      - `name_filter` (string, optional) - Case-insensitive partial match on test name
      - `order_by` (string, default "end_time") - Sort field: "end_time", "start_time", "name", "duration"
      - `order_direction` (string, default "desc") - Sort direction: "desc" or "asc"

--- a/prds/bugfix-SAF-34457-restore-paused-status-filter/prd.md
+++ b/prds/bugfix-SAF-34457-restore-paused-status-filter/prd.md
@@ -1,0 +1,66 @@
+# PRD: SAF-34457 — restore `paused` as a valid `get_tests` `status_filter`
+
+- **Ticket**: [SAF-34457](https://safebreach.atlassian.net/browse/SAF-34457) (Bug)
+- **Branch**: `bugfix/restore-paused-status-filter` (off `main`; predates the ticket key, so the
+  branch name carries no key — this folder is named by the key instead)
+- **PR**: [#83](https://github.com/SafeBreach/safebreach-mcp/pull/83)
+
+## Problem
+
+Customer-reported regression, validated on Clearwater01/02/03. `get_tests` with
+`status_filter="paused"` fails before any API call:
+
+```
+Invalid status_filter parameter 'paused'. Valid values are: completed, canceled, failed, running, queued
+```
+
+The customer pauses tests routinely outside business hours and can no longer detect them.
+
+## Root cause
+
+SAF-33511 (`f6b20ee`, shipped 1.10.0) added the **first** `status_filter` allowlist. `git log -L`
+confirms no validation existed before: any string was accepted, lowercased, sent to `testsummaries`
+as `&status={UPPER}`, and matched client-side in `_apply_filters`. The allowlist was built from the
+four documented values plus the new `queued`, silently dropping every undocumented-but-working
+value — `paused` among them.
+
+## Change
+
+| File | Change |
+|------|--------|
+| `data_functions.py:134` | `'paused'` added to `valid_status_filters` — the fix |
+| `data_functions.py:104` | docstring value list |
+| `data_server.py:69` | MCP tool description |
+| `README.md:873`, `CLAUDE.md:496` | documented value lists |
+
+Restores the exact pre-1.10.0 code path. The four supporting edits are the same one-word change:
+an accepted value that no description advertises is the SAF-30863 failure mode, where the agent
+never learns the option exists.
+
+## Tests
+
+One regression test asserting `status_filter="paused"` is accepted and selects the paused row, plus
+`paused` added to the existing invalid-value error-message assertion. **1066 passed, 0 failed**
+(non-e2e).
+
+## Known limitation
+
+Pause state is authoritative in the orchestrator (`slotState[].isPaused`) — which is why
+`get_test_details` and `manage_test` consult the orchestrator queue as phase 1, and why SAF-33511
+found the list API has no functional `QUEUED` status. Whether `testsummaries` reports `paused` in
+the **list** response is unverified: it needs a live console with a genuinely paused test, which
+isn't reproducible locally. If the customer reports the call now succeeds but returns nothing, the
+remaining fix is an orchestrator overlay (mark tests in paused slots as `status='paused'`), not this
+allowlist.
+
+## Definition of done
+
+- [x] `status_filter='paused'` accepted; value advertised in tool description, docstring, README, CLAUDE.md
+- [x] Regression test green; full non-e2e suite green (1066)
+- [ ] Customer confirms on Clearwater with a genuinely paused test
+
+## Notes
+
+Written after the fix, not before — the change was triaged and shipped as a one-line validation
+regression before a ticket existed. Recorded here for the PRD gate and for whoever hits the known
+limitation above.

--- a/safebreach_mcp_data/data_functions.py
+++ b/safebreach_mcp_data/data_functions.py
@@ -101,7 +101,7 @@ def sb_get_tests(
         test_type: Filter by test type ('validate', 'propagate')
         start_date: Start date filter (Unix timestamp)
         end_date: End date filter (Unix timestamp)
-        status_filter: Filter by status ('completed', 'canceled', 'failed', 'running')
+        status_filter: Filter by status ('completed', 'canceled', 'failed', 'running', 'paused', 'queued')
         name_filter: Filter by test name (partial match)
         launched_by_filter: Filter by launcher username (partial match, case-insensitive)
         order_by: Field to order by ('end_time', 'start_time', 'name', 'duration')
@@ -131,7 +131,7 @@ def sb_get_tests(
         raise ValueError(f"Invalid order_direction parameter '{order_direction}'. Valid values are: {', '.join(valid_order_direction)}")
 
     # Validate status_filter parameter (SAF-33511)
-    valid_status_filters = ['completed', 'canceled', 'failed', 'running', 'queued']
+    valid_status_filters = ['completed', 'canceled', 'failed', 'running', 'paused', 'queued']
     if status_filter is not None and (
         not isinstance(status_filter, str) or status_filter.lower() not in valid_status_filters
     ):

--- a/safebreach_mcp_data/data_server.py
+++ b/safebreach_mcp_data/data_server.py
@@ -66,7 +66,7 @@ The response includes queued_tests_count.
 Parameters: console (required), page_number (default 0), test_type ('validate'/'propagate'/None), \
 start_date (epoch ms/seconds or ISO 8601 string, e.g. '2026-03-01T00:00:00Z'), \
 end_date (epoch ms/seconds or ISO 8601 string),
-status_filter ('completed'/'canceled'/'failed'/'running'/'queued'/None), name_filter (partial name match), \
+status_filter ('completed'/'canceled'/'failed'/'running'/'paused'/'queued'/None), name_filter (partial name match), \
 launched_by_filter (partial username match, case-insensitive — e.g. 'sbadmin'), \
 order_by ('end_time'/'start_time'/'name'/'duration'), order_direction ('desc'/'asc').
 Accepts both epoch timestamps and ISO 8601 strings for date parameters.

--- a/safebreach_mcp_data/tests/test_data_functions.py
+++ b/safebreach_mcp_data/tests/test_data_functions.py
@@ -4573,8 +4573,35 @@ class TestQueuedTestsMerge:
         with pytest.raises(ValueError) as exc_info:
             sb_get_tests(console="c", status_filter="bogus")
         message = str(exc_info.value)
-        for value in ("completed", "canceled", "failed", "running", "queued"):
+        for value in ("completed", "canceled", "failed", "running", "paused", "queued"):
             assert value in message
+
+    # Regression: the SAF-33511 allowlist dropped 'paused', which the pre-allowlist
+    # pass-through accepted. Customers pause tests outside business hours and filter
+    # for them; rejecting the value made those tests undetectable.
+    @patch('safebreach_mcp_data.data_functions.get_orchestrator_queue_snapshot')
+    @patch('safebreach_mcp_data.data_functions.get_api_account_id', return_value='123')
+    @patch('safebreach_mcp_data.data_functions.get_api_base_url', return_value='https://test.com')
+    @patch('safebreach_mcp_data.data_functions.requests.get')
+    def test_paused_status_filter_is_accepted(
+        self, mock_get, mock_base, mock_acct, mock_snapshot
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = [
+            {"planName": "Paused overnight", "planRunId": "p1", "status": "paused",
+             "startTime": 1000, "systemTags": [], "finalStatus": {}},
+            {"planName": "Running", "planRunId": "r1", "status": "running",
+             "startTime": 1000, "systemTags": [], "finalStatus": {}},
+        ]
+        mock_get.return_value = mock_response
+        mock_snapshot.return_value = self._empty_snapshot()
+
+        result = sb_get_tests(console="c", status_filter="paused")
+
+        assert [t["test_id"] for t in result["tests_in_page"]] == ["p1"]
+        assert result["applied_filters"]["status_filter"] == "paused"
 
     # T-10 — terminal filters skip the snapshot
     @patch('safebreach_mcp_data.data_functions.get_orchestrator_queue_snapshot')


### PR DESCRIPTION
Fixes [SAF-34457](https://safebreach.atlassian.net/browse/SAF-34457).

## Problem

Customer-reported regression, validated on a customer env. Calling `get_tests` with `status_filter: "paused"` fails immediately:

```
Error executing tool get_tests: Invalid status_filter parameter 'paused'.
Valid values are: completed, canceled, failed, running, queued
```

It fails regardless of whether a paused test actually exists — validation runs before any API call. The customer pauses tests routinely outside business hours and can no longer detect them.

## Root cause

SAF-33511 (`f6b20ee`, shipped in 1.10.0) introduced the **first** `status_filter` allowlist. `git log -L` on the block confirms no validation existed before it: any status string was accepted, lowercased, forwarded to `testsummaries` as `&status={UPPER}`, and matched client-side in `_apply_filters`. The old contract doc records it verbatim — `status_filter | str|None | no validation; lowercased`.

The allowlist was written from the four documented values plus the new `queued`, which silently dropped every undocumented-but-working value. `paused` was one of them.

## Change

| File | Change |
|---|---|
| `data_functions.py:134` | `'paused'` added to `valid_status_filters` — the fix |
| `data_server.py:69` | MCP tool description — what the agent reads to know the value is legal |
| `data_functions.py:104` | docstring |
| `README.md`, `CLAUDE.md` | documented value lists |

The supporting edits are the same one-word change. An accepted value that no description advertises is the SAF-30863 failure mode (agent never learns the option exists), so accepting it in one place and omitting it in another would only half-fix this.

## Tests

One regression test asserting `status_filter="paused"` is accepted and selects the paused row; `paused` added to the existing T-9 error-message assertion.

**1066 passed, 0 failed** — `safebreach_mcp_data` 573, config/utilities/playbook/core 493. E2E deselected (needs live consoles).

## Reviewer note — please read

This restores the exact pre-1.10.0 code path, so `paused` is accepted, forwarded as `&status=PAUSED`, and matched client-side. **What is unverified is whether the `testsummaries` *list* API actually reports `paused` there.**

Pause state is authoritative in the orchestrator (`slotState[].isPaused`) — which is precisely why `get_test_details` and `manage_test` consult `GET /api/orch/v4/.../queue` as phase 1. And SAF-33511 established that the list API "has no functional QUEUED status", so `PAUSED` may be non-functional there for the same reason. There is no paused-test fixture anywhere in the repo, so this path has never been exercised.

Evidence the other way: the SAF-31111 investigation documented `testsummaries` `status` as returning `RUNNING`/`PAUSED`/`CANCELED`/`COMPLETED`, and `manage_test`'s state machine depends on that fallback.

Verifying needs a live console with a genuinely paused test. **If the customer reports the call now succeeds but returns an empty list, the remaining fix is an orchestrator overlay (mark tests in paused slots as `status='paused'`), not this allowlist.** Suggest asking them to re-test on the customer env while a test is actually paused.

## Notes

Triaged and fixed directly as a one-line validation regression; SAF-34457 and the PRD (`prds/bugfix-SAF-34457-restore-paused-status-filter/prd.md`) were filed afterwards. The branch name predates the ticket, so the PRD folder is named by the key instead — renaming the branch would have closed this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
