### PR TITLE
SAF-33575 name Quick Run tests after the attack, matching the Playboo…

### DIFF
--- a/prds/saf-33575/prd.md
+++ b/prds/saf-33575/prd.md
@@ -1,0 +1,89 @@
+# Quick Run test name should reflect the attack — SAF-33575
+
+## 1. Overview
+
+Ad-hoc attack execution through Helm queues a test named `Quick Run (1 attacks)`, omitting the
+name of the attack that was run. The operator looking at the "Now Running" panel cannot tell what
+is executing without opening the test.
+
+Bug: `safebreach_mcp_studio/studio_functions.py:2786`
+
+```python
+effective_test_name = test_name or f"Quick Run ({len(steps)} attacks)"
+```
+
+## 2. Solution Description
+
+### 2.1 The name format is already decided by precedent
+
+`ui-react/src/components/QuickRunModal/index.tsx:199` — the Playbook UI's own Quick Run — already
+ships this convention:
+
+```js
+const plan = { name: `Quick Run - ${moveName || ''}`, steps: [step] };
+```
+
+So this is not "the generated name is unhelpful", it is **the Helm/MCP path diverging from the UI's
+shipped convention**. Match the UI. No new format decision is required; the ticket's open question
+to Tal Rotem is answered by the existing product behaviour.
+
+### 2.2 The attack name is already in scope
+
+`_build_quick_run_steps` (`studio_functions.py:2582-2585`) already resolves and stores the name on
+every step:
+
+```python
+attack_name = name_map.get(attack_id, f"Attack {attack_id}")
+steps.append({..., "name": attack_name, ...})
+```
+
+So the fix reads `step["name"]` and needs no `name_map` plumbing. Because the name is built at
+line 2786 — *after* the 0-simulation filter at 2770-2780 replaces `steps` with `exec_steps` — it
+naturally reflects the attacks **actually queued**, not the attacks requested. That is the correct
+behaviour: the test card should describe what is running.
+
+### 2.3 Multi-attack naming
+
+The UI path only ever handles a single attack (`moveName`, one `step`); `sb_quick_run` accepts
+several `attack_ids`, so multi-attack naming has no precedent. Extension:
+
+| Queued attacks | Name |
+|---|---|
+| 1 | `Quick Run - Lazarus Fake TLS` |
+| 3 | `Quick Run - Lazarus Fake TLS +2 more` |
+| 0 names resolvable | `Quick Run (N attacks)` (existing fallback) |
+
+An explicitly passed `test_name` still wins — unchanged.
+
+## 3. API / Integration
+
+No tool-signature change. `quick_run`'s `test_name` parameter and all other behaviour are
+untouched; only the default fallback changes. No console/backend change.
+
+## 4. Definition of Done
+
+- [ ] Single-attack Quick Run through Helm produces `Quick Run - <attack name>`.
+- [ ] Multi-attack Quick Run produces `Quick Run - <first> +<n> more`.
+- [ ] Explicit `test_name` still overrides the default.
+- [ ] Unresolvable names fall back to `Quick Run (N attacks)` — no crash, no empty name.
+- [ ] Name reflects queued (post-skip-filter) attacks, not requested ones.
+- [ ] Unit tests green; lint clean.
+
+## 5. Testing Strategy
+
+Unit tests on `_default_quick_run_name` covering: one step, several steps, zero steps, and steps
+missing a `name` key. Existing `sb_quick_run` tests in
+`safebreach_mcp_studio/tests/test_studio_functions.py` must stay green — any that assert the old
+`Quick Run (N attacks)` string are updated to the new expectation.
+
+## 6. Implementation Phases
+
+| Phase | Status | Notes |
+|---|---|---|
+| 1. `_default_quick_run_name` helper + call site | pending | one helper, one line changed |
+| 2. Unit tests | pending | four cases above |
+
+## 7. Risks
+
+Low. Pure presentation change on a default value, behind an existing override, with no signature
+or payload-shape change. Only risk is a test elsewhere asserting the old literal name.

--- a/safebreach_mcp_studio/studio_functions.py
+++ b/safebreach_mcp_studio/studio_functions.py
@@ -2609,6 +2609,24 @@ def _build_quick_run_steps(parsed_ids, name_map):
     return steps
 
 
+def _default_quick_run_name(steps):
+    """
+    Build the default Quick Run test name from the attacks being queued.
+
+    Args:
+        steps: Step dicts that will actually be queued
+
+    Returns:
+        Name following the Playbook UI convention ("Quick Run - <attack>")
+    """
+    names = [step.get("name") for step in steps if step.get("name")]
+    if not names:
+        return f"Quick Run ({len(steps)} attacks)"
+    if len(names) == 1:
+        return f"Quick Run - {names[0]}"
+    return f"Quick Run - {names[0]} +{len(names) - 1} more"
+
+
 def _apply_quick_run_overrides(steps, overrides, parsed_ids):
     """
     Apply per-attack simulator overrides to constructed steps.
@@ -2783,7 +2801,7 @@ def sb_quick_run(
     actions, edges = _build_linear_dag(steps)
 
     # Build queue payload
-    effective_test_name = test_name or f"Quick Run ({len(steps)} attacks)"
+    effective_test_name = test_name or _default_quick_run_name(steps)
     payload = {
         "plan": {
             "name": effective_test_name,

--- a/safebreach_mcp_studio/tests/test_e2e_quick_run.py
+++ b/safebreach_mcp_studio/tests/test_e2e_quick_run.py
@@ -188,6 +188,9 @@ class TestQuickRunE2E:
             assert result["status"] == "queued"
             assert result["test_id"]
             assert len(result["step_run_ids"]) > 0
+            assert result["test_name"].startswith("Quick Run - "), (
+                f"SAF-33575: default name must name the attack, got {result['test_name']!r}"
+            )
             test_id = result["test_id"]
             passed = True
             logger.info(

--- a/safebreach_mcp_studio/tests/test_studio_functions.py
+++ b/safebreach_mcp_studio/tests/test_studio_functions.py
@@ -10045,14 +10045,39 @@ class TestQuickRunTestName:
     def test_default_test_name_auto_generated(
         self, mock_playbook, mock_stats, mock_queue, mock_limiter
     ):
-        """No test_name → auto-generated default containing 'Quick Run'."""
+        """No test_name → default names the attack (SAF-33575)."""
         mock_stats.return_value = [{"simulationCount": 10}]
         mock_queue.return_value = MOCK_QUEUE_RESPONSE_QUICK_RUN
         sb_quick_run(
             attack_ids="8849", console="test", evaluate=False,
         )
         payload = mock_queue.call_args[0][0]
-        assert "Quick Run" in payload["plan"]["name"]
+        assert payload["plan"]["name"] == (
+            "Quick Run - Transfer of LAPSUS infostealer over HTTP/S"
+        )
+
+
+class TestDefaultQuickRunName:
+    """SAF-33575: default Quick Run name reflects the queued attacks."""
+
+    def test_single_attack_names_it(self):
+        from safebreach_mcp_studio.studio_functions import _default_quick_run_name
+        steps = [{"name": "Lazarus Fake TLS"}]
+        assert _default_quick_run_name(steps) == "Quick Run - Lazarus Fake TLS"
+
+    def test_multiple_attacks_summarise(self):
+        from safebreach_mcp_studio.studio_functions import _default_quick_run_name
+        steps = [{"name": "Lazarus Fake TLS"}, {"name": "RIG kit"}, {"name": "GAMARUE C&C"}]
+        assert _default_quick_run_name(steps) == "Quick Run - Lazarus Fake TLS +2 more"
+
+    def test_unnamed_steps_fall_back_to_count(self):
+        from safebreach_mcp_studio.studio_functions import _default_quick_run_name
+        steps = [{}, {"name": ""}]
+        assert _default_quick_run_name(steps) == "Quick Run (2 attacks)"
+
+    def test_no_steps_falls_back_to_count(self):
+        from safebreach_mcp_studio.studio_functions import _default_quick_run_name
+        assert _default_quick_run_name([]) == "Quick Run (0 attacks)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## SAF-33575 — Quick Run test name omits the attack

Ad-hoc execution through Helm queued tests named `Quick Run (1 attacks)`, so the Now Running card gave the operator no idea what was executing.

**Fix:** build the default name from the attacks being queued. `_build_quick_run_steps` already stores the resolved attack name on each step, so no new lookup was needed.

- 1 attack → `Quick Run - Lazarus Fake TLS`
- N attacks → `Quick Run - Lazarus Fake TLS +2 more`
- No name resolvable → `Quick Run (N attacks)` (existing fallback)

Format matches the Playbook UI's shipped convention (`QuickRunModal/index.tsx:199`), so Helm and the UI now agree. An explicit `test_name` still wins — unchanged. No tool-signature or backend change.

Because the name is built *after* the 0-simulation filter, it reflects the attacks actually queued rather than those requested.

**Testing:** 4 new unit tests, 1 existing test tightened to assert the exact name, and a `test_name` assertion added to the e2e queue test (which had never checked the name). 455 unit tests green. Verified live on pentest01 via Claude Desktop: `Quick Run - Write BPF_Rapid7Controller (f64baf) backdoor to disk`.