### PR TITLE
fix(config): make step_count null-safe in scenario/plan mappers (SAF-34228)

### DIFF
--- a/prds/bugfix-SAF-34228-get-scenarios-null-steps/context.md
+++ b/prds/bugfix-SAF-34228-get-scenarios-null-steps/context.md
@@ -1,0 +1,293 @@
+# Ticket Context: SAF-34228
+
+## Status
+Phase 3: Context Initialized
+
+## Mode
+Improving
+
+## Original Ticket
+
+- **Key**: SAF-34228 — https://safebreach.atlassian.net/browse/SAF-34228
+- **Summary**: `test_mcp_operation[list_simulations]: get_scenarios crashes with NoneType len() on null steps field`
+- **Type**: Bug | **Priority**: Medium | **Status**: To Do
+- **Reporter**: Boris Ifraimov | **Assignee**: Noam Sagiv
+- **Labels**: CTEM-dev, automation, prod, test-failure
+- **Created**: 2026-07-29 | **Updated**: 2026-08-03
+- **Origin**: filed automatically via `/investigate-test-failure` from a post-merge CI failure
+
+### Description (as filed)
+
+Failing test `tests/ui/sanity/sb_mcp/test_mcp_sanity.py::test_mcp_operation[list_simulations]` in the
+scheduled `Automation-staging-sanity` pipeline against `staging.sbops.com`. The MCP `get_scenarios`
+tool (config server) fails server-side with:
+
+```
+Failed to get scenarios: object of type 'NoneType' has no len()
+```
+
+Traced to `safebreach_mcp_config/config_types.py` (pinned at tag `1.8.0` via `mcp-proxy`'s
+`requirements.txt`):
+
+```python
+"step_count": len(scenario.get("steps", [])),   # get_reduced_scenario_mapping
+"step_count": len(plan.get("steps", [])),       # get_reduced_plan_mapping
+```
+
+`dict.get(key, default)` returns `default` only when the key is **missing** — not when the key is
+present with value `null`. A record with `"steps": null` yields `None`, and `len(None)` raises
+`TypeError`. `sb_get_scenarios` wraps this in a broad `except Exception`, producing the
+`"Failed to get scenarios: ..."` error payload that the sanity test flags as a broken response shape.
+
+Not a code regression — `git blame` traces the pattern to `b7ce727` (SAF-29966, 2026-04-16), with zero
+commits to `config_types.py`/`config_functions.py` between tags `1.7.0` and `1.8.0`. No commits landed in
+automation, craft, mcp-proxy, configuration, or safebreach-mcp between last-good build #1861
+(2026-07-28 20:33 UTC) and first-bad #1862 (2026-07-29 07:32 UTC). Reproduced across builds #1862 and
+#1863 — deterministic, not flaky.
+
+Ticket's suggested fix: replace `scenario.get("steps", [])` / `plan.get("steps", [])` with
+`scenario.get("steps") or []` / `plan.get("steps") or []` in both mapping functions (matching the
+existing safe pattern already used for `tags`), and audit the staging `default` console for the
+offending record.
+
+CI reference: https://butler.sbops.com/job/Automation-staging-sanity/1863/
+
+### Comment (Sebastian Altheim, 2026-07-29) — the trigger identified
+
+Of 475 scenarios on the console, exactly 2 have `"steps": null`:
+
+| Scenario | id | createdBy | createdAt (UTC) | updatedAt (UTC) |
+|---|---|---|---|---|
+| Adversary Reconnaissance | 278b6968-676e-4940-bbd2-59c933437238 | SafeBreach | 2026-07-29 06:45:57 | 07:19:06 |
+| Adversary Propagation | aa0ab29d-7bb3-4b9b-8c79-b43bd9c6060c | SafeBreach | 2026-07-29 06:53:52 | 07:18:50 |
+
+Timeline fits exactly:
+
+```
+2026-07-28 20:33  build #1861  PASS  (last good)
+2026-07-29 06:45  <- Adversary Reconnaissance created
+2026-07-29 06:53  <- Adversary Propagation created
+2026-07-29 07:32  build #1862  FAIL  (first bad)
+```
+
+Both are the two newest records in the entire collection by nearly a week (next newest 2026-07-23).
+Nothing else in the window. Assigned to Noam Sagiv to decide whether stepless scenarios are expected
+or whether these two records should have steps.
+
+## Task Scope
+
+Two questions are entangled in this ticket and must be separated:
+
+1. **Data question (NOT this ticket's work, assigned to Noam Sagiv)** — is `steps: null` a legal
+   scenario shape? If a stepless scenario is valid, `step_count: 0` is a correct projection and the
+   data is fine. If invalid, content-manager should reject it at write time.
+2. **MCP resilience (this ticket's work, our repo)** — regardless of the answer above, the MCP must
+   not turn one malformed upstream record into a total failure of the whole tool. This is the scope
+   being prepared here.
+
+Scope (final — deliberately narrowed to the reported bug; see note below):
+
+1. Make `step_count` null-safe in the two mapping functions the ticket names
+   (`config_types.py:197`, `:230`).
+2. Make `sb_get_scenarios` survive a record it cannot map: skip it, return the rest, and surface the
+   skipped count via a top-level field + `hint_to_agent`.
+
+Explicitly out of scope:
+
+- The upstream content-manager write path, and auditing/repairing the staging data records (on the
+  ticket for Noam Sagiv).
+- Every other finding in the Phase 4 audit below. The audit was run repo-wide and turned up ~40
+  null-unsafe expressions and 11 structurally identical mapping sites, including two that are
+  arguably more severe than this bug (`get_minimal_simulator_mapping`, and `run_scenario`'s evaluate
+  path breaking on these same two records). **None of that is this ticket.** It is retained below as
+  reference material to seed separate tickets, not as work items here.
+
+**Note on the Phase 4 section**: it is broader than the scope above by design — it was an exploratory
+audit, and it over-reached for a single bug ticket. Read it as background, not as a task list. The
+only findings this ticket acts on are items 1-2 above.
+
+## Repositories Under Investigation
+
+- `/Users/sebastian.altheim/safebreach-mcp` (this repo — `SafeBreach/safebreach-mcp`, GitHub)
+
+Branch: `bugfix/SAF-34228-get-scenarios-null-steps` (off `main`; this repo has no `develop`)
+
+## Investigation Findings
+
+### Pre-investigation (verified directly on `main`, before Phase 4 fan-out)
+
+The ticket's code citations are against tag `1.8.0`; all were re-verified against current `main`.
+
+1. **Both cited sites still present**: `config_types.py:197` (`get_reduced_scenario_mapping`) and
+   `config_types.py:230` (`get_reduced_plan_mapping`).
+
+2. **`len()` is the only crash point for this record shape.** The two other helpers that consume
+   `steps` already tolerate `None`:
+   - `compute_is_ready_to_run` (`config_types.py:129-131`) — `steps = scenario.get('steps', [])`
+     followed by `if not steps: return False`
+   - `_compute_total_attack_count` (`config_types.py:149-157`) — `if not steps: return 0`
+
+   So the ticket's suggested fix does resolve this specific crash. It also means the safe pattern is
+   **already this codebase's own convention** (also `queue_state.py:103`, `entry.get('steps') or []`,
+   and the `tags` handling the ticket mentions). `len(x.get(k, []))` is the outlier, not the norm.
+
+3. **The ticket misses two further instances of the identical pattern:**
+   - `safebreach_mcp_studio/studio_functions.py:2964` — `len(scenario.get('steps', []))` in
+     `run_scenario`'s evaluate path. Worse, `:2940` passes `scenario['steps']` directly into
+     `_get_scenario_statistics()`, which has no null guard (`:2400-2425`). The same two staging
+     records are therefore likely broken for **evaluate/run**, not just listing — a larger blast
+     radius than the reported symptom, and outside the ticket's stated fix.
+   - `safebreach_mcp_studio/studio_types.py:336` — `len(execution.get('simulationEvents', []))`,
+     same shape, awaiting the same trigger.
+
+4. **The all-or-nothing failure mode is the deeper defect.** `sb_get_scenarios`
+   (`config_functions.py:620-632`) maps all 475 records inside a single `try`, under a broad
+   `except Exception` (`:673-678`) that collapses any per-record mapping error into a whole-tool
+   failure returning `{"error": ..., "console": ...}`. Consequences:
+   - One malformed record out of 475 blacks out the entire scenario catalog for the console; the 473
+     healthy records are discarded.
+   - The agent receives a string in an `error` key, so it cannot route around the problem or report
+     "473 scenarios, 2 unreadable" — it only sees the tool as down.
+   - The failure does not present as an exception, unlike the rest of the repo's tools, which is
+     precisely why CI caught it as a *response-shape* assertion rather than an error.
+   - It will recur with the next unanticipated upstream shape. Patching `len()` sites per incident is
+     a treadmill.
+   - The same error-dict pattern exists at `config_functions.py:132` (`get_console_simulators`).
+
+### Phase 4 (parallel repo audit)
+
+Two parallel Explore audits: (A) null-unsafe projection patterns repo-wide, (B) error-handling
+contract + resilience precedent + structural blast radius. High-impact claims were re-verified by hand
+against `main` (noted below); the rest are agent-reported and marked as needing confirmation before
+any code change relies on them.
+
+#### A. There is no central fix point — `map_reduced_entity` propagates nulls
+
+**VERIFIED** (`config_types.py:34`, and the twin at `data_types.py:61`):
+
+```python
+return {new_key: entity[old_key] for new_key, old_key in mapping.items() if old_key in entity}
+```
+
+The `if old_key in entity` guard makes it **KeyError-safe but null-propagating**: a present-but-`null`
+upstream value is copied through verbatim, relocating the defect one hop downstream to whatever next
+calls `.get(new_key, default)` on the reduced dict. This is the confirmed bug's shape, indirected
+through a rename.
+
+One counter-example exists: `data_types.py:422` `map_security_control_event` **does** drop nulls
+(`if value is not None`). It is a one-off used only for security-control events. So the codebase
+already contains the null-safe mapping idea but has not generalized it.
+
+**Implication**: every call site must be patched individually, OR `map_reduced_entity` gains a
+null-drop to match `map_security_control_event`. The latter is a contract change (turns "key present
+with null" into "key absent") and needs its own decision — not a free win.
+
+#### B. Highest-severity finding is NOT in this ticket: `get_minimal_simulator_mapping`
+
+**VERIFIED** (`config_types.py:37-85`). Worse than the reported bug:
+
+- **`:41`** — `map_reduced_entity(simulator_entity['nodeInfo']['MACHINE_INFO']['OS'], ...)`: a triple
+  unguarded subscript. Any simulator missing `nodeInfo`, or with `nodeInfo`/`MACHINE_INFO`/`OS`
+  explicitly `null` (a disconnected or newly-registered agent that has not reported system info),
+  crashes the **entire** `get_console_simulators` listing for that console.
+- **`:69-77`** — nine consecutive unguarded direct subscripts (`labels`, `isEnabled`, `id`, `name`,
+  `isConnected`, `isCritical`, `externalIp`, `internalIp`, `version`). Zero `.get()` calls. Any record
+  missing any one field raises `KeyError` and takes down the whole listing.
+- `get_full_simulator_mapping:96-100` guards only `INSTALLED_SOFTWARE`, and only for `KeyError` — a
+  `null` intermediate raises `TypeError`, which that handler does not catch. It also calls the
+  unguarded minimal mapping first (`:93`), so the guard is moot.
+
+This is the same bug class as SAF-34228, in the same server, on the most frequently listed entity in
+the product — and it is one malformed simulator record away from an identical incident.
+
+#### C. Additional null-unsafe sites (agent-reported, high-confidence, spot-checked)
+
+Same tool as the ticket (`get_scenarios` / `get_scenario_details`):
+
+- `config_types.py:182-184` — `for cat_id in scenario.get('categories', [])`: null `categories`
+  raises `TypeError`. Same function, same listing, missed by the ticket.
+- `config_types.py:196` — `"name": scenario.get("name")` (no default) feeds
+  `filter_scenarios_by_criteria:254` and `apply_scenario_ordering:298,305`, all doing
+  `s.get('name', '').lower()` → `AttributeError` on a null name. **`order_by='name'` is the default**,
+  so this is on the default path.
+- `config_types.py:503-511` + `_simplify_step:381-383` — the detail-view sibling of the list-view bug,
+  reachable from `get_scenario_details`.
+- `config_functions.py:183` — `logger.info(..., simulator['name'])` on a **raw** record, before mapping.
+
+Elsewhere (proves the pattern is a repo-wide inconsistency, not a one-off):
+
+- `data_types.py:194` — `"ALM" in test_summary_entity.get('systemTags', [])` → `TypeError` on null.
+  **VERIFIED**, and its sibling `get_reduced_queued_test_mapping:162` does it correctly
+  (`pending_entry.get('systemTags') or []`) — right pattern, same file, missed here.
+- `data_functions.py:405,410` and `_apply_ordering:447` — `t.get('status','').lower()` /
+  `t.get('name','').lower()` unguarded, while `:241` in the *same file* is guarded as
+  `(t.get('status','') or '').lower()`. **VERIFIED.**
+- `data_functions.py:1304-1343` — six unguarded chained `.get('fields', {}).get(...)` on **raw** SIEM
+  events in `_apply_security_control_events_filters`.
+- `data_types.py:893-920`, `1047-1051`, `1120` — unguarded `record.get("from"/"to", {})` chains on raw
+  drift records; direct sibling of the confirmed bug.
+- `studio_types.py:340` — `_parse_simulation_steps(execution.get('simulationEvents', []))`: a
+  **second** crash point on the same field as `:336`. Patching only the `len()` at `:336` leaves this.
+- `studio_functions.py:1993` — `_apply_step_overrides` does `len(steps)` with no `if not steps` guard,
+  unlike its siblings `compute_scenario_readiness`/`diagnose_scenario_readiness`.
+
+#### D. Error contract: the error-dict style is the exception, not the rule
+
+Agent-inventoried across 34 public `sb_*` functions:
+
+| Style | Count | Where |
+|---|---|---|
+| (a) returns `{"error": ...}` | **2** | `config_functions.py:129-134` (`get_console_simulators`), `:673-678` (`get_scenarios`) |
+| (b) raises / propagates | **29** | all of data, playbook, studio, plus `config_functions.py:331` |
+| (c) inline narrow "not-found" dicts *inside* the try | 3 | deliberate expected-condition returns; those functions still re-raise unexpected errors |
+
+Plus a fourth flavor at the **server** layer, **VERIFIED**: `playbook_server.py` (`:167-169`, `:286-288`,
+`:348-350`) and `studio_server.py` (12 sites) wrap every tool in `except Exception: return f"Error ..."`,
+returning a formatted **string** — swallowing even deliberate `ValueError`s from the function layer.
+`config_server.py`/`data_server.py` are thin pass-throughs that let exceptions propagate to FastMCP.
+
+`ToolError` precedent exists (`rate_limiter.py:90,106`; `safebreach_base.py:204`) but is scoped to
+rate limiting, not data/mapping errors.
+
+**Constraint for the fix**: two existing tests lock the error-dict contract in —
+`test_config_functions.py:284` (`test_sb_get_console_simulators_error`) and `:658`
+(`test_api_failure_returns_error_dict`) assert `"error" in result`. A fix must either deliberately
+change that contract (updating these tests) or keep the error dict for the *fully unusable* case while
+adding new fields for the *partially usable* case.
+
+#### E. In-repo precedent to copy for graceful degradation (do not invent a new pattern)
+
+The repo already has a consistent convention for incomplete data: **never silently drop; count what
+was excluded; surface the count in a top-level field; add a `hint_to_agent` naming the number.**
+
+Best structural match — `_bulk_result_summary` (`playbook_functions.py:580-617`): returns
+`succeeded` / `failed_count` / `failures[]` plus a quantifying `hint_to_agent`.
+
+Also: `sb_get_test_drifts` (`data_functions.py:2055-2147`) — `continue` on an excluded record plus
+`hidden_no_result_drift_count` and a loud `WARNING:` hint; `get_simulation_logs_mapping`
+(`data_types.py:707-767`) — `total_capped` flag + hint; best-effort enrichment isolated behind a
+sentinel-returning helper (`user_lookup.py:31-86` → `{}`/`None`; `config_functions.py:440-442`,
+`:487-489`; `data_functions.py:714-716` → `0`).
+
+#### F. Structural blast radius: 11 sites share the all-or-nothing shape
+
+Mapping an entire upstream list via one comprehension/loop, with no per-record isolation:
+
+| # | Site | Feeds |
+|---|---|---|
+| 1-2 | `config_functions.py:625-627`, `:632` | `get_scenarios` — **the reported bug** |
+| 3 | `config_functions.py:182-184` | `get_console_simulators` |
+| 4 | `data_functions.py:334-336` | `get_tests` |
+| 5-6 | `data_functions.py:803`, `1038-1040` | `get_simulations` |
+| 7 | `data_functions.py:1411-1413` | `get_security_controls_events` |
+| 8 | `data_functions.py:3579-3581` | `get_simulation_lineage` — **no try at all**, raises uncaught |
+| 9-10 | `playbook_functions.py:165-168`, `324-327` | `get_playbook_attacks`, `..._by_tags` |
+| 11 | `studio_functions.py:1516-1518` | `get_studio_attack_latest_result` |
+
+Only sites 1-3 currently degrade to an error dict; the other 8 surface as raw propagated exceptions.
+
+## Problem Analysis
+(Phase 5)
+
+## Proposed Improvements
+(Phase 6)

--- a/prds/bugfix-SAF-34228-get-scenarios-null-steps/prd.md
+++ b/prds/bugfix-SAF-34228-get-scenarios-null-steps/prd.md
@@ -1,4 +1,4 @@
-# PRD: SAF-34228 — `get_scenarios` null `steps` crash and per-record resilience
+# PRD: SAF-34228 — `get_scenarios` crashes on a scenario with `steps: null`
 
 - **Ticket**: [SAF-34228](https://safebreach.atlassian.net/browse/SAF-34228) (Bug, Medium)
 - **Branch**: `bugfix/SAF-34228-get-scenarios-null-steps` (off `main` — this repo has no `develop`)
@@ -9,232 +9,126 @@
 
 ## 1. Problem
 
-`dict.get(key, default)` returns `default` only when the key is **absent**; a key present with value
-`null` returns `None`. Both scenario/plan mappers compute:
+`dict.get(key, default)` returns `default` only when the key is **absent**. A key present with value
+`null` returns `None`. Both scenario/plan mappers computed:
 
 ```python
 "step_count": len(scenario.get("steps", [])),   # config_types.py:197
 "step_count": len(plan.get("steps", [])),       # config_types.py:230
 ```
 
-so a record with `"steps": null` raises `TypeError: object of type 'NoneType' has no len()`.
-
-`sb_get_scenarios` maps every record inside one `try` (`config_functions.py:620-632`) under a broad
-`except Exception` (`:673-678`), so that single record's failure becomes a whole-tool failure:
+so a record with `"steps": null` raised `TypeError: object of type 'NoneType' has no len()`. Because
+`sb_get_scenarios` maps every record inside one `try` under a broad `except Exception`, that single
+record's failure surfaced as a whole-tool failure:
 
 ```json
 {"error": "Failed to get scenarios: object of type 'NoneType' has no len()", "console": "default"}
 ```
 
-2 of 475 records on `staging.sbops.com` trip this, and the other 473 plus all custom plans are
-discarded. Deterministic since CI build #1862.
-
-Two defects, both in scope:
-
-| # | Defect | Fix |
-|---|--------|-----|
-| A | `len()` on a null-valued key | null-safe extraction at the two sites |
-| B | One unmappable record fails the whole listing | per-record isolation + surfaced skip count |
-
-B is the one that matters long-term: A is a single record shape, B is the reason any future
-unanticipated upstream shape reproduces the same total outage.
+2 of 475 records on `staging.sbops.com` (created 2026-07-29) trip this, breaking the
+`Automation-staging-sanity` pipeline deterministically from build #1862.
 
 ## 2. Scope
 
-**In scope** — exactly two changes plus their tests:
+**In scope**: make `step_count` null-safe in the two mapping functions the ticket names, so a stepless
+scenario is projected as a scenario with zero steps.
 
-1. `config_types.py` — null-safe `step_count` in `get_reduced_scenario_mapping` and
-   `get_reduced_plan_mapping`.
-2. `config_functions.py` — per-record isolation in `sb_get_scenarios`, with the skipped count surfaced
-   in the response and `hint_to_agent`.
+**Out of scope**:
 
-**Out of scope** (deliberate — see `context.md` "Out of Scope"): the upstream content-manager write
-path; auditing/repairing the staging records (Noam Sagiv, on the ticket); and every other finding from
-the investigation audit, including `get_minimal_simulator_mapping` and `run_scenario`'s evaluate path.
-Those get their own tickets.
+- The upstream content-manager write path, and auditing/repairing the staging records (with Noam Sagiv
+  on the ticket).
+- Any change to `sb_get_scenarios`, its error handling, or its response shape.
+- Every other finding from the investigation audit recorded in `context.md`.
 
 ## 3. Solution
 
-### 3.1 Null-safe `step_count` (defect A)
-
-`config_types.py:197` and `:230`:
+`config_types.py:197-200` (`get_reduced_scenario_mapping`) and `:232-234` (`get_reduced_plan_mapping`):
 
 ```python
 # before
 "step_count": len(scenario.get("steps", [])),
+"total_attack_count": _compute_total_attack_count(scenario.get("steps", [])),
 # after
 "step_count": len(scenario.get("steps") or []),
+"total_attack_count": _compute_total_attack_count(scenario.get("steps") or []),
 ```
 
-This is the ticket's suggested fix and matches the repo's existing idiom (`queue_state.py:103`, the
-`tags` handling, and `compute_is_ready_to_run` / `_compute_total_attack_count`, which already guard
-with `if not steps`). No other line in either mapper needs changing for this record shape — verified:
-`_compute_total_attack_count(None)` returns `0` and `compute_is_ready_to_run` returns `False`.
+This is the fix suggested on the ticket, and it matches the repo's existing idiom — `queue_state.py:103`
+(`entry.get('steps') or []`), the adjacent `tags` handling, and `compute_is_ready_to_run` /
+`_compute_total_attack_count`, which both already guard with `if not steps`.
 
-`step_count: 0` is the correct projection of a stepless record regardless of how the data question is
-answered upstream.
+`total_attack_count` is guarded on the same lines even though `_compute_total_attack_count(None)`
+already returns `0` safely. Not a bug fix — it stops the two adjacent expressions from disagreeing
+about whether `steps` can be null, which is how this defect class survives review.
 
-### 3.2 Per-record isolation (defect B)
+### 3.1 What this produces
 
-Replace the two bulk comprehensions with a helper that isolates each record:
+A `steps: null` record maps successfully and is **returned in the listing** as
+`step_count: 0`, `total_attack_count: 0`, `is_ready_to_run: False`. It is not skipped, not flagged, and
+not treated as an error. Verified against the two real staging records:
 
-```python
-def _map_records_resiliently(records, mapper, kind):
-    """Map upstream records one at a time. A record that cannot be mapped is skipped rather than
-    failing the whole listing (SAF-34228) — upstream shapes are not under our control."""
-    mapped, skipped = [], []
-    for record in records:
-        try:
-            mapped.append(mapper(record))
-        except Exception as e:  # noqa: BLE001 - upstream shape is untrusted; never fail the listing
-            record_id = record.get('id') if isinstance(record, dict) else None
-            record_name = record.get('name') if isinstance(record, dict) else None
-            logger.warning("Skipping unmappable %s record id=%s: %s", kind, record_id, e)
-            skipped.append({"id": record_id, "name": record_name, "reason": f"{type(e).__name__}: {e}"})
-    return mapped, skipped
+```
+total_scenarios: 3
+  A Normal Scenario          step_count=1  attacks=2  ready=True
+  Adversary Propagation      step_count=0  attacks=0  ready=False
+  Adversary Reconnaissance   step_count=0  attacks=0  ready=False
 ```
 
-Used at both call sites in `sb_get_scenarios`, accumulating one combined skip list across OOB
-scenarios and custom plans.
+This is deliberately agnostic on the open data question: `step_count: 0` is the correct projection of a
+stepless record whether or not stepless scenarios turn out to be intended. Nothing here needs revisiting
+when that question is answered.
 
-Note this makes 3.1 belt-and-braces rather than redundant: 3.1 keeps a stepless record **usable**
-(it lists correctly with `step_count: 0`), while 3.2 ensures *any* unmappable record — including
-shapes not yet seen — costs one row instead of the whole catalog.
+### 3.2 No contract change
 
-### 3.3 Response contract
+Response shape, error handling and tool description are untouched. The only observable difference is
+that a call which previously returned an error payload now returns the listing. Consequently no
+documentation change is required — nothing in `CLAUDE.md`, `README.md` or the `get_scenarios` tool
+description describes behavior that has changed.
 
-Additive only. `sb_get_scenarios` post-processes the `paginate_scenarios` result the same way it
-already attaches `applied_filters`:
+## 4. Testing
 
-```python
-paginated['applied_filters'] = applied_filters
-if skipped:
-    paginated['skipped_records_count'] = len(skipped)
-    paginated['skipped_records'] = skipped[:SKIPPED_SAMPLE_LIMIT]   # cap the sample
-    # prepend so the degradation is the first thing the agent reads
-    paginated['hint_to_agent'] = ' | '.join(filter(None, [skip_hint, paginated.get('hint_to_agent')]))
-```
-
-Where `skip_hint` names the count explicitly, e.g.:
-
-> `WARNING: 2 scenario/plan record(s) could not be read and were SKIPPED (malformed upstream data);
-> 473 returned. The listing is incomplete — disclose this to the user. See skipped_records for ids.`
-
-Fields are absent entirely when nothing was skipped, so existing callers and tests are unaffected.
-
-This copies the repo's established never-silently-truncate convention: counted, surfaced top-level,
-and named in `hint_to_agent` — as done by `_bulk_result_summary`
-(`playbook_functions.py:580-617`), `hidden_no_result_drift_count` (`data_functions.py:2055-2147`),
-and `total_capped` (`data_types.py:707-767`).
-
-### 3.4 Total-failure case
-
-If every record fails to map (`mapped == []` and `skipped` non-empty), do **not** report a successful
-empty listing — that reads as "this console has no scenarios". Return the existing error-dict shape
-with the aggregate reason plus the skip metadata, preserving today's contract for unusable results:
-
-```python
-{"error": f"Failed to get scenarios: all {len(skipped)} record(s) were unmappable",
- "console": console, "skipped_records_count": len(skipped), "skipped_records": skipped[:LIMIT]}
-```
-
-The broad `except Exception` at `:673-678` stays exactly as-is for genuine global failures (auth,
-network, RBAC) — unchanged contract, and the two tests asserting it keep passing.
-
-### 3.5 Flow
-
-```mermaid
-flowchart TD
-    A[sb_get_scenarios] --> B[fetch OOB scenarios + custom plans]
-    B --> C{map each record<br/>individually}
-    C -->|ok| D[mapped records]
-    C -->|raises| E[skip + log + record id/name/reason]
-    D --> F{any mapped?}
-    E --> F
-    F -->|no, and skips exist| G[error dict + skip metadata<br/>§3.4]
-    F -->|yes| H[filter / order / paginate]
-    H --> I{any skips?}
-    I -->|no| J[response unchanged]
-    I -->|yes| K[+ skipped_records_count<br/>+ skipped_records<br/>+ prepended WARNING hint]
-```
-
-## 4. Testing strategy
-
-New unit tests (`safebreach_mcp_config/tests/`):
+Four unit tests in `safebreach_mcp_config/tests/test_config_types.py`:
 
 | # | Test | Asserts |
 |---|------|---------|
-| T-1 | `get_reduced_scenario_mapping` with `"steps": null` | `step_count == 0`, no raise |
-| T-2 | `get_reduced_plan_mapping` with `"steps": null` | `step_count == 0`, no raise |
-| T-3 | `steps` key entirely absent (both mappers) | `step_count == 0` — no regression on the old path |
-| T-4 | **Regression, exact ticket payload**: `sb_get_scenarios` over a 3-record set where 1 has `"steps": null` | returns the 2 healthy records; no `error` key. Fails before fix, passes after |
-| T-5 | Unmappable record that 3.1 does *not* cover (e.g. `categories: null`, still raising in the mapper) | still degrades: healthy records returned, 1 skipped — proves B is independent of A |
-| T-6 | Skip metadata | `skipped_records_count == 1`; `skipped_records[0]` carries id/name/reason |
-| T-7 | `hint_to_agent` on partial result | contains the count and the word `SKIPPED`; existing hints preserved after it |
-| T-8 | Clean listing | `skipped_records_count` / `skipped_records` keys ABSENT; response byte-identical to today |
-| T-9 | All records unmappable | error dict per §3.4, not an empty success |
-| T-10 | Skip sample cap | with >`SKIPPED_SAMPLE_LIMIT` bad records, `skipped_records` is capped while `skipped_records_count` reports the true total |
-| T-11 | Global API failure unchanged | existing `test_api_failure_returns_error_dict` / `test_sb_get_console_simulators_error` still pass |
-| T-12 | Cached path | a malformed record cached from a prior call degrades identically on a cache hit |
+| T-1 | `get_reduced_scenario_mapping` with `"steps": None` | `step_count == 0`, `total_attack_count == 0`, `is_ready_to_run is False`; no raise. Fixture uses the real incident record id `278b6968-676e-4940-bbd2-59c933437238` ("Adversary Reconnaissance") |
+| T-2 | `get_reduced_plan_mapping` with `"steps": None` | same, on the custom-plan mapper |
+| T-3a | `get_reduced_scenario_mapping` with the `steps` key absent | `step_count == 0` — guards the pre-existing missing-key path |
+| T-3b | `get_reduced_plan_mapping` with the `steps` key absent | same |
 
-Regression gate: full suite (`config` + `data` + `utilities` + `playbook` + `core`, `-m "not e2e"`)
-must stay green — 1066 tests as of this branch point.
+Both null tests were confirmed failing before the fix with the exact reported error
+(`TypeError: object of type 'NoneType' has no len()`).
 
-Manual/E2E verification: not reproducible locally (needs a console holding a `steps: null` record).
-T-4 encodes the exact reported payload instead. Post-merge, confirm
-`Automation-staging-sanity` goes green.
+**Regression gate**: full non-e2e suite green — 1548 tests.
 
-## 5. Phased implementation
+**Not locally reproducible end-to-end**: needs a console holding a `steps: null` record, so T-1/T-2
+encode the reported payload instead. Post-merge, confirm `Automation-staging-sanity` goes green.
 
-### Phase 1 — null-safe `step_count` (defect A)
+## 5. Implementation
 
-1. T-1..T-3 written first, failing.
-2. Apply the two `or []` edits.
-3. **Gate**: T-1..T-3 green; full config suite green.
+Single phase, complete:
 
-### Phase 2 — per-record isolation (defect B)
+1. T-1, T-2, T-3a, T-3b written first and confirmed failing with the reported `TypeError`.
+2. The two `or []` edits applied.
+3. **Gate**: new tests green; full config suite green (91); full non-e2e suite green (1548).
 
-1. T-4..T-12 written first, failing.
-2. Add `_map_records_resiliently`, wire both call sites, add response fields + hint, add the
-   all-failed branch.
-3. **Gate**: T-4..T-12 green; full suite green (1066+); no change to any existing assertion.
+Committed as `0749a2a`.
 
-### Phase 3 — docs
+## 6. Definition of done
 
-1. `CLAUDE.md` + `README.md`: document `skipped_records_count` / `skipped_records` on `get_scenarios`.
-2. `get_scenarios` MCP tool description in `config_server.py`: one line that the listing may be partial
-   and the agent must disclose it — the tool description is what the agent actually reads.
-3. **Gate**: user sign-off, then PR.
-
-Each phase is committed separately after sign-off, per the AI-First flow.
-
-## 6. Risks and edge cases
-
-| Risk | Mitigation |
-|------|-----------|
-| A broad per-record `except` masks real bugs in our own mapper | Every skip is `logger.warning`-ed with id + exception type, and surfaced in the response. Loud, not silent. |
-| Log flood if many records are bad | One warning per skipped record is bounded by the fetch size; the aggregate count carries the signal. Revisit only if a console shows mass failure. |
-| Unbounded `skipped_records` payload | Capped by `SKIPPED_SAMPLE_LIMIT`; the true total stays in `skipped_records_count`. |
-| Agent silently reports a partial catalog as complete | `hint_to_agent` is prepended (read first) and worded as a `WARNING` with an explicit instruction to disclose. |
-| Malformed record persists in cache | Caches hold raw payloads, so behavior is identical on hit and miss — covered by T-12. |
-| Contract drift for existing callers | New keys are omitted when nothing is skipped (T-8); global-failure path untouched (T-11). |
-
-## 7. Definition of done
-
-- [ ] `step_count` is `0` for `steps: null` in both mappers; no raise
-- [ ] `get_scenarios` returns healthy records when some records are unmappable
-- [ ] `skipped_records_count` + `skipped_records` present only on partial results
-- [ ] `hint_to_agent` names the skipped count and instructs disclosure
-- [ ] All-unmappable case returns an explicit error, not an empty success
-- [ ] Existing `{"error": ...}` global-failure contract and its tests unchanged
-- [ ] T-1..T-12 green; full non-e2e suite green
-- [ ] `CLAUDE.md`, `README.md`, and the `get_scenarios` tool description updated
+- [x] `step_count` is `0` for `steps: null` in both mappers; no raise
+- [x] A stepless scenario is returned in the listing, not skipped or flagged
+- [x] Missing-`steps`-key path unchanged
+- [x] No response-shape, error-handling or tool-description change
+- [x] T-1/T-2 fail before the fix with the exact reported error, pass after
+- [x] Full non-e2e suite green (1548)
+- [ ] `Automation-staging-sanity` green post-merge
 - [ ] Follow-up tickets filed for the out-of-scope audit findings
 
-## 8. Decision log
+## 7. Decision log
 
 | Date | Decision |
 |------|----------|
-| 2026-08-04 | Scope held to the ticket: defects A + B on `get_scenarios` only. An investigation audit surfaced ~40 further null-unsafe expressions and 11 identical structural sites; these were explicitly excluded rather than folded in, and are recorded in `context.md` for separate tickets. |
-| 2026-08-04 | Error contract: keep the existing error dict for globally-unusable results; add additive fields for partial results. Rejected migrating these 2 outlier functions to `raise`/`ToolError` — real cleanup, but not this bug's job and it would churn two passing contract tests. |
-| 2026-08-04 | Data question (`steps: null` legal?) left with Noam Sagiv and explicitly decoupled: this fix is correct under either answer and must not wait on it. |
+| 2026-08-04 | Scope held to the ticket. An investigation audit surfaced ~40 further null-unsafe expressions and 11 structurally identical mapping sites; excluded rather than folded in, and recorded in `context.md` to seed separate tickets. |
+| 2026-08-04 | **Per-record mapping resilience considered, implemented, and reverted.** A `_map_records_resiliently` helper in `sb_get_scenarios` (skip an unmappable record, return the rest, surface `skipped_records_count` + a warning hint) was built and passing (9 tests) before being dropped. Reasons: (a) it is not needed for this bug — after §3 the stepless records map cleanly and are listed, so the reported crash and the CI failure are fixed without it; (b) it rests on the premise that a stepless scenario is malformed, which is exactly the open question, and "skip the record" is the wrong default if the shape turns out to be legal; (c) it modified a generic flow serving every scenario/plan listing, so its own risk of introducing a regression exceeded the hypothetical failure it guarded against. The structural concern is real but belongs in its own ticket with its own justification, not as a passenger on a two-line bugfix. |
+| 2026-08-04 | Data question (`steps: null` legal?) left with Noam Sagiv and explicitly decoupled: §3 is correct under either answer and does not wait on it. |

--- a/prds/bugfix-SAF-34228-get-scenarios-null-steps/prd.md
+++ b/prds/bugfix-SAF-34228-get-scenarios-null-steps/prd.md
@@ -1,0 +1,240 @@
+# PRD: SAF-34228 — `get_scenarios` null `steps` crash and per-record resilience
+
+- **Ticket**: [SAF-34228](https://safebreach.atlassian.net/browse/SAF-34228) (Bug, Medium)
+- **Branch**: `bugfix/SAF-34228-get-scenarios-null-steps` (off `main` — this repo has no `develop`)
+- **Repo**: `SafeBreach/safebreach-mcp`
+- **Context**: [context.md](./context.md) | **Ticket content**: [summary.md](./summary.md)
+
+---
+
+## 1. Problem
+
+`dict.get(key, default)` returns `default` only when the key is **absent**; a key present with value
+`null` returns `None`. Both scenario/plan mappers compute:
+
+```python
+"step_count": len(scenario.get("steps", [])),   # config_types.py:197
+"step_count": len(plan.get("steps", [])),       # config_types.py:230
+```
+
+so a record with `"steps": null` raises `TypeError: object of type 'NoneType' has no len()`.
+
+`sb_get_scenarios` maps every record inside one `try` (`config_functions.py:620-632`) under a broad
+`except Exception` (`:673-678`), so that single record's failure becomes a whole-tool failure:
+
+```json
+{"error": "Failed to get scenarios: object of type 'NoneType' has no len()", "console": "default"}
+```
+
+2 of 475 records on `staging.sbops.com` trip this, and the other 473 plus all custom plans are
+discarded. Deterministic since CI build #1862.
+
+Two defects, both in scope:
+
+| # | Defect | Fix |
+|---|--------|-----|
+| A | `len()` on a null-valued key | null-safe extraction at the two sites |
+| B | One unmappable record fails the whole listing | per-record isolation + surfaced skip count |
+
+B is the one that matters long-term: A is a single record shape, B is the reason any future
+unanticipated upstream shape reproduces the same total outage.
+
+## 2. Scope
+
+**In scope** — exactly two changes plus their tests:
+
+1. `config_types.py` — null-safe `step_count` in `get_reduced_scenario_mapping` and
+   `get_reduced_plan_mapping`.
+2. `config_functions.py` — per-record isolation in `sb_get_scenarios`, with the skipped count surfaced
+   in the response and `hint_to_agent`.
+
+**Out of scope** (deliberate — see `context.md` "Out of Scope"): the upstream content-manager write
+path; auditing/repairing the staging records (Noam Sagiv, on the ticket); and every other finding from
+the investigation audit, including `get_minimal_simulator_mapping` and `run_scenario`'s evaluate path.
+Those get their own tickets.
+
+## 3. Solution
+
+### 3.1 Null-safe `step_count` (defect A)
+
+`config_types.py:197` and `:230`:
+
+```python
+# before
+"step_count": len(scenario.get("steps", [])),
+# after
+"step_count": len(scenario.get("steps") or []),
+```
+
+This is the ticket's suggested fix and matches the repo's existing idiom (`queue_state.py:103`, the
+`tags` handling, and `compute_is_ready_to_run` / `_compute_total_attack_count`, which already guard
+with `if not steps`). No other line in either mapper needs changing for this record shape — verified:
+`_compute_total_attack_count(None)` returns `0` and `compute_is_ready_to_run` returns `False`.
+
+`step_count: 0` is the correct projection of a stepless record regardless of how the data question is
+answered upstream.
+
+### 3.2 Per-record isolation (defect B)
+
+Replace the two bulk comprehensions with a helper that isolates each record:
+
+```python
+def _map_records_resiliently(records, mapper, kind):
+    """Map upstream records one at a time. A record that cannot be mapped is skipped rather than
+    failing the whole listing (SAF-34228) — upstream shapes are not under our control."""
+    mapped, skipped = [], []
+    for record in records:
+        try:
+            mapped.append(mapper(record))
+        except Exception as e:  # noqa: BLE001 - upstream shape is untrusted; never fail the listing
+            record_id = record.get('id') if isinstance(record, dict) else None
+            record_name = record.get('name') if isinstance(record, dict) else None
+            logger.warning("Skipping unmappable %s record id=%s: %s", kind, record_id, e)
+            skipped.append({"id": record_id, "name": record_name, "reason": f"{type(e).__name__}: {e}"})
+    return mapped, skipped
+```
+
+Used at both call sites in `sb_get_scenarios`, accumulating one combined skip list across OOB
+scenarios and custom plans.
+
+Note this makes 3.1 belt-and-braces rather than redundant: 3.1 keeps a stepless record **usable**
+(it lists correctly with `step_count: 0`), while 3.2 ensures *any* unmappable record — including
+shapes not yet seen — costs one row instead of the whole catalog.
+
+### 3.3 Response contract
+
+Additive only. `sb_get_scenarios` post-processes the `paginate_scenarios` result the same way it
+already attaches `applied_filters`:
+
+```python
+paginated['applied_filters'] = applied_filters
+if skipped:
+    paginated['skipped_records_count'] = len(skipped)
+    paginated['skipped_records'] = skipped[:SKIPPED_SAMPLE_LIMIT]   # cap the sample
+    # prepend so the degradation is the first thing the agent reads
+    paginated['hint_to_agent'] = ' | '.join(filter(None, [skip_hint, paginated.get('hint_to_agent')]))
+```
+
+Where `skip_hint` names the count explicitly, e.g.:
+
+> `WARNING: 2 scenario/plan record(s) could not be read and were SKIPPED (malformed upstream data);
+> 473 returned. The listing is incomplete — disclose this to the user. See skipped_records for ids.`
+
+Fields are absent entirely when nothing was skipped, so existing callers and tests are unaffected.
+
+This copies the repo's established never-silently-truncate convention: counted, surfaced top-level,
+and named in `hint_to_agent` — as done by `_bulk_result_summary`
+(`playbook_functions.py:580-617`), `hidden_no_result_drift_count` (`data_functions.py:2055-2147`),
+and `total_capped` (`data_types.py:707-767`).
+
+### 3.4 Total-failure case
+
+If every record fails to map (`mapped == []` and `skipped` non-empty), do **not** report a successful
+empty listing — that reads as "this console has no scenarios". Return the existing error-dict shape
+with the aggregate reason plus the skip metadata, preserving today's contract for unusable results:
+
+```python
+{"error": f"Failed to get scenarios: all {len(skipped)} record(s) were unmappable",
+ "console": console, "skipped_records_count": len(skipped), "skipped_records": skipped[:LIMIT]}
+```
+
+The broad `except Exception` at `:673-678` stays exactly as-is for genuine global failures (auth,
+network, RBAC) — unchanged contract, and the two tests asserting it keep passing.
+
+### 3.5 Flow
+
+```mermaid
+flowchart TD
+    A[sb_get_scenarios] --> B[fetch OOB scenarios + custom plans]
+    B --> C{map each record<br/>individually}
+    C -->|ok| D[mapped records]
+    C -->|raises| E[skip + log + record id/name/reason]
+    D --> F{any mapped?}
+    E --> F
+    F -->|no, and skips exist| G[error dict + skip metadata<br/>§3.4]
+    F -->|yes| H[filter / order / paginate]
+    H --> I{any skips?}
+    I -->|no| J[response unchanged]
+    I -->|yes| K[+ skipped_records_count<br/>+ skipped_records<br/>+ prepended WARNING hint]
+```
+
+## 4. Testing strategy
+
+New unit tests (`safebreach_mcp_config/tests/`):
+
+| # | Test | Asserts |
+|---|------|---------|
+| T-1 | `get_reduced_scenario_mapping` with `"steps": null` | `step_count == 0`, no raise |
+| T-2 | `get_reduced_plan_mapping` with `"steps": null` | `step_count == 0`, no raise |
+| T-3 | `steps` key entirely absent (both mappers) | `step_count == 0` — no regression on the old path |
+| T-4 | **Regression, exact ticket payload**: `sb_get_scenarios` over a 3-record set where 1 has `"steps": null` | returns the 2 healthy records; no `error` key. Fails before fix, passes after |
+| T-5 | Unmappable record that 3.1 does *not* cover (e.g. `categories: null`, still raising in the mapper) | still degrades: healthy records returned, 1 skipped — proves B is independent of A |
+| T-6 | Skip metadata | `skipped_records_count == 1`; `skipped_records[0]` carries id/name/reason |
+| T-7 | `hint_to_agent` on partial result | contains the count and the word `SKIPPED`; existing hints preserved after it |
+| T-8 | Clean listing | `skipped_records_count` / `skipped_records` keys ABSENT; response byte-identical to today |
+| T-9 | All records unmappable | error dict per §3.4, not an empty success |
+| T-10 | Skip sample cap | with >`SKIPPED_SAMPLE_LIMIT` bad records, `skipped_records` is capped while `skipped_records_count` reports the true total |
+| T-11 | Global API failure unchanged | existing `test_api_failure_returns_error_dict` / `test_sb_get_console_simulators_error` still pass |
+| T-12 | Cached path | a malformed record cached from a prior call degrades identically on a cache hit |
+
+Regression gate: full suite (`config` + `data` + `utilities` + `playbook` + `core`, `-m "not e2e"`)
+must stay green — 1066 tests as of this branch point.
+
+Manual/E2E verification: not reproducible locally (needs a console holding a `steps: null` record).
+T-4 encodes the exact reported payload instead. Post-merge, confirm
+`Automation-staging-sanity` goes green.
+
+## 5. Phased implementation
+
+### Phase 1 — null-safe `step_count` (defect A)
+
+1. T-1..T-3 written first, failing.
+2. Apply the two `or []` edits.
+3. **Gate**: T-1..T-3 green; full config suite green.
+
+### Phase 2 — per-record isolation (defect B)
+
+1. T-4..T-12 written first, failing.
+2. Add `_map_records_resiliently`, wire both call sites, add response fields + hint, add the
+   all-failed branch.
+3. **Gate**: T-4..T-12 green; full suite green (1066+); no change to any existing assertion.
+
+### Phase 3 — docs
+
+1. `CLAUDE.md` + `README.md`: document `skipped_records_count` / `skipped_records` on `get_scenarios`.
+2. `get_scenarios` MCP tool description in `config_server.py`: one line that the listing may be partial
+   and the agent must disclose it — the tool description is what the agent actually reads.
+3. **Gate**: user sign-off, then PR.
+
+Each phase is committed separately after sign-off, per the AI-First flow.
+
+## 6. Risks and edge cases
+
+| Risk | Mitigation |
+|------|-----------|
+| A broad per-record `except` masks real bugs in our own mapper | Every skip is `logger.warning`-ed with id + exception type, and surfaced in the response. Loud, not silent. |
+| Log flood if many records are bad | One warning per skipped record is bounded by the fetch size; the aggregate count carries the signal. Revisit only if a console shows mass failure. |
+| Unbounded `skipped_records` payload | Capped by `SKIPPED_SAMPLE_LIMIT`; the true total stays in `skipped_records_count`. |
+| Agent silently reports a partial catalog as complete | `hint_to_agent` is prepended (read first) and worded as a `WARNING` with an explicit instruction to disclose. |
+| Malformed record persists in cache | Caches hold raw payloads, so behavior is identical on hit and miss — covered by T-12. |
+| Contract drift for existing callers | New keys are omitted when nothing is skipped (T-8); global-failure path untouched (T-11). |
+
+## 7. Definition of done
+
+- [ ] `step_count` is `0` for `steps: null` in both mappers; no raise
+- [ ] `get_scenarios` returns healthy records when some records are unmappable
+- [ ] `skipped_records_count` + `skipped_records` present only on partial results
+- [ ] `hint_to_agent` names the skipped count and instructs disclosure
+- [ ] All-unmappable case returns an explicit error, not an empty success
+- [ ] Existing `{"error": ...}` global-failure contract and its tests unchanged
+- [ ] T-1..T-12 green; full non-e2e suite green
+- [ ] `CLAUDE.md`, `README.md`, and the `get_scenarios` tool description updated
+- [ ] Follow-up tickets filed for the out-of-scope audit findings
+
+## 8. Decision log
+
+| Date | Decision |
+|------|----------|
+| 2026-08-04 | Scope held to the ticket: defects A + B on `get_scenarios` only. An investigation audit surfaced ~40 further null-unsafe expressions and 11 identical structural sites; these were explicitly excluded rather than folded in, and are recorded in `context.md` for separate tickets. |
+| 2026-08-04 | Error contract: keep the existing error dict for globally-unusable results; add additive fields for partial results. Rejected migrating these 2 outlier functions to `raise`/`ToolError` — real cleanup, but not this bug's job and it would churn two passing contract tests. |
+| 2026-08-04 | Data question (`steps: null` legal?) left with Noam Sagiv and explicitly decoupled: this fix is correct under either answer and must not wait on it. |

--- a/prds/bugfix-SAF-34228-get-scenarios-null-steps/summary.md
+++ b/prds/bugfix-SAF-34228-get-scenarios-null-steps/summary.md
@@ -77,19 +77,21 @@ every call against the console, and the 473 healthy scenarios plus all custom pl
   begin with scenario discovery (notably `run_scenario`) are blocked.
 - **CI**: the scheduled `Automation-staging-sanity` pipeline fails deterministically
   (builds #1862, #1863+) on a response-shape assertion.
-- **Recurrence**: the failure mode is generic. Any future unanticipated upstream shape in any mapped
-  field reproduces the same total outage, so fixing only `steps` leaves the blast radius intact.
+- **Noted, not addressed here**: the same all-or-nothing structure means any *other* unanticipated
+  upstream shape would reproduce a total outage. Deliberately left alone — see the decision log in
+  `prd.md`. Changing that generic path carries its own regression risk and needs its own ticket.
 
 ### Risks & Edge Cases
 
-- **All records malformed** — must not report success with an empty list; needs an explicit signal.
-- **Log noise** — a per-record `except` could emit hundreds of warnings; log per record at `warning`
-  once and keep the aggregate in the response.
-- **Unbounded skip list** — must not dump hundreds of IDs into the response; cap the sample.
+- **Semantics of a stepless scenario** — the fix must not assert that `steps: null` is invalid. It
+  projects the record as a scenario with zero steps and lists it normally, which is correct under
+  either answer to the open data question.
+- **Missing-key path** — the pre-existing `steps`-absent behavior must not regress; covered by test.
 - **Cache interaction** — the scenario/plan caches hold *raw* API payloads, so a malformed record
-  persists for the cache TTL. Behavior must be stable across cached and uncached reads.
-- **Contract stability** — new fields must be additive; the two tests asserting `"error" in result`
-  for genuine API failures must keep passing.
+  persists for the cache TTL. The fix is in the mapper, which runs on every read, so cached and
+  uncached reads behave identically.
+- **Contract stability** — no response-shape or error-handling change; the two tests asserting
+  `"error" in result` for genuine API failures are untouched.
 
 ---
 
@@ -97,7 +99,7 @@ every call against the console, and the 473 healthy scenarios plus all custom pl
 
 ### Summary (Title)
 
-`get_scenarios: null steps crashes the whole listing — make step_count null-safe and isolate per-record mapping failures`
+`get_scenarios: scenario with steps: null crashes the listing — make step_count null-safe`
 
 ### Description
 
@@ -130,16 +132,24 @@ description and comment: 2 of 475 scenarios were created with `steps: null` on 2
 * The agent receives an error string rather than a degraded result, so it cannot route around the
   problem or report partial availability — the tool appears down. Scenario-discovery-dependent flows
   such as `run_scenario` are blocked.
-* The failure mode is generic: fixing only `steps` leaves the same total-outage blast radius for the
-  next unanticipated upstream shape.
 * Whether `steps: null` is a legal scenario shape is a separate data question (assigned to Noam
-  Sagiv). The MCP must not fail this way under either answer, and this fix does not depend on it.
+  Sagiv). The fix does not take a position on it: a stepless record is projected as a scenario with
+  zero steps and listed normally, which is correct under either answer.
+
+### Fix
+
+* Null-safe extraction in both mappers: `scenario.get("steps") or []` instead of
+  `scenario.get("steps", [])`. The record then maps cleanly and appears in the listing with
+  `step_count: 0` — not skipped, not flagged, not an error.
+* No change to `sb_get_scenarios`, its error handling, or the response shape. The broader
+  all-or-nothing structure of that function is noted but deliberately left alone: changing a generic
+  path that serves every scenario and plan listing carries its own regression risk and warrants its
+  own ticket rather than riding along on a two-line bugfix.
 
 ### Affected Areas
 
 * safebreach-mcp: `safebreach_mcp_config/config_types.py` (`get_reduced_scenario_mapping`,
-  `get_reduced_plan_mapping`)
-* safebreach-mcp: `safebreach_mcp_config/config_functions.py` (`sb_get_scenarios`)
+  `get_reduced_plan_mapping`) — the only file changed
 ```
 
 ### Acceptance Criteria
@@ -147,14 +157,10 @@ description and comment: 2 of 475 scenarios were created with `steps: null` on 2
 ```markdown
 * `get_reduced_scenario_mapping` and `get_reduced_plan_mapping` return `step_count: 0` for a record
   whose `steps` key is present with value `null`, and do not raise.
-* `get_scenarios` returns the healthy records when one or more records cannot be mapped, instead of
-  failing the whole call.
-* The response reports how many records were skipped, and `hint_to_agent` states the count so the
-  agent can disclose partial results to the user.
-* When every record fails to map, the response makes that explicit rather than reporting an empty
-  but successful listing.
-* Genuine global failures (auth, network, RBAC) still surface as they do today — the existing
-  `{"error": ...}` contract and the tests asserting it are unchanged.
+* A scenario with `steps: null` is RETURNED in the get_scenarios listing (step_count 0), not skipped,
+  flagged, or treated as an error — a stepless scenario is projected as a scenario with zero steps.
+* The pre-existing missing-`steps`-key path is unchanged.
+* No change to the get_scenarios response shape, its error handling, or its tool description.
 * Regression test reproducing the exact reported payload (`"steps": null`) fails before the fix and
   passes after.
 * The full existing suite passes.

--- a/prds/bugfix-SAF-34228-get-scenarios-null-steps/summary.md
+++ b/prds/bugfix-SAF-34228-get-scenarios-null-steps/summary.md
@@ -1,0 +1,176 @@
+# Ticket Summary: SAF-34228
+
+## Overview
+
+**Mode**: Improving existing
+**Project**: SAF
+**Repositories**: `SafeBreach/safebreach-mcp` (GitHub)
+**Branch**: `bugfix/SAF-34228-get-scenarios-null-steps`
+
+---
+
+## Current State
+
+**Summary**: `test_mcp_operation[list_simulations]: get_scenarios crashes with NoneType len() on null steps field`
+
+The ticket is accurate and well-investigated — the root cause, the offending code, the non-regression
+finding, and the exact data trigger (2 of 475 scenarios created with `steps: null` on 2026-07-29) are
+all already established. Two things it does not cover:
+
+1. It treats the crash as the whole defect. The `TypeError` is only the trigger; the reason a
+   two-record data anomaly took down the entire tool is that `sb_get_scenarios` maps all 475 records
+   inside one `try` under a broad `except Exception`, so any single unmappable record discards the
+   other 474 and returns an error payload instead of a listing.
+2. It leaves the data question and the MCP-robustness question entangled. They should be decoupled:
+   whether `steps: null` is legal is for Noam Sagiv to rule on; the MCP must not fail this way either
+   way, and that fix should not wait on the data decision.
+
+---
+
+## Investigation Summary
+
+### safebreach-mcp
+
+- Both cited sites confirmed present on current `main` (ticket cites tag `1.8.0`): `config_types.py:197`
+  in `get_reduced_scenario_mapping`, `:230` in `get_reduced_plan_mapping`.
+- `len()` is the **only** crash point for this record shape. The two other helpers that consume `steps`
+  already tolerate `None`: `compute_is_ready_to_run` (`:129-131`, `if not steps: return False`) and
+  `_compute_total_attack_count` (`:149-157`, `if not steps: return 0`). The ticket's suggested fix does
+  therefore resolve the reported crash.
+- The safe idiom is already this repo's own convention — the same file uses it elsewhere, as does
+  `queue_state.py:103` (`entry.get('steps') or []`) and the `tags` handling the ticket cites.
+  `len(x.get(k, []))` is the outlier, not the norm.
+- `sb_get_scenarios` (`config_functions.py:620-632`, `except` at `:673-678`) has no per-record
+  isolation — the structural cause of the total-outage blast radius.
+- The repo already has an established convention for incomplete data: never drop silently, count what
+  was excluded, surface the count top-level, warn via `hint_to_agent` (`_bulk_result_summary` in
+  `playbook_functions.py:580-617`; `hidden_no_result_drift_count` in `data_functions.py:2055-2147`;
+  `total_capped` in `data_types.py:707-767`). The fix copies this rather than inventing a pattern.
+- The error-dict return style is used by only 2 of 34 public `sb_*` functions
+  (`config_functions.py:132`, `:676`); the other 29 raise or propagate. Two tests assert the dict
+  (`test_config_functions.py:284`, `:658`), so it is retained for global failures and not changed here.
+
+Relevant files: `safebreach_mcp_config/config_types.py`, `safebreach_mcp_config/config_functions.py`,
+`safebreach_mcp_config/tests/test_config_functions.py`, `safebreach_mcp_config/tests/test_config_types.py`
+
+---
+
+## Problem Analysis
+
+### Problem Description
+
+`dict.get(key, default)` returns `default` only when the key is **absent**. When the key is present
+with value `null`, it returns `None`. `get_reduced_scenario_mapping` and `get_reduced_plan_mapping`
+compute `"step_count": len(scenario.get("steps", []))`, so a record with `"steps": null` raises
+`TypeError: object of type 'NoneType' has no len()`.
+
+Because the whole mapping pass sits inside one `try`/`except Exception`, that single record's failure
+is converted into a whole-tool failure: `get_scenarios` returns
+`{"error": "Failed to get scenarios: object of type 'NoneType' has no len()", "console": "..."}` for
+every call against the console, and the 473 healthy scenarios plus all custom plans are discarded.
+
+### Impact Assessment
+
+- **Agent-facing**: `get_scenarios` is unusable on any console holding one malformed record. The agent
+  receives a string in an `error` key, so it cannot route around the problem or tell the user
+  "473 scenarios available, 2 unreadable" — the tool simply appears to be down. Downstream flows that
+  begin with scenario discovery (notably `run_scenario`) are blocked.
+- **CI**: the scheduled `Automation-staging-sanity` pipeline fails deterministically
+  (builds #1862, #1863+) on a response-shape assertion.
+- **Recurrence**: the failure mode is generic. Any future unanticipated upstream shape in any mapped
+  field reproduces the same total outage, so fixing only `steps` leaves the blast radius intact.
+
+### Risks & Edge Cases
+
+- **All records malformed** — must not report success with an empty list; needs an explicit signal.
+- **Log noise** — a per-record `except` could emit hundreds of warnings; log per record at `warning`
+  once and keep the aggregate in the response.
+- **Unbounded skip list** — must not dump hundreds of IDs into the response; cap the sample.
+- **Cache interaction** — the scenario/plan caches hold *raw* API payloads, so a malformed record
+  persists for the cache TTL. Behavior must be stable across cached and uncached reads.
+- **Contract stability** — new fields must be additive; the two tests asserting `"error" in result`
+  for genuine API failures must keep passing.
+
+---
+
+## Proposed Ticket Content
+
+### Summary (Title)
+
+`get_scenarios: null steps crashes the whole listing — make step_count null-safe and isolate per-record mapping failures`
+
+### Description
+
+```markdown
+### Background
+
+The MCP `get_scenarios` tool (config server) fails on `staging.sbops.com` with
+`Failed to get scenarios: object of type 'NoneType' has no len()`, breaking the scheduled
+`Automation-staging-sanity` pipeline deterministically from build #1862 onward. Root cause, code
+location, non-regression status and the exact data trigger are established in the original
+description and comment: 2 of 475 scenarios were created with `steps: null` on 2026-07-29.
+
+### Technical Context
+
+* `dict.get(key, default)` returns `default` only when the key is MISSING, not when it is present
+  with value `null`. `len(scenario.get("steps", []))` therefore raises `TypeError` on such a record.
+* Confirmed still present on `main`: `config_types.py:197` (`get_reduced_scenario_mapping`) and
+  `:230` (`get_reduced_plan_mapping`).
+* `len()` is the only crash point for this shape — `compute_is_ready_to_run` and
+  `_compute_total_attack_count` already guard with `if not steps`.
+* The safe idiom is already the repo's convention (`queue_state.py:103`, the `tags` handling, and the
+  two helpers above); these two `len()` calls are the outlier.
+* `sb_get_scenarios` maps all records inside a single `try` under a broad `except Exception`
+  (`config_functions.py:620-632`, `:673-678`), so one unmappable record discards all the others.
+
+### Problem Description
+
+* A single malformed record out of 475 blacks out the entire scenario catalog for the console; the
+  473 healthy scenarios and all custom plans are discarded.
+* The agent receives an error string rather than a degraded result, so it cannot route around the
+  problem or report partial availability — the tool appears down. Scenario-discovery-dependent flows
+  such as `run_scenario` are blocked.
+* The failure mode is generic: fixing only `steps` leaves the same total-outage blast radius for the
+  next unanticipated upstream shape.
+* Whether `steps: null` is a legal scenario shape is a separate data question (assigned to Noam
+  Sagiv). The MCP must not fail this way under either answer, and this fix does not depend on it.
+
+### Affected Areas
+
+* safebreach-mcp: `safebreach_mcp_config/config_types.py` (`get_reduced_scenario_mapping`,
+  `get_reduced_plan_mapping`)
+* safebreach-mcp: `safebreach_mcp_config/config_functions.py` (`sb_get_scenarios`)
+```
+
+### Acceptance Criteria
+
+```markdown
+* `get_reduced_scenario_mapping` and `get_reduced_plan_mapping` return `step_count: 0` for a record
+  whose `steps` key is present with value `null`, and do not raise.
+* `get_scenarios` returns the healthy records when one or more records cannot be mapped, instead of
+  failing the whole call.
+* The response reports how many records were skipped, and `hint_to_agent` states the count so the
+  agent can disclose partial results to the user.
+* When every record fails to map, the response makes that explicit rather than reporting an empty
+  but successful listing.
+* Genuine global failures (auth, network, RBAC) still surface as they do today — the existing
+  `{"error": ...}` contract and the tests asserting it are unchanged.
+* Regression test reproducing the exact reported payload (`"steps": null`) fails before the fix and
+  passes after.
+* The full existing suite passes.
+```
+
+### Suggested Labels/Components
+
+- Labels (existing, keep): `CTEM-dev`, `automation`, `prod`, `test-failure`
+- No component change
+
+---
+
+## Out of Scope (recorded, not proposed as work here)
+
+A repo-wide audit run during investigation found ~40 further null-unsafe expressions and 11 mapping
+sites with the same all-or-nothing structure, including two arguably more severe than this bug
+(`get_minimal_simulator_mapping` at `config_types.py:41,69-77`; `run_scenario`'s evaluate path at
+`studio_functions.py:2940,2964`, which the same two staging records likely also break). These are
+retained in `context.md` to seed separate tickets and are deliberately excluded from SAF-34228.

--- a/safebreach_mcp_config/config_types.py
+++ b/safebreach_mcp_config/config_types.py
@@ -194,8 +194,10 @@ def get_reduced_scenario_mapping(
         "recommended": scenario.get("recommended", False),
         "category_names": category_names,
         "tags": scenario.get("tags") or [],
-        "step_count": len(scenario.get("steps", [])),
-        "total_attack_count": _compute_total_attack_count(scenario.get("steps", [])),
+        # SAF-34228: `or []` not `.get(k, [])` — the default applies only to a MISSING key, so a
+        # record with "steps": null yields None and len() raises, failing the whole listing.
+        "step_count": len(scenario.get("steps") or []),
+        "total_attack_count": _compute_total_attack_count(scenario.get("steps") or []),
         "is_ready_to_run": compute_is_ready_to_run(scenario),
         "createdAt": scenario.get("createdAt"),
         "updatedAt": scenario.get("updatedAt"),
@@ -227,8 +229,9 @@ def get_reduced_plan_mapping(
         "recommended": False,  # Custom plans don't have the recommended concept
         "category_names": [],  # Custom plans don't have categories
         "tags": plan.get("tags") or [],
-        "step_count": len(plan.get("steps", [])),
-        "total_attack_count": _compute_total_attack_count(plan.get("steps", [])),
+        # SAF-34228: see get_reduced_scenario_mapping — null-safe, not just missing-safe.
+        "step_count": len(plan.get("steps") or []),
+        "total_attack_count": _compute_total_attack_count(plan.get("steps") or []),
         "is_ready_to_run": compute_is_ready_to_run(plan),
         "createdAt": plan.get("createdAt"),
         "updatedAt": plan.get("updatedAt"),

--- a/safebreach_mcp_config/tests/test_config_types.py
+++ b/safebreach_mcp_config/tests/test_config_types.py
@@ -344,6 +344,43 @@ class TestGetReducedScenarioMapping:
         result = get_reduced_scenario_mapping(scenario, sample_categories_map)
         assert result["category_names"] == ["Known Threats Series"]
 
+    # T-1 (SAF-34228) — `steps` present with value null. `.get("steps", [])` returns None
+    # (the default applies only to a MISSING key), so len() raised TypeError and took down
+    # the whole get_scenarios listing.
+    def test_null_steps_yields_zero_step_count(self, sample_categories_map):
+        scenario = {
+            "id": "278b6968-676e-4940-bbd2-59c933437238",
+            "name": "Adversary Reconnaissance",
+            "description": None,
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "categories": [2],
+            "tags": None,
+            "createdAt": "2026-07-29T06:45:57.000Z",
+            "updatedAt": "2026-07-29T07:19:06.000Z",
+            "steps": None,
+        }
+        result = get_reduced_scenario_mapping(scenario, sample_categories_map)
+        assert result["step_count"] == 0
+        assert result["total_attack_count"] == 0
+        assert result["is_ready_to_run"] is False
+
+    # T-3 (SAF-34228) — the pre-existing missing-key path must keep working.
+    def test_absent_steps_key_yields_zero_step_count(self, sample_categories_map):
+        scenario = {
+            "id": "no-steps-key",
+            "name": "No Steps Key",
+            "description": None,
+            "createdBy": "SafeBreach",
+            "recommended": False,
+            "categories": [2],
+            "tags": None,
+            "createdAt": "2025-01-01T00:00:00.000Z",
+            "updatedAt": "2025-01-01T00:00:00.000Z",
+        }
+        result = get_reduced_scenario_mapping(scenario, sample_categories_map)
+        assert result["step_count"] == 0
+
 
 class TestGetReducedPlanMapping:
     """Test the get_reduced_plan_mapping function for custom plans."""
@@ -418,6 +455,21 @@ class TestGetReducedPlanMapping:
     def test_is_ready_to_run_for_plans(self, sample_plan):
         result = get_reduced_plan_mapping(sample_plan)
         assert result["is_ready_to_run"] is True
+
+    # T-2 (SAF-34228) — same null-vs-missing defect on the custom-plan mapper. Plans are
+    # user-editable, so a null steps field is at least as reachable here as on OOB scenarios.
+    def test_null_steps_yields_zero_step_count(self, sample_plan):
+        sample_plan["steps"] = None
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["step_count"] == 0
+        assert result["total_attack_count"] == 0
+        assert result["is_ready_to_run"] is False
+
+    # T-3 (SAF-34228) — missing-key path unchanged.
+    def test_absent_steps_key_yields_zero_step_count(self, sample_plan):
+        del sample_plan["steps"]
+        result = get_reduced_plan_mapping(sample_plan)
+        assert result["step_count"] == 0
 
 
 class TestFilterScenariosByCriteria:


### PR DESCRIPTION
Fixes [SAF-34228](https://safebreach.atlassian.net/browse/SAF-34228).

## Problem

`get_scenarios` fails on `staging.sbops.com` with:

```
Failed to get scenarios: object of type 'NoneType' has no len()
```

`dict.get(key, default)` returns `default` only when the key is **absent**. A key present with value `null` returns `None`, so `len(scenario.get("steps", []))` raises `TypeError`. Because `sb_get_scenarios` maps every record inside one `try` under a broad `except Exception`, that single record's failure surfaced as a whole-tool failure — 2 malformed records out of 475 discarded the entire scenario catalog for the console.

Deterministic since CI build #1862; breaks the scheduled `Automation-staging-sanity` pipeline. Not a code regression — the pattern dates to `b7ce727` (SAF-29966, 2026-04-16); it was triggered by two scenarios created on staging on 2026-07-29 with `steps: null`.

## Change

One file, `safebreach_mcp_config/config_types.py` (+11/−4) — in both `get_reduced_scenario_mapping` and `get_reduced_plan_mapping`:

```python
"step_count": len(scenario.get("steps") or []),                        # was .get("steps", [])
"total_attack_count": _compute_total_attack_count(scenario.get("steps") or []),
```

This is the fix suggested on the ticket. It matches the repo's existing idiom — `queue_state.py:103` (`entry.get('steps') or []`), the adjacent `tags` handling, and `compute_is_ready_to_run` / `_compute_total_attack_count`, which both already guard with `if not steps`. These two `len()` calls were the outlier.

`total_attack_count` is guarded on the same lines even though `_compute_total_attack_count(None)` already returns `0`. Not a bug fix — it keeps the two adjacent expressions from disagreeing about whether `steps` can be null, which is how this defect class survives review.

## Behavior

A `steps: null` record now maps cleanly and is **returned in the listing**, not skipped or flagged:

```
total_scenarios: 3
  A Normal Scenario          step_count=1  attacks=2  ready=True
  Adversary Propagation      step_count=0  attacks=0  ready=False
  Adversary Reconnaissance   step_count=0  attacks=0  ready=False
```

This is deliberately agnostic on the open data question (is a stepless scenario legal? — with the ticket assignee). `step_count: 0` is the correct projection either way, so nothing here needs revisiting once that's answered.

No change to `sb_get_scenarios`, its error handling, the response shape, or the tool description — so no documentation change was required.

## Tests

4 unit tests in `test_config_types.py`: the null case and the absent-`steps`-key case for both mappers. The null tests were confirmed failing before the fix with the exact reported error; the absent-key tests guard the pre-existing path from regression. T-1's fixture uses the real incident record id `278b6968-676e-4940-bbd2-59c933437238` ("Adversary Reconnaissance").

**1539 passed, 0 failed** (non-e2e; e2e needs live consoles). Not reproducible locally end-to-end — it needs a console holding a `steps: null` record — so the tests encode the reported payload instead. Post-merge, `Automation-staging-sanity` should go green.

## Scope note for reviewers

An earlier revision of this branch also added per-record isolation to `sb_get_scenarios` (skip an unmappable record, return the rest, surface a skipped count and warning hint). **It was implemented, passing with 9 tests, and then reverted.** The reasoning is in the PRD decision log:

1. **Not needed for this bug.** Once `step_count` is null-safe, the stepless records map fine and are listed. The crash and the CI failure are fixed without it.
2. **It presumed an answer to the open question.** Skipping a record treats `steps: null` as malformed — precisely what hasn't been decided. If a stepless scenario is legal, skipping it is wrong behavior.
3. **It changed a generic path.** The isolation rewrote the mapping flow serving every scenario and plan listing. For a two-line bug, that regression risk exceeded the hypothetical failure it guarded against.

The broader all-or-nothing structure is a real concern — one unmappable record still fails the whole call for shapes this fix doesn't cover — but it belongs in its own ticket with its own justification. A repo-wide audit run during investigation found ~40 further null-unsafe expressions and 11 structurally identical mapping sites, including two arguably more severe than this bug (`get_minimal_simulator_mapping`, and `run_scenario`'s evaluate path breaking on these same two records). All recorded in `prds/bugfix-SAF-34228-get-scenarios-null-steps/context.md` to seed follow-up tickets, deliberately excluded here.

PRD: `prds/bugfix-SAF-34228-get-scenarios-null-steps/` (`context.md`, `summary.md`, `prd.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)