### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the safebreach-mcp project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.10.1 — 2026-08-04
+
+### Fixed
+
+- `get_tests` accepts `status_filter='paused'` again. The status allowlist added in 1.10.0 was
+  built from the documented values and omitted `paused`, which had worked by pass-through before —
+  the call then failed immediately with a validation error, regardless of whether a paused test
+  existed. Note that pause state is authoritative in the orchestrator, so if a console's test-list
+  API does not report `paused`, the filter may return no rows rather than an error; that case needs
+  a separate orchestrator-backed fix
+- `get_scenarios` no longer fails outright when a scenario or custom plan has a null `steps` field.
+  Such a record is now listed as a scenario with zero steps (`step_count: 0`) instead of raising a
+  `TypeError` that discarded the entire scenario catalog for the console
+
 ## 1.10.0 — 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "safebreach-mcp-server"
-version = "1.10.0"
+version = "1.10.1"
 description = "SafeBreach MCP Server - Bridge AI agents with SafeBreach's Breach and Attack Simulation platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "safebreach-mcp-server"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 1.10.1

Patch release — two bug fixes, no new features and no contract changes.

### Fixed

- `get_tests` accepts `status_filter='paused'` again. The status allowlist added in 1.10.0 was
  built from the documented values and omitted `paused`, which had worked by pass-through before —
  the call then failed immediately with a validation error, regardless of whether a paused test
  existed. Note that pause state is authoritative in the orchestrator, so if a console's test-list
  API does not report `paused`, the filter may return no rows rather than an error; that case needs
  a separate orchestrator-backed fix
- `get_scenarios` no longer fails outright when a scenario or custom plan has a null `steps` field.
  Such a record is now listed as a scenario with zero steps (`step_count: 0`) instead of raising a
  `TypeError` that discarded the entire scenario catalog for the console

### Included

| PR | Ticket | Change |
|---|---|---|
| #83 | [SAF-34457](https://safebreach.atlassian.net/browse/SAF-34457) | restore `paused` as a valid `get_tests` `status_filter` |
| #84 | [SAF-34228](https://safebreach.atlassian.net/browse/SAF-34228) | null-safe `step_count` in scenario/plan mappers |

### Note on the version number

This is the repo's first **patch** release — 1.7.0 through 1.10.0 were all minor bumps. Both changes
are bug fixes with no new features and no contract changes, so 1.10.1 is the semver-correct bump.
The release workflow is version-agnostic (it reads whatever is in `pyproject.toml`, checks the tag
does not exist, and validates a matching `## VERSION` changelog entry), so the patch version needs
no workflow change. Verified locally: the changelog grep matches and the awk notes extraction
returns the Fixed section cleanly.

The `/mcp-create-release` skill only offers minor/major, so these steps were run manually following
it — worth teaching the skill patch bumps if we expect more of these.

---
Once this PR is merged to main, GitHub Actions will automatically:
1. Validate the CHANGELOG entry
2. Create git tag `1.10.1`
3. Create a GitHub Release with the changelog notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)